### PR TITLE
add get_user_coll_id function to repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@
 * Add a new help function *find_cards_via_db_object*
 ## 0.1.8 (2024-03-07)
 * Upgrade for new MB API dashboard + fix small bugs
+## 0.1.9 (2024-04-26)
+* Add a new help function *get_user_coll_id*

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.1.8",
+    version="0.1.9",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",

--- a/spark_metabase_api/_helper_methods.py
+++ b/spark_metabase_api/_helper_methods.py
@@ -366,6 +366,20 @@ def get_db_id_from_table_id(self, table_id):
     return tables[0]
 
 
+def get_user_coll_id(self, user_id):
+    """
+    Return user's personnal collection.
+    """
+    collections = [user["personal_collection_id"] for user in self.get("/api/user/") if user["id"] == user_id]
+
+    if len(collections) == 0:
+        raise ValueError(
+            'There is no active user with ID "{}"'.format(user_id)
+        )
+
+    return collections[0]
+
+
 def get_db_info(self, db_name=None, db_id=None, params=None):
     """
     Return Database info. Use 'params' for providing arguments.


### PR DESCRIPTION
### Summary
Add a function to retrieve the personnal collection of an active user

### Details
Obligé de passer par l'endpoint "/api/user" sans préciser l'id pour avoir "personnal_collection_id"

### Reference
[User Story](https://airtable.com/app8gA9M46hqIfBPO/pagP0Y5C8FZtswoqP?detail=eyJwYWdlSWQiOiJwYWdtaWRWRURyVHFwUW5zOSIsInJvd0lkIjoicmVjZG93dnlaSml3VnJoc3MiLCJzaG93Q29tbWVudHMiOmZhbHNlfQ)

### Checks
- [X] Tested changes in DEV environment.
- [ ] Code modification approved by other Data team members.
