### PR TITLE
Add full db scan functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,5 @@
 * Add helper function *get_user_coll_id* to main
 ## 0.1.12 (2024-04-29)
 * Fix small bugs
+## 0.1.13 (2024-10-29)
+* Add 2 functions *rescan_db_field_values* & *rescan_db_sync_schemas* to main

--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ In construction 🚧
 
 ## To-Do
 
-- [ ] Remove search based on names.
-- [ ] Make sure admins are not removed when collection access is being restricted.
-- [ ] Add functions for users, groups and permissions for all of that.
-- [ ] Verbose all functions (parametrize it in function argument of course).
+- [ ] XXX
 
 ## Acknowledgements
 

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.1.12",
+    version="0.1.13",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/Spark-Data-Team/spark_metabase_api",
+    url="https://github.com/Spark-Data-Team/spark-metabase-api",
     packages=setuptools.find_packages(),
     install_requires=[
         "requests",

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -420,3 +420,31 @@ class Metabase_API:
             self.verbose_print(verbose, 'Rescan {} values ...'.format(object_type))
             return self.post("/api/{}/{}/rescan_values".format(object_type, str(object_id)))
     
+    def rescan_db_field_values(
+            self,
+            db_id=None,
+            verbose=False,
+        ):
+            """
+            Trigger a manual scan of the field values for this Database.
+            """
+            if not db_id:
+                raise ValueError("id of the databasemust be provided.")
+            
+            self.verbose_print(verbose, 'Rescan database field values triggered...')
+            return self.post("/api/database/{}/rescan_values".format(db_id))
+
+    def rescan_db_sync_schemas(
+            self,
+            db_id=None,
+            verbose=False,
+        ):
+            """
+            Trigger a manual update of the schema metadata for this Database.
+            """
+            if not db_id:
+                raise ValueError("id of the databasemust be provided.")
+            
+            self.verbose_print(verbose, 'Update database schema metadata triggered...')
+            return self.post("/api/database/{}/sync_schema".format(db_id))
+    

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -429,7 +429,7 @@ class Metabase_API:
             Trigger a manual scan of the field values for this Database.
             """
             if not db_id:
-                raise ValueError("id of the databasemust be provided.")
+                raise ValueError("id of the database must be provided.")
             
             self.verbose_print(verbose, 'Rescan database field values triggered...')
             return self.post("/api/database/{}/rescan_values".format(db_id))
@@ -443,7 +443,7 @@ class Metabase_API:
             Trigger a manual update of the schema metadata for this Database.
             """
             if not db_id:
-                raise ValueError("id of the databasemust be provided.")
+                raise ValueError("id of the database must be provided.")
             
             self.verbose_print(verbose, 'Update database schema metadata triggered...')
             return self.post("/api/database/{}/sync_schema".format(db_id))

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -274,7 +274,7 @@ class Metabase_API:
             # find column IDs
             import re
 
-            res = re.findall("\['field', .*?\]", query_data_str)
+            res = re.findall(r"\['field', .*?\]", query_data_str)
             source_column_IDs = [eval(i)[1] for i in res]
 
             # replace column IDs from old table with the column IDs from new table


### PR DESCRIPTION
### Summary
* Add 2 functions *rescan_db_field_values* & *rescan_db_sync_schemas* to main

### Details
* Fix regex warning

### Reference

[Couper les syncs auto Metabase de la base de donnée](https://airtable.com/app8gA9M46hqIfBPO/pag63JyZUA6NTYSlL?detail=eyJwYWdlSWQiOiJwYWd4UE5UbzVycHdnZklqayIsInJvd0lkIjoicmVjN1dmc1FqQXdTYVBQM2QiLCJzaG93Q29tbWVudHMiOmZhbHNlLCJxdWVyeU9yaWdpbkhpbnQiOm51bGx9)

### Checks
- [x] Tested changes in DEV environment.
- [x] Code modification approved by other Data team members.
