### PR TITLE
Add search question via db object names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
 ## 0.1.6 (2024-01-23)
 * Add a new function *rescan_object_values*
 ## 0.1.6 (2024-01-23)
-* Add a new help function *find_cards_with_pattern*
+* Add a new help function *find_cards_via_db_object*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 ## 0.1.5 (2024-01-18)
 ## 0.1.6 (2024-01-23)
 * Add a new function *rescan_object_values*
+## 0.1.6 (2024-01-23)
+* Add a new help function *find_cards_with_pattern*

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.1.6",
+    version="0.1.7",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -84,7 +84,8 @@ class Metabase_API:
         friendly_names_is_disabled,
         verbose_print,
         check_collection,
-        get_dashboard_question_ids
+        get_dashboard_question_ids,
+        find_cards_via_db_object
     )
 
     ##################################################################
@@ -417,3 +418,4 @@ class Metabase_API:
             
             self.verbose_print(verbose, 'Rescan {} values ...'.format(object_type))
             return self.post("/api/{}/{}/rescan_values".format(object_type, str(object_id)))
+    


### PR DESCRIPTION
### Summary
* Find Metabase questions by searching for _**schema_name.table_name**_ inside the code
* Only works with native queries of course

### Detail
* Developed to find easily questions for the issue below:
* 
### Reference
[MàJ du flow BO EVS | Attribution de la colonne "training_start_date"](https://airtable.com/app8gA9M46hqIfBPO/pagPuey3euHOhOMbE?detail=eyJwYWdlSWQiOiJwYWdHRDV6UDhrNUZqeGFRYSIsInJvd0lkIjoicmVjRk1UVE93YkY1UnRuYTgiLCJzaG93Q29tbWVudHMiOmZhbHNlfQ)

### Checks

- [x] Tested changes in DEV environment.
- [ ] Code modification approved by other Data team members.
