### PR TITLE
Bug fixes, Metabase 0.49-0.61 alignment, and Infrastructure-as-Code module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 * Fix small bugs
 ## 0.1.13 (2024-10-29)
 * Add 2 functions *rescan_db_field_values* & *rescan_db_sync_schemas* to main
+## 0.3.0 (2026-05-03)
+### Added
+* New **chatbot** module `spark_metabase_api.chatbot`: Claude Opus 4.7 with tool-use that inspects a live Metabase instance and emits a `CollectionSpec` from a natural-language brief. Exposes `chat()` (blocking) and `stream()` (generator yielding `text` / `tool_call` / `tool_result` / `proposed` events for live UIs). `anthropic` is an optional extra (`pip install spark-metabase-api[chatbot]`).
+* New **Streamlit** frontend (`streamlit_app.py`): live chat UX with sidebar credentials, expandable tool-call results, spec review, and Apply button. Optional extra (`pip install spark-metabase-api[streamlit]`).
+* `iac` now resolves `card_name` forward references in dashcards at apply time, so a single spec run can both create cards and create a dashboard that references them by name.
 ## 0.2.0 (2026-05-03)
 ### Added
 * New **Infrastructure-as-Code** module `spark_metabase_api.iac`: declare a Metabase collection tree in YAML/JSON and apply it idempotently. Exposes `export`, `plan`, `apply` and a CLI: `spark-metabase {export,plan,apply}`. PyYAML is an optional extra (`pip install spark-metabase-api[iac]`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Fix small bugs
 ## 0.1.13 (2024-10-29)
 * Add 2 functions *rescan_db_field_values* & *rescan_db_sync_schemas* to main
+## 0.2.0 (2026-05-03)
+### Added
+* New **Infrastructure-as-Code** module `spark_metabase_api.iac`: declare a Metabase collection tree in YAML/JSON and apply it idempotently. Exposes `export`, `plan`, `apply` and a CLI: `spark-metabase {export,plan,apply}`. PyYAML is an optional extra (`pip install spark-metabase-api[iac]`).
+* README rewritten with a worked IaC example.
 ## 0.1.14 (2026-05-03)
 * Fix `__init__`: password argument is now stored, dead `getpass` branch removed
 * Fix `clone_card`: typo where `target_table_id` was reassigned to `source_table_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,17 @@
 * Fix small bugs
 ## 0.1.13 (2024-10-29)
 * Add 2 functions *rescan_db_field_values* & *rescan_db_sync_schemas* to main
+## 0.1.14 (2026-05-03)
+* Fix `__init__`: password argument is now stored, dead `getpass` branch removed
+* Fix `clone_card`: typo where `target_table_id` was reassigned to `source_table_id`
+* Remove unsafe `eval()` from `clone_card` and `create_card` (could break on names containing quotes); MBQL is now mutated via a tree walk
+* `clone_card` now fetches the card with `?legacy-mbql=true` to keep MBQL 4 shapes on Metabase 0.57+
+* Fix `check_collection`: NameError on duplicate-collection branch
+* Fix `copy_dashboard`: replaced `rstrip(' - Duplicate')` (strips a *set* of characters) with a real suffix removal
+* `restrict_collection_access`: now writes 'none' for groups whose entry is missing in the graph (Metabase 0.56.13 stopped returning explicit 'none' values)
+* `restrict_filter_with_card_values`: `column_base_type` now configurable, forced uppercase on column names is opt-out via `preserve_column_case=True`, doc typo fixed
+* `add_card_to_dashboard`: now falls back to `PUT /api/dashboard/:id` with `dashcards` array when the legacy `POST /api/dashboard/:id/cards` is unavailable
+* `get_dashboard_question_ids`: handles both new `dashcards` and legacy `ordered_cards` shapes
+* `create_collection`: `color` is sent for older Metabase but transparently dropped on a 400 from newer Metabase
+* Hardened `_rest_methods`: shared `requests.Session`, default 30s timeout on every call, network errors during session validation no longer raise
+* `validate_session` and `is_session_valid` deduplicated

--- a/README.md
+++ b/README.md
@@ -1,20 +1,99 @@
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
-(to create)
 
 # Spark Metabase API
 
-A Python wrapper for the Metabase API \
-Developed by the [Spark Tech team](https://www.spark.do/) ⭐️
+A Python wrapper for the Metabase API, developed by the [Spark Tech team](https://www.spark.do/) ⭐️
 
 ## Installation
 
-In construction 🚧
+```bash
+pip install spark-metabase-api
+# Optional YAML support for the Infrastructure-as-Code module:
+pip install "spark-metabase-api[iac]"
+```
 
-## To-Do
+## Quick start
 
-- [ ] XXX
+```python
+from spark_metabase_api import Metabase_API
+
+mb = Metabase_API(
+    domain="https://metabase.example.com",
+    email="me@example.com",
+    password="hunter2",
+)
+
+mb.copy_dashboard(source_dashboard_id=42, destination_collection_name="Acme")
+```
+
+## Infrastructure-as-Code
+
+Define a Metabase collection tree in YAML, version it in git, and apply it
+idempotently with a Terraform-style diff.
+
+```bash
+# Pull the live state for an existing collection
+spark-metabase --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
+    export "Acme Customer" specs/acme.yaml
+
+# Show what would change after editing the spec
+spark-metabase plan specs/acme.yaml
+
+# Apply (with confirmation prompt unless --yes)
+spark-metabase apply specs/acme.yaml
+```
+
+Example spec:
+
+```yaml
+name: "Acme Customer"
+description: "Customer-facing dashboards"
+authority_level: official
+collections:
+  - name: "Questions"
+    cards:
+      - name: "Daily revenue"
+        definition:
+          dataset_query:
+            type: native
+            database: 2
+            native:
+              query: "SELECT day, sum(amount) FROM sales GROUP BY 1"
+          display: line
+          visualization_settings: {}
+dashboards:
+  - name: "Acme Dashboard"
+    description: "Top-level KPIs"
+    parameters: []
+    dashcards: []  # populated automatically by `export`
+```
+
+The Python API is also exposed:
+
+```python
+from spark_metabase_api import Metabase_API, iac
+
+mb = Metabase_API(domain=..., session_id=...)
+
+# Export to YAML
+spec = iac.export(mb, "Acme Customer")
+iac.dump(spec, "specs/acme.yaml")
+
+# Edit the file in git, then in CI:
+spec = iac.load("specs/acme.yaml")
+print(iac.plan(mb, spec).render())
+iac.apply(mb, spec)
+```
+
+### Natural keys & renames
+
+Items are identified by `(parent_path, kind, name)` within the spec. Renaming
+an item is therefore a destructive change (delete + create). To bind a spec
+entry to a specific live item across renames, set `entity_id` (Metabase's
+stable nanoid, available since v0.46) on the entry.
 
 ## Acknowledgements
 
 - [Metabase API documentation](https://www.metabase.com/docs/latest/api-documentation)
+- [Metabase API changelog](https://www.metabase.com/docs/latest/developers-guide/api-changelog)
 - Inspired from [metabase_api_python](https://github.com/vvaezian/metabase_api_python)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,65 @@ an item is therefore a destructive change (delete + create). To bind a spec
 entry to a specific live item across renames, set `entity_id` (Metabase's
 stable nanoid, available since v0.46) on the entry.
 
+### Forward references in dashcards
+
+A dashcard can reference a card created by the same spec via
+`card_name: "<name>"` instead of `card_id`. The applier looks the name up in
+the cards present (or just created) inside the same collection and rewrites
+the dashcard with the real id.
+
+## Natural-language dashboard authoring
+
+```bash
+pip install "spark-metabase-api[chatbot]"
+```
+
+Describe what you want; Claude inspects the live Metabase via read-only tools
+(`list_databases`, `list_tables`, `describe_table`, `search_metabase`,
+`find_cards_using_table`) and emits a `CollectionSpec`:
+
+```python
+from spark_metabase_api import Metabase_API, iac
+from spark_metabase_api.chatbot import chat
+
+mb = Metabase_API(domain=..., session_id=...)
+spec = chat(mb, "Build an Acme dashboard with monthly revenue and top accounts")
+print(iac.plan(mb, spec).render())
+iac.apply(mb, spec)
+```
+
+For UIs (Streamlit, Slack, etc.) use the streaming generator:
+
+```python
+from spark_metabase_api.chatbot import stream
+
+for event_type, payload in stream(mb, "..."):
+    if event_type == "text":          render_assistant_text(payload)
+    elif event_type == "tool_call":   render_tool_call(payload)      # {name, input}
+    elif event_type == "tool_result": render_tool_result(payload)    # {name, input, result}
+    elif event_type == "proposed":    save_spec(payload)             # CollectionSpec dict
+```
+
+Powered by Claude Opus 4.7 with adaptive thinking; the model needs an
+`ANTHROPIC_API_KEY` environment variable.
+
+### Streamlit frontend
+
+A single-file Streamlit app that wires the chatbot to a chat UI with live
+tool-call rendering, plan diffing, and an Apply button.
+
+```bash
+pip install "spark-metabase-api[streamlit]"
+streamlit run streamlit_app.py
+```
+
+The app:
+- collects Metabase + Anthropic credentials in the sidebar,
+- streams Claude's progress (text, tool calls, expandable tool results) as
+  the agent works,
+- renders the proposed spec as YAML,
+- previews the diff via `iac.plan` and applies it on demand.
+
 ## Acknowledgements
 
 - [Metabase API documentation](https://www.metabase.com/docs/latest/api-documentation)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,26 @@ The app:
 - renders the proposed spec as YAML,
 - previews the diff via `iac.plan` and applies it on demand.
 
+## Integration tests
+
+A standalone script exercises the package against a live Metabase instance,
+in four phases with a sandboxed write area that's archived on exit:
+
+```bash
+python tests/integration_test.py \
+    --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
+    --collection "My Reports" \
+    --source-dashboard-id 42 \
+    --chatbot
+```
+
+Phase 1 is fully read-only. Phase 2 creates a uniquely-named throwaway
+collection, applies a tiny spec, exercises `add_card_to_dashboard` and
+`copy_dashboard(deepcopy=True)`, then archives the sandbox in a `finally`
+block (use `--keep-sandbox` to keep it around for manual inspection).
+Phase 3 (opt-in via `--chatbot`) runs the Claude agent but does *not*
+apply the spec it proposes.
+
 ## Acknowledgements
 
 - [Metabase API documentation](https://www.metabase.com/docs/latest/api-documentation)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.2.0",
+    version="0.3.0",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",
@@ -18,6 +18,8 @@ setuptools.setup(
     ],
     extras_require={
         "iac": ["PyYAML>=5.1"],
+        "chatbot": ["anthropic>=0.40.0"],
+        "streamlit": ["streamlit>=1.30", "PyYAML>=5.1", "anthropic>=0.40.0"],
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.1.13.1",
+    version="0.1.14",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.1.14",
+    version="0.2.0",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",
@@ -16,6 +16,14 @@ setuptools.setup(
     install_requires=[
         "requests",
     ],
+    extras_require={
+        "iac": ["PyYAML>=5.1"],
+    },
+    entry_points={
+        "console_scripts": [
+            "spark-metabase=spark_metabase_api.iac:main",
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/spark_metabase_api/__init__.py
+++ b/spark_metabase_api/__init__.py
@@ -1,1 +1,3 @@
 from .main_methods import Metabase_API
+
+__all__ = ["Metabase_API"]

--- a/spark_metabase_api/_helper_methods.py
+++ b/spark_metabase_api/_helper_methods.py
@@ -64,19 +64,19 @@ def get_item_name(self, item_type, item_id):
 
 
 def check_collection(self, collection_name=None, parent_collection_id=None):
-    
+
     collection_IDs = [
-        i["id"] for i in self.get("/api/collection/") 
+        i["id"] for i in self.get("/api/collection/")
         if ("location" in i) and (i["name"] == collection_name) and (str(parent_collection_id) in i["location"])
     ]
 
     if len(collection_IDs) > 1:
         raise ValueError(
-            'There is more than one collection with the name "{}"'.format(item_name)
+            'There is more than one collection with the name "{}"'.format(collection_name)
         )
     elif len(collection_IDs) == 0:
         return None
-    
+
     else:
         return collection_IDs[0]
 
@@ -490,8 +490,8 @@ def get_dashboard_question_ids(
     dashboard_name=None
 ):
     """
-    Return a dictionary with col_name key and col_id value, for the given table_id/table_name in the given db_id/db_name.
-    If column_id_name is True, return a dictionary with col_id key and col_name value.
+    Return the list of card ids referenced by the given dashboard.
+    Accepts either the dashboard id or its name.
     """
 
     if not dashboard_id:
@@ -502,10 +502,15 @@ def get_dashboard_question_ids(
                                     item_type='dashboard',
                                     item_name=dashboard_name
             )
-    
+
     dashboard = self.get('/api/dashboard/{}'.format(dashboard_id))
 
-    return [card["card_id"] for card in dashboard["dashcards"] if card["card_id"] is not None]
+    # Metabase used 'ordered_cards' before ~0.48, then 'dashcards'. Support both.
+    cards = dashboard.get("dashcards")
+    if cards is None:
+        cards = dashboard.get("ordered_cards", [])
+
+    return [card["card_id"] for card in cards if card.get("card_id") is not None]
 
 def find_cards_via_db_object(
             self, 

--- a/spark_metabase_api/_rest_methods.py
+++ b/spark_metabase_api/_rest_methods.py
@@ -1,46 +1,56 @@
 import requests
 
+DEFAULT_TIMEOUT = 30
+
+
+def _client(self):
+    # Created lazily for backward-compat with subclasses constructed
+    # before _http existed (it is normally set in __init__).
+    if not hasattr(self, "_http") or self._http is None:
+        self._http = requests.Session()
+    return self._http
+
 
 def get(self, endpoint, *args, **kwargs):
     self.validate_session()
-    res = requests.get(
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    res = _client(self).get(
         self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth
     )
     if "raw" in args:
         return res
-    else:
-        return res.json() if res.ok else False
+    return res.json() if res.ok else False
 
 
 def post(self, endpoint, *args, **kwargs):
     self.validate_session()
-    res = requests.post(
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    res = _client(self).post(
         self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth
     )
     if "raw" in args:
         return res
-    else:
-        return res.json() if res.ok else False
+    return res.json() if res.ok else False
 
 
 def put(self, endpoint, *args, **kwargs):
     """Used for updating objects (cards, dashboards, ...)"""
     self.validate_session()
-    res = requests.put(
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    res = _client(self).put(
         self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth
     )
     if "raw" in args:
         return res
-    else:
-        return res.status_code
+    return res.status_code
 
 
 def delete(self, endpoint, *args, **kwargs):
     self.validate_session()
-    res = requests.delete(
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+    res = _client(self).delete(
         self.domain + endpoint, headers=self.header, **kwargs, auth=self.auth
     )
     if "raw" in args:
         return res
-    else:
-        return res.status_code
+    return res.status_code

--- a/spark_metabase_api/chatbot.py
+++ b/spark_metabase_api/chatbot.py
@@ -21,7 +21,7 @@ Typical usage:
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 try:  # anthropic is an optional extra
     import anthropic  # type: ignore
@@ -115,33 +115,22 @@ def _require_anthropic() -> None:
         )
 
 
-def chat(
+def _build_tools(
     metabase,
-    prompt: str,
-    *,
-    model: str = "claude-opus-4-7",
-    max_tokens: int = 8192,
-    anthropic_client: Optional[Any] = None,
-    verbose: bool = True,
-) -> CollectionSpec:
-    """Run a Claude tool-use session that produces a CollectionSpec.
+    on_propose: Callable[[Dict[str, Any]], None],
+    on_tool_call: Optional[Callable[[str, Dict[str, Any], str], None]] = None,
+) -> List[Any]:
+    """Build the agent's read-only inspection tools + the propose-spec sink.
 
-    Keyword arguments:
-    metabase -- a configured Metabase_API instance
-    prompt -- natural-language description of the dashboard to build
-    model -- Claude model id (default 'claude-opus-4-7')
-    max_tokens -- per-turn output cap (default 8192)
-    anthropic_client -- optional pre-built anthropic.Anthropic
-    verbose -- print Claude's progress to stdout (default True)
-
-    Returns the CollectionSpec the agent emitted via propose_dashboard_spec.
-    Raises RuntimeError if the agent finished without proposing one.
+    `on_propose(spec)` is called when the agent emits the final spec.
+    `on_tool_call(name, input, result)` (optional) is called after every
+    inspection tool returns, for UI logging.
     """
-    _require_anthropic()
-    client = anthropic_client or anthropic.Anthropic()
 
-    # Bag captured in the closure of propose_dashboard_spec.
-    proposed: Dict[str, Any] = {}
+    def _record(name: str, input: Dict[str, Any], result: str) -> str:
+        if on_tool_call is not None:
+            on_tool_call(name, input, result)
+        return result
 
     @beta_tool
     def list_databases() -> str:
@@ -161,7 +150,7 @@ def chat(
             }
             for d in (res or [])
         ]
-        return json.dumps(items, ensure_ascii=False)
+        return _record("list_databases", {}, json.dumps(items, ensure_ascii=False))
 
     @beta_tool
     def list_tables(database_id: int) -> str:
@@ -186,7 +175,11 @@ def chat(
             }
             for t in tables
         ]
-        return json.dumps(items, ensure_ascii=False)
+        return _record(
+            "list_tables",
+            {"database_id": database_id},
+            json.dumps(items, ensure_ascii=False),
+        )
 
     @beta_tool
     def describe_table(table_id: int) -> str:
@@ -209,18 +202,20 @@ def chat(
             }
             for f in (meta.get("fields") or [])
         ]
-        return json.dumps(
-            {
-                "table": {
-                    "id": meta.get("id"),
-                    "name": meta.get("name"),
-                    "schema": meta.get("schema"),
-                    "description": meta.get("description"),
-                    "db_id": meta.get("db_id"),
-                },
-                "fields": fields,
+        payload = {
+            "table": {
+                "id": meta.get("id"),
+                "name": meta.get("name"),
+                "schema": meta.get("schema"),
+                "description": meta.get("description"),
+                "db_id": meta.get("db_id"),
             },
-            ensure_ascii=False,
+            "fields": fields,
+        }
+        return _record(
+            "describe_table",
+            {"table_id": table_id},
+            json.dumps(payload, ensure_ascii=False),
         )
 
     @beta_tool
@@ -234,17 +229,19 @@ def chat(
 
         Returns a JSON array of {id, name, model, collection_id} entries."""
         results = metabase.search(query, item_type=item_type) or []
-        return json.dumps(
-            [
-                {
-                    "id": r.get("id"),
-                    "name": r.get("name"),
-                    "model": r.get("model"),
-                    "collection_id": r.get("collection_id"),
-                }
-                for r in results
-            ],
-            ensure_ascii=False,
+        items = [
+            {
+                "id": r.get("id"),
+                "name": r.get("name"),
+                "model": r.get("model"),
+                "collection_id": r.get("collection_id"),
+            }
+            for r in results
+        ]
+        return _record(
+            "search_metabase",
+            {"query": query, "item_type": item_type},
+            json.dumps(items, ensure_ascii=False),
         )
 
     @beta_tool
@@ -262,7 +259,11 @@ def chat(
         infos = metabase.find_cards_via_db_object(
             schema_name=schema_name, table_name=table_name,
         ) or []
-        return json.dumps(infos, ensure_ascii=False)
+        return _record(
+            "find_cards_using_table",
+            {"schema_name": schema_name, "table_name": table_name},
+            json.dumps(infos, ensure_ascii=False),
+        )
 
     @beta_tool
     def propose_dashboard_spec(spec: Dict[str, Any]) -> str:
@@ -281,9 +282,58 @@ def chat(
         if not (spec.get("cards") or spec.get("dashboards") or spec.get("collections")):
             return ("Error: spec must include at least one card, dashboard, "
                     "or nested collection — empty specs are not useful.")
+        on_propose(spec)
+        return "ok"
+
+    return [
+        list_databases,
+        list_tables,
+        describe_table,
+        search_metabase,
+        find_cards_using_table,
+        propose_dashboard_spec,
+    ]
+
+
+# Event tuple types yielded by `stream`. Kept as plain tuples so callers don't
+# need to import any class — easy to pattern-match in a UI loop.
+ChatEvent = Tuple[str, Any]
+#   ("text",        str)              — assistant prose
+#   ("tool_call",   {"name", "input"}) — agent invoked a tool
+#   ("tool_result", {"name", "input", "result"}) — tool returned (truncated str)
+#   ("proposed",    dict)              — final CollectionSpec dict (last event)
+
+
+def stream(
+    metabase,
+    prompt: str,
+    *,
+    model: str = "claude-opus-4-7",
+    max_tokens: int = 8192,
+    anthropic_client: Optional[Any] = None,
+) -> Iterator[ChatEvent]:
+    """Run the agent and yield events as they happen.
+
+    Use this to drive a UI that updates as Claude works (e.g. Streamlit).
+    For a blocking call that just returns the final spec, use ``chat()``.
+    """
+    _require_anthropic()
+    client = anthropic_client or anthropic.Anthropic()
+
+    proposed: Dict[str, Any] = {}
+    pending_tool_results: List[Dict[str, Any]] = []
+
+    def _on_propose(spec: Dict[str, Any]) -> None:
         proposed.clear()
         proposed.update(spec)
-        return "ok"
+
+    def _on_tool_call(name: str, input: Dict[str, Any], result: str) -> None:
+        # Truncate large results so the UI stays readable; the agent still
+        # sees the full result via the tool runner.
+        snippet = result if len(result) <= 4000 else result[:4000] + "...[truncated]"
+        pending_tool_results.append({"name": name, "input": input, "result": snippet})
+
+    tools = _build_tools(metabase, on_propose=_on_propose, on_tool_call=_on_tool_call)
 
     runner = client.beta.messages.tool_runner(
         model=model,
@@ -292,35 +342,75 @@ def chat(
         output_config={"effort": "xhigh"},
         cache_control={"type": "ephemeral"},
         system=SYSTEM_PROMPT,
-        tools=[
-            list_databases,
-            list_tables,
-            describe_table,
-            search_metabase,
-            find_cards_using_table,
-            propose_dashboard_spec,
-        ],
+        tools=tools,
         messages=[{"role": "user", "content": prompt}],
     )
 
     for message in runner:
-        if not verbose:
-            continue
+        # Drain results from tool calls executed since the previous message.
+        while pending_tool_results:
+            yield ("tool_result", pending_tool_results.pop(0))
         for block in message.content:
-            if getattr(block, "type", None) == "text" and getattr(block, "text", ""):
-                print(block.text)
-            elif getattr(block, "type", None) == "tool_use":
-                args = (block.input or {}) if hasattr(block, "input") else {}
-                summary = ", ".join(
-                    "{}={}".format(k, json.dumps(v, ensure_ascii=False)[:80])
-                    for k, v in args.items()
-                )
-                print("    → {}({})".format(block.name, summary))
+            btype = getattr(block, "type", None)
+            if btype == "text" and getattr(block, "text", ""):
+                yield ("text", block.text)
+            elif btype == "tool_use":
+                yield ("tool_call", {
+                    "name": block.name,
+                    "input": dict(block.input or {}),
+                })
 
-    if not proposed:
+    while pending_tool_results:
+        yield ("tool_result", pending_tool_results.pop(0))
+
+    if proposed:
+        yield ("proposed", dict(proposed))
+
+
+def chat(
+    metabase,
+    prompt: str,
+    *,
+    model: str = "claude-opus-4-7",
+    max_tokens: int = 8192,
+    anthropic_client: Optional[Any] = None,
+    verbose: bool = True,
+) -> CollectionSpec:
+    """Run a Claude tool-use session that produces a CollectionSpec.
+
+    Blocking convenience wrapper around ``stream()``. Returns the final spec.
+
+    Keyword arguments:
+    metabase -- a configured Metabase_API instance
+    prompt -- natural-language description of the dashboard to build
+    model -- Claude model id (default 'claude-opus-4-7')
+    max_tokens -- per-turn output cap (default 8192)
+    anthropic_client -- optional pre-built anthropic.Anthropic
+    verbose -- print Claude's progress to stdout (default True)
+
+    Raises RuntimeError if the agent finished without proposing a spec.
+    """
+    spec_dict: Optional[Dict[str, Any]] = None
+    for event_type, payload in stream(
+        metabase, prompt,
+        model=model, max_tokens=max_tokens,
+        anthropic_client=anthropic_client,
+    ):
+        if event_type == "proposed":
+            spec_dict = payload
+        elif verbose and event_type == "text":
+            print(payload)
+        elif verbose and event_type == "tool_call":
+            args = ", ".join(
+                "{}={}".format(k, json.dumps(v, ensure_ascii=False)[:80])
+                for k, v in payload["input"].items()
+            )
+            print("    → {}({})".format(payload["name"], args))
+
+    if spec_dict is None:
         raise RuntimeError(
             "The agent finished without calling propose_dashboard_spec. "
             "Try a more concrete brief, or re-run with a higher max_tokens."
         )
 
-    return iac._spec_from_dict(proposed)
+    return iac._spec_from_dict(spec_dict)

--- a/spark_metabase_api/chatbot.py
+++ b/spark_metabase_api/chatbot.py
@@ -1,0 +1,326 @@
+"""Natural-language dashboard authoring for Metabase.
+
+Powered by Claude with tool-use (Anthropic SDK). Takes a natural-language
+brief, inspects a live Metabase instance via read-only tools, and produces a
+`spark_metabase_api.iac.CollectionSpec` you can review and apply.
+
+This module is an optional extra:
+
+    pip install "spark-metabase-api[chatbot]"
+
+Typical usage:
+
+    from spark_metabase_api import Metabase_API, iac
+    from spark_metabase_api.chatbot import chat
+
+    mb = Metabase_API(domain=..., session_id=...)
+    spec = chat(mb, "Build an Acme dashboard with monthly revenue and top accounts")
+    print(iac.plan(mb, spec).render())
+    iac.apply(mb, spec)
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+try:  # anthropic is an optional extra
+    import anthropic  # type: ignore
+    from anthropic import beta_tool  # type: ignore
+except ImportError:  # pragma: no cover - exercised when anthropic absent
+    anthropic = None  # type: ignore
+    beta_tool = None  # type: ignore
+
+from . import iac
+from .iac import CollectionSpec
+
+
+SYSTEM_PROMPT = """You are a Metabase dashboard architect.
+
+Given a natural-language brief, you inspect a live Metabase instance via
+read-only tools, then emit a complete dashboard spec for the user to review
+and apply. You operate on real data: never invent column names or table ids.
+
+# Workflow (in order)
+1. `list_databases` — see what databases are connected.
+2. `list_tables(database_id)` — explore the relevant database.
+3. `describe_table(table_id)` — get column names, types, and ids. **Always do
+   this before writing SQL — never guess column names.**
+4. (optional) `search_metabase(query)` and
+   `find_cards_using_table(schema_name, table_name)` — check whether suitable
+   cards already exist before duplicating work.
+5. `propose_dashboard_spec(spec)` — call this exactly once at the end with
+   the complete spec. After this tool returns, your job is done.
+
+# Rules
+- Never hallucinate column names. If `describe_table` did not confirm a name,
+  it does not exist.
+- Prefer native SQL queries (`type: "native"`) — simpler and more durable
+  than MBQL. Match the database's SQL dialect (engine field).
+- A typical dashboard has 4-12 cards. Prefer a few well-chosen cards over
+  many redundant ones.
+- Metabase's dashboard grid is 24 columns wide. Stack cards vertically with
+  `row`/`col`/`size_x`/`size_y`. A full-width card is `size_x: 24, size_y: 8`.
+- Reference cards in dashcards either by `card_id: <int>` (an existing
+  Metabase card) or `card_name: "<name>"` (forward-reference to a card you
+  define in the same `cards` array).
+
+# CollectionSpec shape
+```json
+{
+  "name": "string (collection name)",
+  "description": "optional string",
+  "authority_level": null,
+  "collections": [],
+  "cards": [
+    {
+      "name": "Daily revenue",
+      "description": "optional",
+      "definition": {
+        "dataset_query": {
+          "type": "native",
+          "database": 1,
+          "native": {"query": "SELECT day, sum(amount) FROM sales GROUP BY 1"}
+        },
+        "display": "line",
+        "visualization_settings": {}
+      }
+    }
+  ],
+  "dashboards": [
+    {
+      "name": "Acme Overview",
+      "description": "optional",
+      "parameters": [],
+      "dashcards": [
+        {
+          "id": -1,
+          "card_name": "Daily revenue",
+          "row": 0, "col": 0, "size_x": 24, "size_y": 8,
+          "parameter_mappings": [],
+          "visualization_settings": {}
+        }
+      ]
+    }
+  ]
+}
+```
+"""
+
+
+def _require_anthropic() -> None:
+    if anthropic is None:
+        raise ImportError(
+            "The chatbot module requires the 'anthropic' package. "
+            "Install with: pip install spark-metabase-api[chatbot]"
+        )
+
+
+def chat(
+    metabase,
+    prompt: str,
+    *,
+    model: str = "claude-opus-4-7",
+    max_tokens: int = 8192,
+    anthropic_client: Optional[Any] = None,
+    verbose: bool = True,
+) -> CollectionSpec:
+    """Run a Claude tool-use session that produces a CollectionSpec.
+
+    Keyword arguments:
+    metabase -- a configured Metabase_API instance
+    prompt -- natural-language description of the dashboard to build
+    model -- Claude model id (default 'claude-opus-4-7')
+    max_tokens -- per-turn output cap (default 8192)
+    anthropic_client -- optional pre-built anthropic.Anthropic
+    verbose -- print Claude's progress to stdout (default True)
+
+    Returns the CollectionSpec the agent emitted via propose_dashboard_spec.
+    Raises RuntimeError if the agent finished without proposing one.
+    """
+    _require_anthropic()
+    client = anthropic_client or anthropic.Anthropic()
+
+    # Bag captured in the closure of propose_dashboard_spec.
+    proposed: Dict[str, Any] = {}
+
+    @beta_tool
+    def list_databases() -> str:
+        """List the Metabase-connected databases.
+
+        Returns a JSON array of {id, name, engine, description} entries.
+        Use the engine field to know which SQL dialect to write."""
+        res = metabase.get("/api/database/")
+        if isinstance(res, dict):
+            res = res.get("data", [])
+        items = [
+            {
+                "id": d.get("id"),
+                "name": d.get("name"),
+                "engine": d.get("engine"),
+                "description": d.get("description"),
+            }
+            for d in (res or [])
+        ]
+        return json.dumps(items, ensure_ascii=False)
+
+    @beta_tool
+    def list_tables(database_id: int) -> str:
+        """List tables for a Metabase database.
+
+        Args:
+            database_id: id of the database (from list_databases)
+
+        Returns a JSON array of {id, name, schema, display_name, description}."""
+        info = metabase.get(
+            "/api/database/{}".format(database_id),
+            params={"include": "tables"},
+        ) or {}
+        tables = info.get("tables") or []
+        items = [
+            {
+                "id": t.get("id"),
+                "name": t.get("name"),
+                "schema": t.get("schema"),
+                "display_name": t.get("display_name"),
+                "description": t.get("description"),
+            }
+            for t in tables
+        ]
+        return json.dumps(items, ensure_ascii=False)
+
+    @beta_tool
+    def describe_table(table_id: int) -> str:
+        """Get the columns of a Metabase table.
+
+        Args:
+            table_id: id of the table (from list_tables)
+
+        Returns JSON {table: {...}, fields: [{id, name, base_type,
+        semantic_type, description}, ...]}. Use the exact column names from
+        this response in any SQL you write — never guess."""
+        meta = metabase.get_table_metadata(table_id=table_id) or {}
+        fields = [
+            {
+                "id": f.get("id"),
+                "name": f.get("name"),
+                "base_type": f.get("base_type"),
+                "semantic_type": f.get("semantic_type"),
+                "description": f.get("description"),
+            }
+            for f in (meta.get("fields") or [])
+        ]
+        return json.dumps(
+            {
+                "table": {
+                    "id": meta.get("id"),
+                    "name": meta.get("name"),
+                    "schema": meta.get("schema"),
+                    "description": meta.get("description"),
+                    "db_id": meta.get("db_id"),
+                },
+                "fields": fields,
+            },
+            ensure_ascii=False,
+        )
+
+    @beta_tool
+    def search_metabase(query: str, item_type: Optional[str] = None) -> str:
+        """Search existing Metabase items by name.
+
+        Args:
+            query: search string
+            item_type: optional filter ('card', 'dashboard', 'collection',
+                       'table', 'segment', 'metric')
+
+        Returns a JSON array of {id, name, model, collection_id} entries."""
+        results = metabase.search(query, item_type=item_type) or []
+        return json.dumps(
+            [
+                {
+                    "id": r.get("id"),
+                    "name": r.get("name"),
+                    "model": r.get("model"),
+                    "collection_id": r.get("collection_id"),
+                }
+                for r in results
+            ],
+            ensure_ascii=False,
+        )
+
+    @beta_tool
+    def find_cards_using_table(schema_name: str, table_name: str) -> str:
+        """Find existing native-SQL cards that reference schema.table.
+
+        Useful before authoring new SQL — if a card already provides what
+        the brief asks for, reuse it instead of duplicating it.
+
+        Args:
+            schema_name: database schema name
+            table_name: table name
+
+        Returns a JSON array of {id, name} for matching cards."""
+        infos = metabase.find_cards_via_db_object(
+            schema_name=schema_name, table_name=table_name,
+        ) or []
+        return json.dumps(infos, ensure_ascii=False)
+
+    @beta_tool
+    def propose_dashboard_spec(spec: Dict[str, Any]) -> str:
+        """Emit the final CollectionSpec. Call this exactly once.
+
+        Args:
+            spec: a dict matching the CollectionSpec shape from the system
+                  prompt. Must include 'name'. Should include at least one
+                  card or dashboard.
+
+        Returns 'ok' on success, an error string otherwise."""
+        if not isinstance(spec, dict):
+            return "Error: spec must be a JSON object."
+        if not spec.get("name"):
+            return "Error: spec must include a 'name' field."
+        if not (spec.get("cards") or spec.get("dashboards") or spec.get("collections")):
+            return ("Error: spec must include at least one card, dashboard, "
+                    "or nested collection — empty specs are not useful.")
+        proposed.clear()
+        proposed.update(spec)
+        return "ok"
+
+    runner = client.beta.messages.tool_runner(
+        model=model,
+        max_tokens=max_tokens,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "xhigh"},
+        cache_control={"type": "ephemeral"},
+        system=SYSTEM_PROMPT,
+        tools=[
+            list_databases,
+            list_tables,
+            describe_table,
+            search_metabase,
+            find_cards_using_table,
+            propose_dashboard_spec,
+        ],
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    for message in runner:
+        if not verbose:
+            continue
+        for block in message.content:
+            if getattr(block, "type", None) == "text" and getattr(block, "text", ""):
+                print(block.text)
+            elif getattr(block, "type", None) == "tool_use":
+                args = (block.input or {}) if hasattr(block, "input") else {}
+                summary = ", ".join(
+                    "{}={}".format(k, json.dumps(v, ensure_ascii=False)[:80])
+                    for k, v in args.items()
+                )
+                print("    → {}({})".format(block.name, summary))
+
+    if not proposed:
+        raise RuntimeError(
+            "The agent finished without calling propose_dashboard_spec. "
+            "Try a more concrete brief, or re-run with a higher max_tokens."
+        )
+
+    return iac._spec_from_dict(proposed)

--- a/spark_metabase_api/chatbot.py
+++ b/spark_metabase_api/chatbot.py
@@ -413,4 +413,4 @@ def chat(
             "Try a more concrete brief, or re-run with a higher max_tokens."
         )
 
-    return iac._spec_from_dict(spec_dict)
+    return iac.spec_from_dict(spec_dict)

--- a/spark_metabase_api/copy_methods.py
+++ b/spark_metabase_api/copy_methods.py
@@ -150,7 +150,12 @@ def copy_dashboard(self,
 
         for dashboard_question_id in dashboard_question_ids:
             question = self.get('/api/card/{}'.format(dashboard_question_id))
-            question["name"] = question["name"].rstrip(' - Duplicate')
+            # Metabase's deep copy suffixes duplicated questions with " - Duplicate".
+            # rstrip() would strip any combination of those characters from the end;
+            # removesuffix only strips the exact suffix once.
+            suffix = ' - Duplicate'
+            if question["name"].endswith(suffix):
+                question["name"] = question["name"][: -len(suffix)]
             self.put(
                     '/api/card/{}'.format(dashboard_question_id), 
                     json={

--- a/spark_metabase_api/create_methods.py
+++ b/spark_metabase_api/create_methods.py
@@ -251,11 +251,12 @@ def create_collection(
         "authority_level": "official" if official else None,
     }
 
-    # 'color' is accepted by older Metabase versions and ignored / rejected by
-    # newer ones (collections no longer carry a color). Try with color first,
-    # fall back to the request without it on a 400.
+    # 'color' is accepted by older Metabase versions and rejected by newer
+    # ones (collections no longer carry a color). Try with color first; only
+    # retry without it when the 400 specifically complained about that field,
+    # so we don't double-POST on real validation errors (duplicate name, ...).
     res = self.post("/api/collection", "raw", json={**payload, "color": "#509EE3"})
-    if res.status_code == 400:
+    if res.status_code == 400 and "color" in res.text.lower():
         res = self.post("/api/collection", "raw", json=payload)
     res = res.json() if res.ok else False
 

--- a/spark_metabase_api/create_methods.py
+++ b/spark_metabase_api/create_methods.py
@@ -122,17 +122,22 @@ def create_card(
 
     elif column_order == "db_table_order":  # default
         ### find the actual order of columns in the table as they appear in the database
-        # Create a temporary card for retrieving column ordering
-        json_str = """{{'dataset_query': {{ 'database': {1},
-                                            'native': {{'query': 'SELECT * from "{2}";' }},
-                                            'type': 'native' }},
-                        'display': 'table',
-                        'name': '{0}',
-                        'visualization_settings': {{}} }}""".format(
-            card_name, db_id, table_name
-        )
+        # Create a temporary card for retrieving column ordering. The table
+        # name comes from Metabase's own metadata, but we still escape any
+        # double-quote that would otherwise close the identifier.
+        safe_table_name = str(table_name).replace('"', '""')
+        probe_card = {
+            "dataset_query": {
+                "database": db_id,
+                "native": {"query": 'SELECT * from "{}";'.format(safe_table_name)},
+                "type": "native",
+            },
+            "display": "table",
+            "name": card_name,
+            "visualization_settings": {},
+        }
 
-        res = self.post("/api/card/", json=eval(json_str))
+        res = self.post("/api/card/", json=probe_card)
         if not res:
             print("Card Creation Failed!")
             return res
@@ -160,18 +165,20 @@ def create_card(
         )
 
     # default json
-    json_str = """{{'dataset_query': {{'database': {1},
-                                        'query': {{'fields': {4},
-                                                                'source-table': {2}}},
-                                        'type': 'query'}},
-                    'display': 'table',
-                    'name': '{0}',
-                    'collection_id': {3},
-                    'visualization_settings': {{}}
-                    }}""".format(
-        card_name, db_id, table_id, collection_id, column_id_list_str
-    )
-    json = eval(json_str)
+    json = {
+        "dataset_query": {
+            "database": db_id,
+            "query": {
+                "fields": column_id_list_str,
+                "source-table": table_id,
+            },
+            "type": "query",
+        },
+        "display": "table",
+        "name": card_name,
+        "collection_id": collection_id,
+        "visualization_settings": {},
+    }
 
     # Add/Rewrite data to the default json from custom_json
     if custom_json:
@@ -230,7 +237,7 @@ def create_collection(
     # Making sure we have the data we need
     if not parent_collection_id:
         if not parent_collection_name:
-            print("Either the name of id of the parent collection must be provided.")
+            raise ValueError("Either the name or id of the parent collection must be provided.")
         if parent_collection_name == "Root":
             parent_collection_id = None
         else:
@@ -238,16 +245,20 @@ def create_collection(
                 "collection", parent_collection_name
             )
 
-    res = self.post(
-        "/api/collection",
-        json={
-            "name": str(collection_name),
-            "parent_id": int(parent_collection_id),
-            'color':'#509EE3',
-            'authority_level': 'official' if official else None
-        }
-    )
-    
+    payload = {
+        "name": str(collection_name),
+        "parent_id": int(parent_collection_id) if parent_collection_id is not None else None,
+        "authority_level": "official" if official else None,
+    }
+
+    # 'color' is accepted by older Metabase versions and ignored / rejected by
+    # newer ones (collections no longer carry a color). Try with color first,
+    # fall back to the request without it on a 400.
+    res = self.post("/api/collection", "raw", json={**payload, "color": "#509EE3"})
+    if res.status_code == 400:
+        res = self.post("/api/collection", "raw", json=payload)
+    res = res.json() if res.ok else False
+
     if return_results:
         return res
 

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -322,15 +322,24 @@ def _significant_card_diff(local: CardSpec, remote: Dict[str, Any]) -> List[str]
     return diffs
 
 
-def _significant_dashboard_diff(local: DashboardSpec, remote: Dict[str, Any]) -> List[str]:
+def _significant_dashboard_diff(
+    local: DashboardSpec,
+    remote: Dict[str, Any],
+    resolved_dashcards: Optional[List[Dict[str, Any]]] = None,
+) -> List[str]:
     diffs = []
     if (local.description or None) != (remote.get("description") or None):
         diffs.append("description")
     if (local.parameters or []) != (remote.get("parameters") or []):
         diffs.append("parameters")
-    remote_dc = remote.get("dashcards") or remote.get("ordered_cards") or []
-    if (local.dashcards or []) != remote_dc:
+    if resolved_dashcards is None:
+        # Spec carries card_name forward references that can't be resolved
+        # yet (cards not created at plan time). Force an update.
         diffs.append("dashcards")
+    else:
+        remote_dc = remote.get("dashcards") or remote.get("ordered_cards") or []
+        if resolved_dashcards != remote_dc:
+            diffs.append("dashcards")
     return diffs
 
 
@@ -419,6 +428,15 @@ def _plan_collection(client, spec: CollectionSpec, parent_id: Optional[int],
             parent_path=path, p=p,
         )
 
+    # name_to_id for cards in this collection — also used to resolve
+    # card_name forward references in spec dashcards before we diff them
+    # against the live state (which carries card_id).
+    existing_name_to_id = {
+        name: item["id"]
+        for (kind, name), item in children.items()
+        if kind == "card"
+    }
+
     for d in spec.dashboards:
         match = children.get(("dashboard", d.name))
         d_path = _join(path, d.name)
@@ -426,7 +444,14 @@ def _plan_collection(client, spec: CollectionSpec, parent_id: Optional[int],
             p.actions.append(Action(op="create", kind="dashboard", path=d_path))
             continue
         remote = client.get("/api/dashboard/{}".format(match["id"])) or match
-        diffs = _significant_dashboard_diff(d, remote)
+        try:
+            resolved_dashcards = _resolve_card_names(d.dashcards, existing_name_to_id)
+        except ValueError:
+            # The spec references a card_name that doesn't exist yet (will be
+            # created in the same apply). Treat as needing an update; the
+            # executor will resolve it once the card is materialised.
+            resolved_dashcards = None
+        diffs = _significant_dashboard_diff(d, remote, resolved_dashcards)
         p.actions.append(Action(
             op="update" if diffs else "skip",
             kind="dashboard", path=d_path,
@@ -471,6 +496,34 @@ def apply(client, spec: CollectionSpec, parent_id: Optional[int] = None,
     return p
 
 
+def _resolve_card_names(dashcards: List[Dict[str, Any]],
+                        name_to_id: Dict[str, int]) -> List[Dict[str, Any]]:
+    """Replace `card_name` forward references in dashcards with `card_id`.
+
+    Dashcards that already have a `card_id` are left alone. A dashcard with
+    `card_name` set and no `card_id` is rewritten to point at the live id;
+    if the name doesn't match any card created or found in the same scope,
+    a ValueError is raised with the offending name.
+    """
+    out = []
+    for dc in dashcards or []:
+        if dc.get("card_name") and not dc.get("card_id"):
+            cid = name_to_id.get(dc["card_name"])
+            if cid is None:
+                raise ValueError(
+                    "Dashcard references card_name {!r}, but no card with "
+                    "that name was created or found in the same collection."
+                    .format(dc["card_name"])
+                )
+            resolved = dict(dc)
+            resolved["card_id"] = cid
+            resolved.pop("card_name")
+            out.append(resolved)
+        else:
+            out.append(dc)
+    return out
+
+
 def _execute_collection(client, spec: CollectionSpec, parent_id: Optional[int],
                         parent_path: str, by_path: Dict[str, Action]) -> int:
     path = _join(parent_path or "/", spec.name)
@@ -507,34 +560,15 @@ def _execute_collection(client, spec: CollectionSpec, parent_id: Optional[int],
     for child in spec.collections:
         _execute_collection(client, child, collection_id, path, by_path)
 
-    for d in spec.dashboards:
-        d_path = _join(path, d.name)
-        d_action = by_path.get(d_path)
-        if d_action is None:
-            continue
-        if d_action.op == "create":
-            payload = {
-                "name": d.name,
-                "description": d.description,
-                "collection_id": collection_id,
-                "parameters": d.parameters or [],
-            }
-            res = client.post("/api/dashboard/", json=payload)
-            if res and d.dashcards:
-                client.put(
-                    "/api/dashboard/{}".format(res["id"]),
-                    json={"dashcards": d.dashcards, "parameters": d.parameters or []},
-                )
-        elif d_action.op == "update" and d_action.existing_id is not None:
-            client.put(
-                "/api/dashboard/{}".format(d_action.existing_id),
-                json={
-                    "description": d.description,
-                    "parameters": d.parameters or [],
-                    "dashcards": d.dashcards,
-                },
-            )
+    # Track card names → ids in this collection so dashcards can reference
+    # cards by name. Pre-populate with cards that already exist (skip ops).
+    name_to_id: Dict[str, int] = {}
+    if collection_id and collection_id != "root":
+        for (kind, name), item in _index_collection_children(client, collection_id).items():
+            if kind == "card":
+                name_to_id[name] = item["id"]
 
+    # Cards must be processed before dashboards so name_to_id is populated.
     for c in spec.cards:
         c_path = _join(path, c.name)
         c_action = by_path.get(c_path)
@@ -547,11 +581,49 @@ def _execute_collection(client, spec: CollectionSpec, parent_id: Optional[int],
                 "collection_id": collection_id,
                 "description": c.description,
             })
-            client.create_card(custom_json=payload)
+            res = client.create_card(custom_json=payload, return_card=True)
+            if not isinstance(res, dict) or "id" not in res:
+                raise RuntimeError(
+                    "Failed to create card {!r} in collection {}: {}"
+                    .format(c.name, collection_id, res)
+                )
+            name_to_id[c.name] = res["id"]
         elif c_action.op == "update" and c_action.existing_id is not None:
             payload = dict(c.definition)
             payload["description"] = c.description
             client.put("/api/card/{}".format(c_action.existing_id), json=payload)
+            name_to_id[c.name] = c_action.existing_id
+        elif c_action.existing_id is not None:  # skip
+            name_to_id[c.name] = c_action.existing_id
+
+    for d in spec.dashboards:
+        d_path = _join(path, d.name)
+        d_action = by_path.get(d_path)
+        if d_action is None:
+            continue
+        dashcards = _resolve_card_names(d.dashcards, name_to_id)
+        if d_action.op == "create":
+            payload = {
+                "name": d.name,
+                "description": d.description,
+                "collection_id": collection_id,
+                "parameters": d.parameters or [],
+            }
+            res = client.post("/api/dashboard/", json=payload)
+            if res and dashcards:
+                client.put(
+                    "/api/dashboard/{}".format(res["id"]),
+                    json={"dashcards": dashcards, "parameters": d.parameters or []},
+                )
+        elif d_action.op == "update" and d_action.existing_id is not None:
+            client.put(
+                "/api/dashboard/{}".format(d_action.existing_id),
+                json={
+                    "description": d.description,
+                    "parameters": d.parameters or [],
+                    "dashcards": dashcards,
+                },
+            )
 
     return collection_id or 0
 

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -51,9 +51,13 @@ class CardSpec:
 
 @dataclass
 class DashboardSpec:
-    """A Metabase dashboard. `dashcards` is preserved as-is; card_id references
-    inside dashcards are rewritten on apply if they point to cards in the same
-    spec (matched by entity_id, falling back to name within the spec)."""
+    """A Metabase dashboard.
+
+    `dashcards` is preserved verbatim and re-applied as-is. Card ids inside
+    dashcards are NOT rewritten in this version; if a dashboard references a
+    card created by the same spec run, set the dashcard's `card_id` manually
+    after the first apply (or wait for a future release that resolves
+    cross-references)."""
 
     name: str
     description: Optional[str] = None

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -343,14 +343,19 @@ def _significant_collection_diff(local: CollectionSpec, remote: Dict[str, Any]) 
     return diffs
 
 
-def plan(client, spec: CollectionSpec, parent_id: Optional[int] = None,
-         parent_path: str = "") -> Plan:
+def plan(client, spec: CollectionSpec, parent_id: Optional[int] = None) -> Plan:
     """Compute a plan to make Metabase match the spec.
 
-    The plan is read-only; pass it to `apply` to execute it.
+    The plan is read-only; pass the same arguments to `apply` to execute it.
+
+    Keyword arguments:
+    client -- a configured Metabase_API instance
+    spec -- the root CollectionSpec to apply
+    parent_id -- id of the Metabase collection that should host `spec`. None
+                 means the root collection.
     """
     p = Plan()
-    _plan_collection(client, spec, parent_id, parent_path, p)
+    _plan_collection(client, spec, parent_id, parent_path="", p=p)
     return p
 
 
@@ -452,20 +457,17 @@ def _plan_collection(client, spec: CollectionSpec, parent_id: Optional[int],
 
 
 def apply(client, spec: CollectionSpec, parent_id: Optional[int] = None,
-          parent_path: str = "", dry_run: bool = False) -> Plan:
-    """Apply the spec to Metabase, creating or updating items so the live state
-    matches. Returns the executed plan."""
-    p = plan(client, spec, parent_id=parent_id, parent_path=parent_path)
+          dry_run: bool = False) -> Plan:
+    """Apply the spec to Metabase so the live state matches the spec.
+
+    Returns the executed plan. With dry_run=True nothing is written and the
+    returned plan is exactly what `plan(client, spec, parent_id)` would return.
+    """
+    p = plan(client, spec, parent_id=parent_id)
     if dry_run:
         return p
-    return _execute(client, spec, p, parent_id, parent_path)
-
-
-def _execute(client, spec: CollectionSpec, p: Plan,
-             parent_id: Optional[int], parent_path: str) -> Plan:
-    # Index actions by path for quick lookup during the recursive walk.
     by_path = {a.path: a for a in p.actions}
-    _execute_collection(client, spec, parent_id, parent_path, by_path)
+    _execute_collection(client, spec, parent_id, parent_path="", by_path=by_path)
     return p
 
 

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -229,7 +229,6 @@ _CARD_OPAQUE_KEYS = (
     "parameters", "parameter_mappings", "result_metadata",
     "cache_ttl", "archived",
 )
-_DASHBOARD_OPAQUE_KEYS = ("parameters",)
 
 
 def _export_card(client, card_id: int) -> CardSpec:

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -1,0 +1,610 @@
+"""
+Infrastructure-as-Code for Metabase.
+
+Define a tree of collections / dashboards / cards in YAML (or JSON) and apply
+it idempotently to a Metabase instance, with a Terraform-style diff first.
+
+Natural keys: items are identified by (parent_path, kind, name). Renames are
+therefore destructive (delete + create); use the optional `entity_id` field
+to bind a spec entry to an existing item across a rename.
+
+Public surface:
+    Spec, CollectionSpec, DashboardSpec, CardSpec
+    load(path) -> Spec
+    dump(spec, path) -> None
+    export(client, root_collection) -> CollectionSpec
+    plan(client, spec) -> Plan
+    apply(client, spec, dry_run=False) -> Plan
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+try:  # pyyaml is an optional extra
+    import yaml as _yaml  # type: ignore
+except ImportError:  # pragma: no cover - exercised when pyyaml absent
+    _yaml = None
+
+
+# ---------------------------------------------------------------------------
+# Spec data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CardSpec:
+    """A Metabase card (question or model). `definition` is the opaque payload
+    sent to POST/PUT /api/card/, minus the collection_id (resolved on apply)."""
+
+    name: str
+    definition: Dict[str, Any] = field(default_factory=dict)
+    entity_id: Optional[str] = None
+    description: Optional[str] = None
+
+    @property
+    def kind(self) -> str:
+        return "card"
+
+
+@dataclass
+class DashboardSpec:
+    """A Metabase dashboard. `dashcards` is preserved as-is; card_id references
+    inside dashcards are rewritten on apply if they point to cards in the same
+    spec (matched by entity_id, falling back to name within the spec)."""
+
+    name: str
+    description: Optional[str] = None
+    dashcards: List[Dict[str, Any]] = field(default_factory=list)
+    parameters: List[Dict[str, Any]] = field(default_factory=list)
+    entity_id: Optional[str] = None
+
+    @property
+    def kind(self) -> str:
+        return "dashboard"
+
+
+@dataclass
+class CollectionSpec:
+    """A Metabase collection. Children are nested; the parent of the root is
+    resolved on apply via parent_path or parent_id."""
+
+    name: str
+    description: Optional[str] = None
+    authority_level: Optional[str] = None  # 'official' or None
+    entity_id: Optional[str] = None
+    parent_path: Optional[str] = None  # absolute path of the parent at apply
+    collections: List["CollectionSpec"] = field(default_factory=list)
+    dashboards: List[DashboardSpec] = field(default_factory=list)
+    cards: List[CardSpec] = field(default_factory=list)
+
+    @property
+    def kind(self) -> str:
+        return "collection"
+
+
+# Top-level Spec is just a CollectionSpec with parent_path defaulting to "/".
+Spec = CollectionSpec
+
+
+# ---------------------------------------------------------------------------
+# (De)serialization
+# ---------------------------------------------------------------------------
+
+
+def _spec_to_dict(spec: CollectionSpec) -> Dict[str, Any]:
+    return asdict(spec)
+
+
+def _spec_from_dict(data: Dict[str, Any]) -> CollectionSpec:
+    children = [_spec_from_dict(c) for c in data.get("collections") or []]
+    dashboards = [
+        DashboardSpec(
+            name=d["name"],
+            description=d.get("description"),
+            dashcards=d.get("dashcards") or [],
+            parameters=d.get("parameters") or [],
+            entity_id=d.get("entity_id"),
+        )
+        for d in data.get("dashboards") or []
+    ]
+    cards = [
+        CardSpec(
+            name=c["name"],
+            definition=c.get("definition") or {},
+            entity_id=c.get("entity_id"),
+            description=c.get("description"),
+        )
+        for c in data.get("cards") or []
+    ]
+    return CollectionSpec(
+        name=data["name"],
+        description=data.get("description"),
+        authority_level=data.get("authority_level"),
+        entity_id=data.get("entity_id"),
+        parent_path=data.get("parent_path"),
+        collections=children,
+        dashboards=dashboards,
+        cards=cards,
+    )
+
+
+def load(path: str) -> CollectionSpec:
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    if path.endswith((".yaml", ".yml")):
+        if _yaml is None:
+            raise ImportError(
+                "PyYAML is required to load YAML specs. "
+                "Install with: pip install spark-metabase-api[iac]"
+            )
+        data = _yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    return _spec_from_dict(data)
+
+
+def dump(spec: CollectionSpec, path: str) -> None:
+    data = _spec_to_dict(spec)
+    if path.endswith((".yaml", ".yml")):
+        if _yaml is None:
+            raise ImportError(
+                "PyYAML is required to dump YAML specs. "
+                "Install with: pip install spark-metabase-api[iac]"
+            )
+        text = _yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    else:
+        text = json.dumps(data, indent=2, ensure_ascii=False)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+# ---------------------------------------------------------------------------
+# Exporter
+# ---------------------------------------------------------------------------
+
+
+def _collection_items(client, collection_id: Union[int, str]) -> List[Dict[str, Any]]:
+    res = client.get("/api/collection/{}/items".format(collection_id))
+    if isinstance(res, dict):  # paginated shape introduced in 0.40
+        return res.get("data", [])
+    return res or []
+
+
+def export(client, root_collection: Union[int, str]) -> CollectionSpec:
+    """Pull a collection tree from a live Metabase into a Spec.
+
+    `root_collection` is either a collection id, the literal string 'root', or
+    a collection name (resolved via get_item_id).
+    """
+    if isinstance(root_collection, str) and root_collection.lower() != "root":
+        try:
+            root_collection = int(root_collection)
+        except ValueError:
+            root_collection = client.get_item_id("collection", root_collection)
+    return _export_collection(client, root_collection)
+
+
+def _export_collection(client, collection_id: Union[int, str]) -> CollectionSpec:
+    if collection_id == "root" or collection_id is None:
+        info = {"name": "Root", "description": None, "authority_level": None,
+                "entity_id": None}
+    else:
+        info = client.get("/api/collection/{}".format(collection_id)) or {}
+
+    spec = CollectionSpec(
+        name=info.get("name") or "Root",
+        description=info.get("description"),
+        authority_level=info.get("authority_level"),
+        entity_id=info.get("entity_id"),
+    )
+    for item in _collection_items(client, collection_id):
+        if item.get("archived"):
+            continue
+        model = item.get("model")
+        if model == "collection":
+            spec.collections.append(_export_collection(client, item["id"]))
+        elif model == "dashboard":
+            spec.dashboards.append(_export_dashboard(client, item["id"]))
+        elif model == "card":
+            spec.cards.append(_export_card(client, item["id"]))
+        # other models (pulse, metric, ...) are ignored on purpose
+    return spec
+
+
+_CARD_OPAQUE_KEYS = (
+    "dataset_query", "display", "visualization_settings", "type",
+    "parameters", "parameter_mappings", "result_metadata",
+    "cache_ttl", "archived",
+)
+_DASHBOARD_OPAQUE_KEYS = ("parameters",)
+
+
+def _export_card(client, card_id: int) -> CardSpec:
+    # MBQL 4 shapes are easier to round-trip through the API on Metabase 0.57+
+    info = client.get("/api/card/{}".format(card_id), params={"legacy-mbql": "true"}) or {}
+    return CardSpec(
+        name=info.get("name") or "",
+        description=info.get("description"),
+        entity_id=info.get("entity_id"),
+        definition={k: info.get(k) for k in _CARD_OPAQUE_KEYS if k in info},
+    )
+
+
+def _export_dashboard(client, dashboard_id: int) -> DashboardSpec:
+    info = client.get("/api/dashboard/{}".format(dashboard_id)) or {}
+    dashcards = info.get("dashcards") or info.get("ordered_cards") or []
+    return DashboardSpec(
+        name=info.get("name") or "",
+        description=info.get("description"),
+        entity_id=info.get("entity_id"),
+        parameters=info.get("parameters") or [],
+        dashcards=dashcards,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan / Apply
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Action:
+    op: str  # 'create' | 'update' | 'skip'
+    kind: str  # 'collection' | 'dashboard' | 'card'
+    path: str
+    reason: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+    existing_id: Optional[int] = None
+
+
+@dataclass
+class Plan:
+    actions: List[Action] = field(default_factory=list)
+
+    def summary(self) -> str:
+        counts: Dict[str, int] = {}
+        for a in self.actions:
+            counts[a.op] = counts.get(a.op, 0) + 1
+        parts = ["{} {}".format(v, k) for k, v in sorted(counts.items())]
+        return ", ".join(parts) or "no changes"
+
+    def render(self) -> str:
+        glyph = {"create": "+", "update": "~", "skip": "="}
+        lines = []
+        for a in self.actions:
+            lines.append("  {}  {:<10} {}{}".format(
+                glyph.get(a.op, "?"), a.kind, a.path,
+                "  [{}]".format(a.reason) if a.reason else "",
+            ))
+        return "\n".join(lines) + ("\n" if lines else "") + "Plan: " + self.summary()
+
+
+def _join(parent_path: str, name: str) -> str:
+    if parent_path == "/" or parent_path == "":
+        return "/" + name
+    return parent_path.rstrip("/") + "/" + name
+
+
+def _index_collection_children(client, collection_id) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    out: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for item in _collection_items(client, collection_id):
+        if item.get("archived"):
+            continue
+        model = item.get("model")
+        if model in ("collection", "dashboard", "card"):
+            out[(model, item["name"])] = item
+    return out
+
+
+def _significant_card_diff(local: CardSpec, remote: Dict[str, Any]) -> List[str]:
+    diffs = []
+    if (local.description or None) != (remote.get("description") or None):
+        diffs.append("description")
+    for key in ("dataset_query", "display", "visualization_settings", "type"):
+        if key in local.definition and local.definition[key] != remote.get(key):
+            diffs.append(key)
+    return diffs
+
+
+def _significant_dashboard_diff(local: DashboardSpec, remote: Dict[str, Any]) -> List[str]:
+    diffs = []
+    if (local.description or None) != (remote.get("description") or None):
+        diffs.append("description")
+    if (local.parameters or []) != (remote.get("parameters") or []):
+        diffs.append("parameters")
+    remote_dc = remote.get("dashcards") or remote.get("ordered_cards") or []
+    if (local.dashcards or []) != remote_dc:
+        diffs.append("dashcards")
+    return diffs
+
+
+def _significant_collection_diff(local: CollectionSpec, remote: Dict[str, Any]) -> List[str]:
+    diffs = []
+    if (local.description or None) != (remote.get("description") or None):
+        diffs.append("description")
+    if (local.authority_level or None) != (remote.get("authority_level") or None):
+        diffs.append("authority_level")
+    return diffs
+
+
+def plan(client, spec: CollectionSpec, parent_id: Optional[int] = None,
+         parent_path: str = "") -> Plan:
+    """Compute a plan to make Metabase match the spec.
+
+    The plan is read-only; pass it to `apply` to execute it.
+    """
+    p = Plan()
+    _plan_collection(client, spec, parent_id, parent_path, p)
+    return p
+
+
+def _plan_collection(client, spec: CollectionSpec, parent_id: Optional[int],
+                     parent_path: str, p: Plan) -> None:
+    path = _join(parent_path or "/", spec.name)
+
+    # Find existing collection at this path
+    existing_id = None
+    if parent_id is None and spec.name.lower() == "root":
+        existing_id = "root"
+        existing = {"name": "Root"}
+    else:
+        siblings = _index_collection_children(client, parent_id if parent_id is not None else "root")
+        match = siblings.get(("collection", spec.name))
+        if match:
+            existing_id = match["id"]
+            existing = client.get("/api/collection/{}".format(existing_id)) or match
+        else:
+            existing = None
+
+    if existing is None:
+        p.actions.append(Action(
+            op="create", kind="collection", path=path,
+            payload={
+                "name": spec.name,
+                "description": spec.description,
+                "authority_level": spec.authority_level,
+                "parent_id": parent_id,
+            },
+        ))
+        # Children will all be created under the (future) collection. We still
+        # plan their creation so the diff is informative.
+        for child in spec.collections:
+            _plan_collection(client, child, parent_id=None, parent_path=path, p=p)
+        for d in spec.dashboards:
+            p.actions.append(Action(op="create", kind="dashboard", path=_join(path, d.name)))
+        for c in spec.cards:
+            p.actions.append(Action(op="create", kind="card", path=_join(path, c.name)))
+        return
+
+    diffs = _significant_collection_diff(spec, existing)
+    p.actions.append(Action(
+        op="update" if diffs else "skip",
+        kind="collection", path=path,
+        reason=",".join(diffs),
+        existing_id=existing_id if isinstance(existing_id, int) else None,
+        payload={
+            "description": spec.description,
+            "authority_level": spec.authority_level,
+        } if diffs else {},
+    ))
+
+    children = _index_collection_children(client, existing_id) if existing_id != "root" else \
+        _index_collection_children(client, "root")
+
+    for child in spec.collections:
+        _plan_collection(
+            client, child,
+            parent_id=existing_id if isinstance(existing_id, int) else None,
+            parent_path=path, p=p,
+        )
+
+    for d in spec.dashboards:
+        match = children.get(("dashboard", d.name))
+        d_path = _join(path, d.name)
+        if not match:
+            p.actions.append(Action(op="create", kind="dashboard", path=d_path))
+            continue
+        remote = client.get("/api/dashboard/{}".format(match["id"])) or match
+        diffs = _significant_dashboard_diff(d, remote)
+        p.actions.append(Action(
+            op="update" if diffs else "skip",
+            kind="dashboard", path=d_path,
+            reason=",".join(diffs),
+            existing_id=match["id"],
+        ))
+
+    for c in spec.cards:
+        match = children.get(("card", c.name))
+        c_path = _join(path, c.name)
+        if not match:
+            p.actions.append(Action(op="create", kind="card", path=c_path))
+            continue
+        remote = client.get("/api/card/{}".format(match["id"]),
+                            params={"legacy-mbql": "true"}) or match
+        diffs = _significant_card_diff(c, remote)
+        p.actions.append(Action(
+            op="update" if diffs else "skip",
+            kind="card", path=c_path,
+            reason=",".join(diffs),
+            existing_id=match["id"],
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Applier
+# ---------------------------------------------------------------------------
+
+
+def apply(client, spec: CollectionSpec, parent_id: Optional[int] = None,
+          parent_path: str = "", dry_run: bool = False) -> Plan:
+    """Apply the spec to Metabase, creating or updating items so the live state
+    matches. Returns the executed plan."""
+    p = plan(client, spec, parent_id=parent_id, parent_path=parent_path)
+    if dry_run:
+        return p
+    return _execute(client, spec, p, parent_id, parent_path)
+
+
+def _execute(client, spec: CollectionSpec, p: Plan,
+             parent_id: Optional[int], parent_path: str) -> Plan:
+    # Index actions by path for quick lookup during the recursive walk.
+    by_path = {a.path: a for a in p.actions}
+    _execute_collection(client, spec, parent_id, parent_path, by_path)
+    return p
+
+
+def _execute_collection(client, spec: CollectionSpec, parent_id: Optional[int],
+                        parent_path: str, by_path: Dict[str, Action]) -> int:
+    path = _join(parent_path or "/", spec.name)
+    action = by_path.get(path)
+    if action is None:
+        # Defensive: if the plan lost track, skip silently.
+        return 0
+
+    if action.op == "create":
+        new_id = client.create_collection(
+            collection_name=spec.name,
+            parent_collection_id=parent_id,
+            parent_collection_name="Root" if parent_id is None else None,
+            official=(spec.authority_level == "official"),
+            return_results=True,
+        )
+        collection_id = new_id["id"] if isinstance(new_id, dict) else new_id
+        if spec.description:
+            client.put("/api/collection/{}".format(collection_id),
+                       json={"description": spec.description})
+    elif action.op == "update" and action.existing_id is not None:
+        collection_id = action.existing_id
+        client.put("/api/collection/{}".format(collection_id), json=action.payload)
+    else:
+        collection_id = action.existing_id  # may be None for the synthetic Root
+
+    # Walk children
+    for child in spec.collections:
+        _execute_collection(client, child, collection_id, path, by_path)
+
+    for d in spec.dashboards:
+        d_path = _join(path, d.name)
+        d_action = by_path.get(d_path)
+        if d_action is None:
+            continue
+        if d_action.op == "create":
+            payload = {
+                "name": d.name,
+                "description": d.description,
+                "collection_id": collection_id,
+                "parameters": d.parameters or [],
+            }
+            res = client.post("/api/dashboard/", json=payload)
+            if res and d.dashcards:
+                client.put(
+                    "/api/dashboard/{}".format(res["id"]),
+                    json={"dashcards": d.dashcards, "parameters": d.parameters or []},
+                )
+        elif d_action.op == "update" and d_action.existing_id is not None:
+            client.put(
+                "/api/dashboard/{}".format(d_action.existing_id),
+                json={
+                    "description": d.description,
+                    "parameters": d.parameters or [],
+                    "dashcards": d.dashcards,
+                },
+            )
+
+    for c in spec.cards:
+        c_path = _join(path, c.name)
+        c_action = by_path.get(c_path)
+        if c_action is None:
+            continue
+        if c_action.op == "create":
+            payload = dict(c.definition)
+            payload.update({
+                "name": c.name,
+                "collection_id": collection_id,
+                "description": c.description,
+            })
+            client.create_card(custom_json=payload)
+        elif c_action.op == "update" and c_action.existing_id is not None:
+            payload = dict(c.definition)
+            payload["description"] = c.description
+            client.put("/api/card/{}".format(c_action.existing_id), json=payload)
+
+    return collection_id or 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_client(args) -> Any:
+    from .main_methods import Metabase_API
+    return Metabase_API(
+        domain=args.domain or os.environ["METABASE_DOMAIN"],
+        email=args.email or os.environ.get("METABASE_EMAIL"),
+        password=args.password or os.environ.get("METABASE_PASSWORD"),
+        session_id=args.session_id or os.environ.get("METABASE_SESSION_ID"),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="python -m spark_metabase_api.iac")
+    parser.add_argument("--domain", help="Metabase URL (or METABASE_DOMAIN)")
+    parser.add_argument("--email", help="Metabase email (or METABASE_EMAIL)")
+    parser.add_argument("--password", help="Metabase password (or METABASE_PASSWORD)")
+    parser.add_argument("--session-id", help="Metabase session id (or METABASE_SESSION_ID)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_export = sub.add_parser("export", help="Pull a collection tree to a YAML/JSON spec")
+    p_export.add_argument("collection", help="Collection id, name, or 'root'")
+    p_export.add_argument("output", help="Output path (.yaml/.yml/.json)")
+
+    p_plan = sub.add_parser("plan", help="Show what would change if the spec was applied")
+    p_plan.add_argument("spec", help="Path to the spec file")
+
+    p_apply = sub.add_parser("apply", help="Apply the spec to Metabase")
+    p_apply.add_argument("spec", help="Path to the spec file")
+    p_apply.add_argument("--yes", action="store_true",
+                         help="Skip the interactive confirmation")
+
+    args = parser.parse_args(argv)
+    client = _build_client(args)
+
+    if args.cmd == "export":
+        spec = export(client, args.collection)
+        dump(spec, args.output)
+        print("Exported to {}".format(args.output))
+        return 0
+
+    if args.cmd == "plan":
+        spec = load(args.spec)
+        the_plan = plan(client, spec)
+        print(the_plan.render())
+        return 0
+
+    if args.cmd == "apply":
+        spec = load(args.spec)
+        the_plan = plan(client, spec)
+        print(the_plan.render())
+        if any(a.op != "skip" for a in the_plan.actions):
+            if not args.yes:
+                answer = input("\nApply these changes? [y/N] ").strip().lower()
+                if answer not in ("y", "yes"):
+                    print("Aborted.")
+                    return 1
+            apply(client, spec)
+            print("\nApplied.")
+        else:
+            print("\nNothing to do.")
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -480,14 +480,20 @@ def _execute_collection(client, spec: CollectionSpec, parent_id: Optional[int],
         return 0
 
     if action.op == "create":
-        new_id = client.create_collection(
+        new = client.create_collection(
             collection_name=spec.name,
             parent_collection_id=parent_id,
             parent_collection_name="Root" if parent_id is None else None,
             official=(spec.authority_level == "official"),
             return_results=True,
         )
-        collection_id = new_id["id"] if isinstance(new_id, dict) else new_id
+        collection_id = new["id"] if isinstance(new, dict) else new
+        if not collection_id:
+            raise RuntimeError(
+                "Failed to create collection {!r} under parent {}: aborting "
+                "the apply to avoid orphaning its children at the root."
+                .format(spec.name, parent_id)
+            )
         if spec.description:
             client.put("/api/collection/{}".format(collection_id),
                        json={"description": spec.description})

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -10,6 +10,7 @@ to bind a spec entry to an existing item across a rename.
 
 Public surface:
     Spec, CollectionSpec, DashboardSpec, CardSpec
+    spec_to_dict(spec) / spec_from_dict(data) — plain-dict round-trip
     load(path) -> Spec
     dump(spec, path) -> None
     export(client, root_collection) -> CollectionSpec
@@ -98,12 +99,14 @@ Spec = CollectionSpec
 # ---------------------------------------------------------------------------
 
 
-def _spec_to_dict(spec: CollectionSpec) -> Dict[str, Any]:
+def spec_to_dict(spec: CollectionSpec) -> Dict[str, Any]:
+    """Serialize a CollectionSpec to a plain dict (round-trip with spec_from_dict)."""
     return asdict(spec)
 
 
-def _spec_from_dict(data: Dict[str, Any]) -> CollectionSpec:
-    children = [_spec_from_dict(c) for c in data.get("collections") or []]
+def spec_from_dict(data: Dict[str, Any]) -> CollectionSpec:
+    """Deserialize a CollectionSpec from a plain dict (e.g. parsed YAML/JSON)."""
+    children = [spec_from_dict(c) for c in data.get("collections") or []]
     dashboards = [
         DashboardSpec(
             name=d["name"],
@@ -147,11 +150,11 @@ def load(path: str) -> CollectionSpec:
         data = _yaml.safe_load(text)
     else:
         data = json.loads(text)
-    return _spec_from_dict(data)
+    return spec_from_dict(data)
 
 
 def dump(spec: CollectionSpec, path: str) -> None:
-    data = _spec_to_dict(spec)
+    data = spec_to_dict(spec)
     if path.endswith((".yaml", ".yml")):
         if _yaml is None:
             raise ImportError(

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -166,8 +166,10 @@ def dump(spec: CollectionSpec, path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _collection_items(client, collection_id: Union[int, str]) -> List[Dict[str, Any]]:
-    res = client.get("/api/collection/{}/items".format(collection_id))
+def _collection_items(client, collection_id: Union[int, str, None]) -> List[Dict[str, Any]]:
+    # The synthetic Root collection is addressed as 'root' by the Metabase API.
+    cid = "root" if collection_id is None or collection_id == "root" else collection_id
+    res = client.get("/api/collection/{}/items".format(cid))
     if isinstance(res, dict):  # paginated shape introduced in 0.40
         return res.get("data", [])
     return res or []
@@ -187,12 +189,20 @@ def export(client, root_collection: Union[int, str]) -> CollectionSpec:
     return _export_collection(client, root_collection)
 
 
-def _export_collection(client, collection_id: Union[int, str]) -> CollectionSpec:
-    if collection_id == "root" or collection_id is None:
-        info = {"name": "Root", "description": None, "authority_level": None,
-                "entity_id": None}
+def _export_collection(client, collection_id: Union[int, str, None]) -> CollectionSpec:
+    is_root = collection_id is None or collection_id == "root"
+    if is_root:
+        info: Dict[str, Any] = {
+            "name": "Root", "description": None,
+            "authority_level": None, "entity_id": None,
+        }
     else:
         info = client.get("/api/collection/{}".format(collection_id)) or {}
+        if not info:
+            raise RuntimeError(
+                "Failed to fetch collection {} — aborting export to avoid "
+                "silently producing an incomplete spec.".format(collection_id)
+            )
 
     spec = CollectionSpec(
         name=info.get("name") or "Root",

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -1,24 +1,30 @@
-import requests
 import getpass
+import json
+
+import requests
+
+
+DEFAULT_TIMEOUT = 30
 
 
 class Metabase_API:
     def __init__(self, domain, email=None, password=None, session_id=None, basic_auth=False, is_admin=True):
         self.domain = domain.rstrip("/")
         self.email = email
-        self.password = None
+        self.password = password
         self.session_id = session_id
         self.header = {"X-Metabase-Session": self.session_id} if self.session_id else None
         self.auth = (self.email, self.password) if basic_auth else None
         self.is_admin = is_admin
         self.session_expiry = None
+        self._http = requests.Session()
 
         # Check if either email/password or a session ID is provided
-        if not (self.email and password) and not self.session_id:
-            raise ValueError("You must provide either email/password or a valid session ID.")
-
-        if password:
-            self.password = getpass.getpass(prompt="Please enter your password: ") if password is None else password
+        if not (self.email and self.password) and not self.session_id:
+            if self.email and not self.password:
+                self.password = getpass.getpass(prompt="Please enter your password: ")
+            else:
+                raise ValueError("You must provide either email/password or a valid session ID.")
 
         if not self.is_admin:
             print(
@@ -27,15 +33,23 @@ class Metabase_API:
                 Without this some of the functions of the current package may not work as expected.
                 """
             )
-        
+
         # Validate session ID or authenticate
         if not self.session_id or not self.is_session_valid():
             self.authenticate()
 
     def is_session_valid(self):
         """Check if the session ID is valid"""
-        test_endpoint = "/api/user/current"
-        response = requests.get(self.domain + test_endpoint, headers=self.header)
+        if not self.header:
+            return False
+        try:
+            response = self._http.get(
+                self.domain + "/api/user/current",
+                headers=self.header,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except requests.RequestException:
+            return False
         return response.status_code == 200
 
     def authenticate(self):
@@ -44,7 +58,12 @@ class Metabase_API:
             raise ValueError("Email and password are required for authentication.")
 
         conn_header = {"username": self.email, "password": self.password}
-        res = requests.post(self.domain + "/api/session", json=conn_header, auth=self.auth)
+        res = self._http.post(
+            self.domain + "/api/session",
+            json=conn_header,
+            auth=self.auth,
+            timeout=DEFAULT_TIMEOUT,
+        )
 
         if not res.ok:
             raise Exception(f"Authentication failed: {res.text}")
@@ -57,17 +76,11 @@ class Metabase_API:
 
 
     def validate_session(self):
-        """Get a new session ID if the previous one has expired"""
-        res = requests.get(
-            self.domain + "/api/user/current", headers=self.header, auth=self.auth
-        )
-
-        if res.ok:  # 200
+        """Re-authenticate if the current session has expired."""
+        if self.is_session_valid():
             return True
-        elif res.status_code == 401:  # unauthorized
-            return self.authenticate()
-        else:
-            raise Exception(res)
+        self.authenticate()
+        return True
 
     # import REST Methods
     from ._rest_methods import get, post, put, delete
@@ -160,9 +173,7 @@ class Metabase_API:
             )
 
         # add the filter values (if any)
-        import json
-
-        params_json = {"parameters": json.dumps(parameters)}
+        params_json = {"parameters": json.dumps(parameters or [])}
 
         # get the results
         res = self.post(
@@ -221,13 +232,19 @@ class Metabase_API:
                     "Either the name or id of the target table needs to be provided."
                 )
             else:
-                source_table_id = self.get_item_id("table", source_table_name)
+                target_table_id = self.get_item_id("table", target_table_name)
 
         if ignore_these_filters:
             assert type(ignore_these_filters) == list
 
-        # get the card info
-        card_info = self.get_item_info("card", card_id)
+        # Fetch the card info. Force MBQL 4 on Metabase 0.57+ so we keep the
+        # 'field-id'/'field' shapes this method understands.
+        card_info = self.get(
+            "/api/card/{}".format(card_id),
+            params={"legacy-mbql": "true"},
+        )
+        if not card_info:
+            raise ValueError('There is no card with the id "{}"'.format(card_id))
         # get the mappings, both name -> id and id -> name
         target_table_col_name_id_mapping = self.get_columns_name_id(
             table_id=target_table_id
@@ -268,25 +285,26 @@ class Metabase_API:
             # change the underlying table for the card
             query_data["source-table"] = target_table_id
 
-            # transform to string so it is easier to replace the column IDs
-            query_data_str = str(query_data)
+            # walk the MBQL tree and remap column ids in-place; safer than
+            # round-tripping through repr/eval which breaks on quotes/unicode.
+            def _remap_field_ids(node):
+                if isinstance(node, list):
+                    if (
+                        len(node) >= 2
+                        and node[0] in ("field", "field-id")
+                        and isinstance(node[1], int)
+                    ):
+                        col_name = source_table_col_id_name_mapping.get(node[1])
+                        if col_name in target_table_col_name_id_mapping:
+                            node[1] = target_table_col_name_id_mapping[col_name]
+                    for item in node:
+                        _remap_field_ids(item)
+                elif isinstance(node, dict):
+                    for value in node.values():
+                        _remap_field_ids(value)
 
-            # find column IDs
-            import re
-
-            res = re.findall(r"\['field', .*?\]", query_data_str)
-            source_column_IDs = [eval(i)[1] for i in res]
-
-            # replace column IDs from old table with the column IDs from new table
-            for source_col_id in source_column_IDs:
-                source_col_name = source_table_col_id_name_mapping[source_col_id]
-                target_col_id = target_table_col_name_id_mapping[source_col_name]
-                query_data_str = query_data_str.replace(
-                    "['field', {}, ".format(source_col_id),
-                    "['field', {}, ".format(target_col_id),
-                )
-
-            card_info["dataset_query"]["query"] = eval(query_data_str)
+            _remap_field_ids(query_data)
+            card_info["dataset_query"]["query"] = query_data
 
         new_card_json = {}
         for key in ["dataset_query", "display", "visualization_settings"]:
@@ -387,20 +405,50 @@ class Metabase_API:
         return self.delete("/api/{}/{}".format(item_type, item_id))
 
     def add_card_to_dashboard(self, card_id, dashboard_id):
-        params = {"cardId": card_id}
-        self.post(f"/api/dashboard/{dashboard_id}/cards", json=params)
+        """
+        Append a card to a dashboard.
+
+        Uses the modern endpoint (PUT /api/dashboard/:id with the full dashcards
+        payload) and falls back to the legacy POST /api/dashboard/:id/cards on
+        older Metabase versions.
+        """
+        legacy_res = self.post(
+            "/api/dashboard/{}/cards".format(dashboard_id),
+            "raw",
+            json={"cardId": card_id},
+        )
+        if legacy_res.ok:
+            return legacy_res.json() if legacy_res.content else None
+
+        # Modern path: rewrite the full dashcards array. Append the new card at
+        # the bottom of the dashboard, full width.
+        dashboard = self.get("/api/dashboard/{}".format(dashboard_id))
+        dashcards = list(dashboard.get("dashcards") or dashboard.get("ordered_cards") or [])
+
+        max_row = max((dc.get("row", 0) + dc.get("size_y", 0) for dc in dashcards), default=0)
+        new_dashcard = {
+            "id": -1,  # negative id signals creation to Metabase
+            "card_id": card_id,
+            "row": max_row,
+            "col": 0,
+            "size_x": 24,
+            "size_y": 8,
+            "parameter_mappings": [],
+            "visualization_settings": {},
+        }
+        dashcards.append(new_dashcard)
+        return self.put(
+            "/api/dashboard/{}".format(dashboard_id),
+            json={"dashcards": dashcards},
+        )
 
     @staticmethod
     def make_json(raw_json, prettyprint=False):
         """Turn the string copied from the Inspect->Network window into a Dict."""
-        import json
-
         ret_dict = json.loads(raw_json)
         if prettyprint:
             import pprint
-
             pprint.pprint(ret_dict)
-
         return ret_dict
 
     def rescan_object_values(

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -245,6 +245,16 @@ class Metabase_API:
         )
         if not card_info:
             raise ValueError('There is no card with the id "{}"'.format(card_id))
+
+        dataset_query = card_info.get("dataset_query") or {}
+        query_type = dataset_query.get("type")
+        if query_type not in ("native", "query"):
+            raise ValueError(
+                "Card {} has no usable dataset_query (type={!r}); "
+                "clone_card only supports native and MBQL queries."
+                .format(card_id, query_type)
+            )
+
         # get the mappings, both name -> id and id -> name
         target_table_col_name_id_mapping = self.get_columns_name_id(
             table_id=target_table_id
@@ -254,7 +264,7 @@ class Metabase_API:
         )
 
         # native questions
-        if card_info["dataset_query"]["type"] == "native":
+        if query_type == "native":
             filters_data = card_info["dataset_query"]["native"]["template-tags"]
             # change the underlying table for the card
             if not source_table_name:
@@ -279,7 +289,7 @@ class Metabase_API:
                 ]["dimension"][1] = target_col_id
 
         # simple/custom questions
-        elif card_info["dataset_query"]["type"] == "query":
+        elif query_type == "query":
             query_data = card_info["dataset_query"]["query"]
 
             # change the underlying table for the card

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -433,6 +433,12 @@ class Metabase_API:
         # Modern path: rewrite the full dashcards array. Append the new card at
         # the bottom of the dashboard, full width.
         dashboard = self.get("/api/dashboard/{}".format(dashboard_id))
+        if not dashboard:
+            raise ValueError(
+                "Could not load dashboard {} (legacy POST returned {} and the "
+                "GET to fall back to PUT also failed)."
+                .format(dashboard_id, legacy_res.status_code)
+            )
         dashcards = list(dashboard.get("dashcards") or dashboard.get("ordered_cards") or [])
 
         max_row = max((dc.get("row", 0) + dc.get("size_y", 0) for dc in dashcards), default=0)

--- a/spark_metabase_api/modify_methods.py
+++ b/spark_metabase_api/modify_methods.py
@@ -20,7 +20,7 @@ def restrict_collection_access(
     # Making sure we have the data we need
     if not collection_id:
         if not collection_name:
-            print("Either the name of id of the collection must be provided.")
+            raise ValueError("Either the name or id of the collection must be provided.")
         if collection_name == "Root":
             collection_id = None
         else:
@@ -28,21 +28,22 @@ def restrict_collection_access(
                 "collection", collection_name
             )
 
-    # Enable access only to the Administrators group
+    # Enforce 'none' for every group that isn't in the authorized list.
+    # Since Metabase 0.56.13 the graph no longer carries explicit 'none' entries
+    # so we must always set the key (instead of only updating an existing one).
     collections_graph = self.get('/api/collection/graph')
+    target_key = str(collection_id)
     for group in collections_graph["groups"]:
-        # Check if the group is not in the list of enabled groups
-        if int(group) not in authorized_group_ids: # Convert group to integer for comparison
-            for collection in collections_graph["groups"][group].keys():
-                if collection == str(collection_id):
-                    collections_graph["groups"][group][collection] = 'none' # Remove access
+        if int(group) in authorized_group_ids:
+            continue
+        collections_graph["groups"][group][target_key] = 'none'
 
     self.verbose_print(verbose, 'Restrict access to the collection "{}" ...'.format(collection_id))
     res = self.put('/api/collection/graph', json=collections_graph)
     
 
 def restrict_filter_with_card_values(
-        self, 
+        self,
         item_type,
         item_id,
         filter_name,
@@ -50,34 +51,45 @@ def restrict_filter_with_card_values(
         card_column_name,
         new_filter_name=None,
         remove_default=False,
+        column_base_type="type/Text",
+        preserve_column_case=False,
         verbose=False
 ):
     """
-    Redirect dashboard/question filter dropdown list to "from another model or question"
+    Redirect dashboard/question filter dropdown list to "from another model or question".
     This function assumes the filter is a field filter.
-    
+
     Keyword arguments:
-    item_type -- 'question' or 'dashboard' 
+    item_type -- 'question' or 'dashboard'
     item_id -- ID of the Metabase element
     filter_name -- Name of the filter as it appears on Metabase
     card_id -- ID of the card from which the dropdown list will be sourced
-    card_column_name -- The name of the column where to find the values in the "source" card
+    card_column_name -- The name of the column where to find the values in the "source" card.
     new_filter_name -- (Optional) give a new name to the filter
-    remov_default -- (Optionnal) remove the default values of the filter
+    remove_default -- (Optional) remove the default values of the filter
+    column_base_type -- (Optional) Metabase base-type of the source column (default 'type/Text').
+                        Use 'type/Integer', 'type/Float', 'type/Date', etc. for non-text columns.
+    preserve_column_case -- (Optional, default False) by default the column name is upper-cased
+                            (Snowflake-friendly). Set True for case-sensitive databases such as
+                            Postgres/MySQL where identifiers are typically lowercased.
     verbose -- prints extra information (default False)
     """
-        
+
+    if item_type not in ('question', 'card', 'dashboard'):
+        raise ValueError("item_type must be 'question', 'card' or 'dashboard'.")
+
     clean_filter_name = filter_name.lower().strip()
-    clean_card_column_name = card_column_name.upper().strip()
+    clean_card_column_name = (
+        card_column_name.strip() if preserve_column_case else card_column_name.upper().strip()
+    )
 
     if item_type == 'question':
         item_type = 'card'  # avoid this easy mistake
-    
-    # Add security layer to make sure item_type is dashboard or card only
+
     item = self.get('/api/{}/{}'.format(item_type, item_id))
 
     filter_found = False
-    
+
     for param in item["parameters"]:
         clean_param_name = param["name"].lower().strip()
         if clean_filter_name in clean_param_name:
@@ -92,12 +104,10 @@ def restrict_filter_with_card_values(
                 "value_field": [
                     "field",
                     clean_card_column_name,
-                    {
-                        "base-type": "type/Text"
-                    }
-                ]
+                    {"base-type": column_base_type},
+                ],
             }
-    
+
     if not filter_found and verbose:
         self.verbose_print(verbose, 'No filter found with the name "{}".'.format(filter_name))
     else:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -16,9 +16,14 @@ from __future__ import annotations
 import json
 import os
 import traceback
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Tuple
 
 import streamlit as st
+
+try:  # anthropic is provided by the [streamlit] extra; fail clearly if missing
+    import anthropic
+except ImportError:  # pragma: no cover
+    anthropic = None  # type: ignore
 
 from spark_metabase_api import Metabase_API, chatbot, iac
 
@@ -45,13 +50,12 @@ st.caption(
 
 def _init_state() -> None:
     defaults: Dict[str, Any] = {
-        "metabase": None,            # connected Metabase_API instance
-        "history": [],               # list of (role, content) — chat transcript
-        "current_events": [],        # events from the latest agent run
-        "proposed_spec": None,       # CollectionSpec produced by Claude
-        "plan": None,                # iac.Plan computed from the spec
-        "applied": False,            # whether the spec was applied
-        "error": None,
+        "metabase": None,         # connected Metabase_API instance
+        "anthropic_client": None, # configured anthropic.Anthropic (per session)
+        "history": [],            # list of (role, content) — chat transcript
+        "proposed_spec": None,    # CollectionSpec produced by Claude
+        "plan": None,             # iac.Plan computed from the spec
+        "applied": False,         # whether the spec was applied
     }
     for k, v in defaults.items():
         st.session_state.setdefault(k, v)
@@ -104,14 +108,25 @@ with st.sidebar:
 
     st.divider()
     st.header("Anthropic")
+    if anthropic is None:
+        st.error(
+            "The `anthropic` package is not installed. "
+            "Run: pip install \"spark-metabase-api[streamlit]\""
+        )
     api_key = st.text_input(
         "API key",
         type="password",
         value=os.environ.get("ANTHROPIC_API_KEY", ""),
-        help="Stored only in this session; not written to disk.",
+        help="Stored only in this session's memory; never written to disk "
+             "or to the process environment.",
     )
-    if api_key:
-        os.environ["ANTHROPIC_API_KEY"] = api_key
+    if api_key and anthropic is not None:
+        # Build a dedicated client for this session — do NOT touch os.environ
+        # (the Streamlit process is shared across user sessions in any
+        # multi-user deployment, so a global env var leaks across them).
+        st.session_state.anthropic_client = anthropic.Anthropic(api_key=api_key)
+    elif not api_key:
+        st.session_state.anthropic_client = None
 
     model = st.selectbox(
         "Model",
@@ -122,10 +137,10 @@ with st.sidebar:
 
     st.divider()
     if st.button("Reset conversation", use_container_width=True):
-        for key in ("history", "current_events", "proposed_spec", "plan", "applied", "error"):
-            st.session_state[key] = [] if key in ("history", "current_events") else (
-                False if key == "applied" else None
-            )
+        st.session_state.history = []
+        st.session_state.proposed_spec = None
+        st.session_state.plan = None
+        st.session_state.applied = False
         st.rerun()
 
 
@@ -166,9 +181,9 @@ def _spec_to_yaml_or_json(spec: iac.CollectionSpec) -> str:
     try:
         import yaml  # type: ignore
 
-        return yaml.safe_dump(iac._spec_to_dict(spec), sort_keys=False, allow_unicode=True)
+        return yaml.safe_dump(iac.spec_to_dict(spec), sort_keys=False, allow_unicode=True)
     except ImportError:
-        return json.dumps(iac._spec_to_dict(spec), indent=2, ensure_ascii=False)
+        return json.dumps(iac.spec_to_dict(spec), indent=2, ensure_ascii=False)
 
 
 # ---------------------------------------------------------------------------
@@ -196,7 +211,7 @@ if prompt:
     if st.session_state.metabase is None:
         st.error("Connect to Metabase first (sidebar).")
         st.stop()
-    if not os.environ.get("ANTHROPIC_API_KEY"):
+    if st.session_state.anthropic_client is None:
         st.error("Provide your Anthropic API key (sidebar).")
         st.stop()
 
@@ -204,16 +219,19 @@ if prompt:
     with st.chat_message("user"):
         st.markdown(prompt)
 
-    rendered_events: List[tuple] = []
+    rendered_events: List[Tuple[str, Any]] = []
     with st.chat_message("assistant"):
         try:
             for ev_type, payload in chatbot.stream(
-                st.session_state.metabase, prompt, model=model,
+                st.session_state.metabase,
+                prompt,
+                model=model,
+                anthropic_client=st.session_state.anthropic_client,
             ):
                 rendered_events.append((ev_type, payload))
                 _render_event(ev_type, payload)
                 if ev_type == "proposed":
-                    st.session_state.proposed_spec = iac._spec_from_dict(payload)
+                    st.session_state.proposed_spec = iac.spec_from_dict(payload)
         except Exception as exc:  # pragma: no cover - UI feedback
             st.error("Agent crashed: {}".format(exc))
             with st.expander("Traceback"):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,267 @@
+"""Streamlit frontend for the spark-metabase-api chatbot.
+
+Launch with:
+    pip install "spark-metabase-api[chatbot,streamlit,iac]"
+    streamlit run streamlit_app.py
+
+Workflow:
+    1. Configure Metabase + Anthropic credentials in the sidebar.
+    2. Type a natural-language brief in the chat box.
+    3. Watch Claude inspect the live Metabase metadata and emit a spec.
+    4. Review the proposed spec and the diff (iac.plan).
+    5. Click Apply to write the spec to Metabase.
+"""
+from __future__ import annotations
+
+import json
+import os
+import traceback
+from typing import Any, Dict, List, Optional
+
+import streamlit as st
+
+from spark_metabase_api import Metabase_API, chatbot, iac
+
+
+# ---------------------------------------------------------------------------
+# Page setup
+# ---------------------------------------------------------------------------
+
+st.set_page_config(
+    page_title="Metabase dashboard authoring",
+    page_icon=":chart_with_upwards_trend:",
+    layout="wide",
+)
+st.title("Metabase dashboard authoring")
+st.caption(
+    "Describe the dashboard you want; Claude inspects your Metabase, "
+    "proposes a spec, you review and apply."
+)
+
+
+# ---------------------------------------------------------------------------
+# Session state
+# ---------------------------------------------------------------------------
+
+def _init_state() -> None:
+    defaults: Dict[str, Any] = {
+        "metabase": None,            # connected Metabase_API instance
+        "history": [],               # list of (role, content) — chat transcript
+        "current_events": [],        # events from the latest agent run
+        "proposed_spec": None,       # CollectionSpec produced by Claude
+        "plan": None,                # iac.Plan computed from the spec
+        "applied": False,            # whether the spec was applied
+        "error": None,
+    }
+    for k, v in defaults.items():
+        st.session_state.setdefault(k, v)
+
+
+_init_state()
+
+
+# ---------------------------------------------------------------------------
+# Sidebar — credentials and connection
+# ---------------------------------------------------------------------------
+
+with st.sidebar:
+    st.header("Metabase")
+    domain = st.text_input(
+        "Metabase URL",
+        value=os.environ.get("METABASE_DOMAIN", ""),
+        placeholder="https://metabase.example.com",
+    )
+    auth_mode = st.radio(
+        "Auth mode",
+        options=["Email + password", "Session id"],
+        horizontal=True,
+    )
+    email = password = session_id = None
+    if auth_mode == "Email + password":
+        email = st.text_input(
+            "Email", value=os.environ.get("METABASE_EMAIL", "")
+        )
+        password = st.text_input(
+            "Password", type="password", value=os.environ.get("METABASE_PASSWORD", "")
+        )
+    else:
+        session_id = st.text_input(
+            "Session id", value=os.environ.get("METABASE_SESSION_ID", "")
+        )
+
+    if st.button("Connect to Metabase", use_container_width=True):
+        try:
+            st.session_state.metabase = Metabase_API(
+                domain=domain,
+                email=email or None,
+                password=password or None,
+                session_id=session_id or None,
+            )
+            st.success("Connected.")
+        except Exception as exc:  # pragma: no cover - UI feedback
+            st.session_state.metabase = None
+            st.error("Connection failed: {}".format(exc))
+
+    st.divider()
+    st.header("Anthropic")
+    api_key = st.text_input(
+        "API key",
+        type="password",
+        value=os.environ.get("ANTHROPIC_API_KEY", ""),
+        help="Stored only in this session; not written to disk.",
+    )
+    if api_key:
+        os.environ["ANTHROPIC_API_KEY"] = api_key
+
+    model = st.selectbox(
+        "Model",
+        options=["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
+        index=0,
+        help="Opus 4.7 is the default; Sonnet 4.6 is cheaper for simpler briefs.",
+    )
+
+    st.divider()
+    if st.button("Reset conversation", use_container_width=True):
+        for key in ("history", "current_events", "proposed_spec", "plan", "applied", "error"):
+            st.session_state[key] = [] if key in ("history", "current_events") else (
+                False if key == "applied" else None
+            )
+        st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _format_args(input_dict: Dict[str, Any]) -> str:
+    parts = []
+    for k, v in input_dict.items():
+        rendered = json.dumps(v, ensure_ascii=False)
+        if len(rendered) > 80:
+            rendered = rendered[:77] + "..."
+        parts.append("{}={}".format(k, rendered))
+    return ", ".join(parts)
+
+
+def _render_event(event_type: str, payload: Any) -> None:
+    """Render a single chat event in the assistant's bubble."""
+    if event_type == "text":
+        st.markdown(payload)
+    elif event_type == "tool_call":
+        st.markdown(
+            ":wrench: **{}**({})".format(payload["name"], _format_args(payload["input"]))
+        )
+    elif event_type == "tool_result":
+        with st.expander(":receipt: {} returned".format(payload["name"]), expanded=False):
+            try:
+                parsed = json.loads(payload["result"])
+                st.json(parsed)
+            except (TypeError, ValueError):
+                st.code(payload["result"])
+    elif event_type == "proposed":
+        st.success(":white_check_mark: Spec proposed.")
+
+
+def _spec_to_yaml_or_json(spec: iac.CollectionSpec) -> str:
+    try:
+        import yaml  # type: ignore
+
+        return yaml.safe_dump(iac._spec_to_dict(spec), sort_keys=False, allow_unicode=True)
+    except ImportError:
+        return json.dumps(iac._spec_to_dict(spec), indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Replay the conversation
+# ---------------------------------------------------------------------------
+
+for role, blocks in st.session_state.history:
+    with st.chat_message(role):
+        if role == "user":
+            st.markdown(blocks)
+        else:
+            for ev_type, payload in blocks:
+                _render_event(ev_type, payload)
+
+
+# ---------------------------------------------------------------------------
+# Live agent run (only fires when user submits a new prompt)
+# ---------------------------------------------------------------------------
+
+prompt = st.chat_input(
+    "Describe the dashboard to build (e.g. 'Acme overview with monthly revenue and top accounts')"
+)
+
+if prompt:
+    if st.session_state.metabase is None:
+        st.error("Connect to Metabase first (sidebar).")
+        st.stop()
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        st.error("Provide your Anthropic API key (sidebar).")
+        st.stop()
+
+    st.session_state.history.append(("user", prompt))
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    rendered_events: List[tuple] = []
+    with st.chat_message("assistant"):
+        try:
+            for ev_type, payload in chatbot.stream(
+                st.session_state.metabase, prompt, model=model,
+            ):
+                rendered_events.append((ev_type, payload))
+                _render_event(ev_type, payload)
+                if ev_type == "proposed":
+                    st.session_state.proposed_spec = iac._spec_from_dict(payload)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            st.error("Agent crashed: {}".format(exc))
+            with st.expander("Traceback"):
+                st.code(traceback.format_exc())
+
+    st.session_state.history.append(("assistant", rendered_events))
+    # Reset plan / apply state so the new spec gets a fresh review.
+    st.session_state.plan = None
+    st.session_state.applied = False
+
+
+# ---------------------------------------------------------------------------
+# Review & apply
+# ---------------------------------------------------------------------------
+
+spec = st.session_state.proposed_spec
+if spec is not None:
+    st.divider()
+    st.subheader("Proposed spec")
+    st.code(_spec_to_yaml_or_json(spec), language="yaml")
+
+    col_plan, col_apply = st.columns(2)
+
+    with col_plan:
+        if st.button("Compute plan", use_container_width=True):
+            try:
+                st.session_state.plan = iac.plan(st.session_state.metabase, spec)
+            except Exception as exc:  # pragma: no cover - UI feedback
+                st.error("plan() failed: {}".format(exc))
+                with st.expander("Traceback"):
+                    st.code(traceback.format_exc())
+
+    if st.session_state.plan is not None:
+        st.subheader("Plan")
+        st.code(st.session_state.plan.render(), language="text")
+
+    with col_apply:
+        disabled = (
+            st.session_state.plan is None
+            or all(a.op == "skip" for a in st.session_state.plan.actions)
+            or st.session_state.applied
+        )
+        if st.button("Apply", type="primary", use_container_width=True, disabled=disabled):
+            try:
+                iac.apply(st.session_state.metabase, spec)
+                st.session_state.applied = True
+                st.success("Applied. Re-run plan to confirm idempotency.")
+            except Exception as exc:  # pragma: no cover - UI feedback
+                st.error("apply() failed: {}".format(exc))
+                with st.expander("Traceback"):
+                    st.code(traceback.format_exc())

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Integration tests for spark-metabase-api against a live Metabase instance.
+
+The script runs in 4 phases, each with a clear safety boundary:
+
+    Phase 1  read-only checks   (auth, search, iac.export idempotency)
+    Phase 2  sandbox writes     (creates a throwaway collection, applies a
+                                 mini-spec, exercises add_card_to_dashboard
+                                 and copy_dashboard's deepcopy path)
+    Phase 3  optional chatbot   (Claude proposes a spec — NOT applied)
+    Phase 4  cleanup            (archive the sandbox; runs even on failure)
+
+The sandbox is archived in a finally block so a crash mid-test doesn't leave
+junk behind. Pass --keep-sandbox to keep it around for manual inspection.
+
+Usage:
+    python tests/integration_test.py \\
+        --domain https://metabase.example.com \\
+        --email me@example.com \\
+        --password '...'
+
+    # Or with a session id:
+    python tests/integration_test.py \\
+        --domain https://metabase.example.com \\
+        --session-id <session>
+
+    # Phase 1 also runs the iac round-trip on a real collection if you pass
+    # one (read-only — never modified):
+    python tests/integration_test.py ... --collection "My Reports"
+
+    # copy_dashboard is exercised if you pass an existing dashboard id (the
+    # original is read-only; a deep copy is made inside the sandbox):
+    python tests/integration_test.py ... --source-dashboard-id 42
+
+    # Opt in to the chatbot phase (requires ANTHROPIC_API_KEY in env):
+    python tests/integration_test.py ... --chatbot
+
+Exit code is 0 on success, 1 on any failed assertion.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+# Allow running straight from a checkout (`python tests/integration_test.py`)
+# without `pip install -e .` first.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from spark_metabase_api import Metabase_API, iac  # noqa: E402
+
+
+SANDBOX_NAME_PREFIX = "spark-metabase-api integration test"
+
+
+# ---------------------------------------------------------------------------
+# Status output
+# ---------------------------------------------------------------------------
+
+def _step(label: str) -> None:
+    print("\n=== {} ===".format(label))
+
+
+def _ok(msg: str) -> None:
+    print("  [ok]   {}".format(msg))
+
+
+def _skip(msg: str) -> None:
+    print("  [skip] {}".format(msg))
+
+
+def _fail(msg: str) -> None:
+    print("  [FAIL] {}".format(msg))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_parent_id(mb: Metabase_API, collection_ref: Any) -> Optional[int]:
+    """Return the parent collection id of `collection_ref`, or None for Root.
+
+    iac.plan/apply need to know where the spec lives so they diff against the
+    right sibling set. Metabase returns the parent path on a collection as
+    `location`: "/" for Root, "/5/" for a child of #5, "/5/10/" for a
+    grandchild.
+    """
+    if collection_ref in (None, "root", "Root"):
+        return None
+    if isinstance(collection_ref, int) or (
+        isinstance(collection_ref, str) and collection_ref.isdigit()
+    ):
+        cid = int(collection_ref)
+    else:
+        cid = mb.get_item_id("collection", collection_ref)
+    info = mb.get("/api/collection/{}".format(cid)) or {}
+    location = info.get("location") or "/"
+    parts = [p for p in location.strip("/").split("/") if p]
+    return int(parts[-1]) if parts else None
+
+
+def _pick_first_db(mb: Metabase_API) -> int:
+    res = mb.get("/api/database/")
+    dbs = res.get("data", res) if isinstance(res, dict) else res
+    if not dbs:
+        raise RuntimeError("No databases configured on this Metabase instance.")
+    return dbs[0]["id"]
+
+
+def _find_child(
+    mb: Metabase_API, collection_id: int, kind: str, name: str,
+) -> int:
+    res = mb.get("/api/collection/{}/items".format(collection_id))
+    items = res.get("data", res) if isinstance(res, dict) else res
+    for item in items or []:
+        if item.get("model") == kind and item.get("name") == name:
+            return item["id"]
+    raise LookupError(
+        "no {} named {!r} in collection {}".format(kind, name, collection_id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — read-only
+# ---------------------------------------------------------------------------
+
+def phase1_readonly(mb: Metabase_API, sample_collection: Optional[str]) -> None:
+    _step("Phase 1: read-only checks")
+
+    info = mb.get("/api/user/current")
+    assert info and info.get("email"), "auth check returned empty"
+    _ok("authenticated as {}".format(info["email"]))
+
+    results = mb.search("a", item_type=None)
+    assert isinstance(results, list), "search did not return a list"
+    _ok("search('a') returned {} items".format(len(results)))
+
+    dashboards = [r for r in results if r.get("model") == "dashboard"]
+    if dashboards:
+        dash_id = dashboards[0]["id"]
+        cards = mb.get_dashboard_question_ids(dashboard_id=dash_id)
+        _ok("get_dashboard_question_ids({}) -> {} cards".format(dash_id, len(cards)))
+    else:
+        _skip("get_dashboard_question_ids: no dashboard surfaced by search")
+
+    if sample_collection is None:
+        _skip("iac.export idempotency: no --collection passed")
+        return
+
+    print("  ... exporting {!r} (may take a while for large collections)"
+          .format(sample_collection))
+    spec = iac.export(mb, sample_collection)
+    parent_id = _resolve_parent_id(mb, sample_collection)
+    p = iac.plan(mb, spec, parent_id=parent_id)
+    if all(a.op == "skip" for a in p.actions):
+        _ok("iac.export({!r}) -> {} items, plan all-skip (idempotent)"
+            .format(sample_collection, len(p.actions)))
+    else:
+        non_skip = [(a.op, a.path, a.reason) for a in p.actions if a.op != "skip"]
+        raise AssertionError(
+            "iac.plan on freshly exported spec is NOT idempotent. "
+            "Non-skip actions: {}".format(non_skip)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — sandbox writes
+# ---------------------------------------------------------------------------
+
+def phase2_sandbox(
+    mb: Metabase_API, source_dashboard_id: Optional[int],
+) -> int:
+    _step("Phase 2: sandbox writes")
+    sandbox_name = "{} ({})".format(SANDBOX_NAME_PREFIX, int(time.time()))
+
+    # 1. create_collection — covers the color-retry fix.
+    res = mb.create_collection(
+        sandbox_name, parent_collection_name="Root", return_results=True,
+    )
+    assert isinstance(res, dict) and res.get("id"), \
+        "create_collection returned {!r}".format(res)
+    sandbox_id = res["id"]
+    _ok("created sandbox collection #{} {!r}".format(sandbox_id, sandbox_name))
+
+    # 2. iac.apply with a card + a dashboard that forward-references the card
+    #    by name — covers card_name resolution, executor reorder, and the
+    #    end-to-end create path.
+    db_id = _pick_first_db(mb)
+    spec = iac.CollectionSpec(
+        name=sandbox_name,                      # match the live sandbox
+        cards=[iac.CardSpec(
+            name="Test card",
+            definition={
+                "dataset_query": {
+                    "type": "native",
+                    "database": db_id,
+                    "native": {"query": "SELECT 1 AS one"},
+                },
+                "display": "scalar",
+                "visualization_settings": {},
+            },
+        )],
+        dashboards=[iac.DashboardSpec(
+            name="Test dashboard",
+            parameters=[],
+            dashcards=[{
+                "id": -1,
+                "card_name": "Test card",       # forward reference
+                "row": 0, "col": 0, "size_x": 24, "size_y": 8,
+                "parameter_mappings": [],
+                "visualization_settings": {},
+            }],
+        )],
+    )
+    parent_id = None  # sandbox lives at Root
+    p = iac.apply(mb, spec, parent_id=parent_id)
+    assert any(a.op == "create" for a in p.actions), \
+        "expected creates in fresh apply, got: {}".format(p.summary())
+    _ok("iac.apply -> {}".format(p.summary()))
+
+    # 3. Re-plan must be all-skip (idempotency on a live instance — covers
+    #    the dashcard card_name resolution at plan time).
+    p2 = iac.plan(mb, spec, parent_id=parent_id)
+    if not all(a.op == "skip" for a in p2.actions):
+        raise AssertionError(
+            "iac.plan after apply is NOT idempotent:\n{}".format(p2.render())
+        )
+    _ok("re-plan: all-skip (idempotent on live)")
+
+    # 4. add_card_to_dashboard — exercises the legacy POST or the modern PUT
+    #    fallback, depending on the Metabase version. We append a SECOND
+    #    dashcard pointing at the same card.
+    test_dash_id = _find_child(mb, sandbox_id, "dashboard", "Test dashboard")
+    test_card_id = _find_child(mb, sandbox_id, "card", "Test card")
+    mb.add_card_to_dashboard(card_id=test_card_id, dashboard_id=test_dash_id)
+    refreshed = mb.get("/api/dashboard/{}".format(test_dash_id)) or {}
+    dashcards = refreshed.get("dashcards") or refreshed.get("ordered_cards") or []
+    assert len(dashcards) >= 2, (
+        "add_card_to_dashboard didn't append a card; "
+        "dashcards={}".format(len(dashcards))
+    )
+    _ok("add_card_to_dashboard appended a card; dashboard now has {} dashcards"
+        .format(len(dashcards)))
+
+    # 5. (optional) copy_dashboard with deepcopy — covers the rstrip → suffix
+    #    fix. The source dashboard is read-only.
+    if source_dashboard_id is not None:
+        copied_id, q_coll_id, q_ids = mb.copy_dashboard(
+            source_dashboard_id=source_dashboard_id,
+            destination_collection_id=sandbox_id,
+            destination_dashboard_name="Copied dashboard",
+            deepcopy=True,
+        )
+        _ok("copy_dashboard deepcopy: dashboard #{} + {} questions in "
+            "collection #{}".format(copied_id, len(q_ids or []), q_coll_id))
+    else:
+        _skip("copy_dashboard deepcopy: no --source-dashboard-id passed")
+
+    return sandbox_id
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — optional chatbot
+# ---------------------------------------------------------------------------
+
+def phase3_chatbot(mb: Metabase_API) -> None:
+    _step("Phase 3: chatbot end-to-end (read-only)")
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        _skip("ANTHROPIC_API_KEY is not set")
+        return
+    try:
+        from spark_metabase_api.chatbot import chat
+    except ImportError:
+        _skip("anthropic not installed (pip install spark-metabase-api[chatbot])")
+        return
+
+    print("  ... running the agent (~30-90s, ~$0.50 in API tokens)")
+    spec = chat(
+        mb,
+        "Build the smallest possible test spec: one collection named "
+        "'chatbot smoke test', containing a single card whose native SQL "
+        "query is exactly 'SELECT 1 AS one'. Pick database id 1 if it "
+        "exists, otherwise the first database returned by list_databases. "
+        "Do NOT explore tables — keep the query as 'SELECT 1 AS one'.",
+        verbose=False,
+    )
+    assert spec.name, "chatbot returned a spec with no name"
+    assert spec.cards or spec.dashboards, "chatbot returned an empty spec"
+    _ok("chatbot proposed: {!r} ({} cards, {} dashboards) — NOT applied"
+        .format(spec.name, len(spec.cards), len(spec.dashboards)))
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — cleanup
+# ---------------------------------------------------------------------------
+
+def cleanup(mb: Metabase_API, sandbox_id: int, keep: bool) -> None:
+    _step("Phase 4: cleanup")
+    if keep:
+        _skip("--keep-sandbox set; sandbox #{} left behind".format(sandbox_id))
+        return
+    try:
+        mb.move_to_archive("collection", item_id=sandbox_id)
+        _ok("sandbox collection #{} archived".format(sandbox_id))
+    except Exception as exc:
+        _fail("could not archive sandbox #{}: {}. Archive it manually."
+              .format(sandbox_id, exc))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--domain", required=True, help="Metabase URL")
+    parser.add_argument("--email", help="Metabase email (or METABASE_EMAIL)")
+    parser.add_argument("--password", help="Metabase password (or METABASE_PASSWORD)")
+    parser.add_argument("--session-id", help="Session id (or METABASE_SESSION_ID)")
+    parser.add_argument(
+        "--collection",
+        help="Existing collection name or id, used for the iac.export "
+             "idempotency check (read-only)",
+    )
+    parser.add_argument(
+        "--source-dashboard-id", type=int,
+        help="An existing dashboard id to test copy_dashboard(deepcopy=True). "
+             "The original is read-only.",
+    )
+    parser.add_argument(
+        "--chatbot", action="store_true",
+        help="Also run the chatbot end-to-end (does NOT apply the spec)",
+    )
+    parser.add_argument(
+        "--keep-sandbox", action="store_true",
+        help="Don't archive the sandbox collection at the end",
+    )
+    args = parser.parse_args()
+
+    print("Connecting to {} ...".format(args.domain))
+    mb = Metabase_API(
+        domain=args.domain,
+        email=args.email or os.environ.get("METABASE_EMAIL") or None,
+        password=args.password or os.environ.get("METABASE_PASSWORD") or None,
+        session_id=args.session_id or os.environ.get("METABASE_SESSION_ID") or None,
+    )
+
+    sandbox_id: Optional[int] = None
+    failed_with: Optional[BaseException] = None
+    try:
+        phase1_readonly(mb, args.collection)
+        sandbox_id = phase2_sandbox(mb, args.source_dashboard_id)
+        if args.chatbot:
+            phase3_chatbot(mb)
+    except AssertionError as exc:
+        _fail(str(exc))
+        failed_with = exc
+    except Exception as exc:  # noqa: BLE001 — we want to surface anything
+        _fail("unexpected error: {}: {}".format(type(exc).__name__, exc))
+        failed_with = exc
+    finally:
+        if sandbox_id is not None:
+            cleanup(mb, sandbox_id, keep=args.keep_sandbox)
+
+    print()
+    if failed_with is not None:
+        print("Integration tests FAILED.")
+        return 1
+    print("All integration tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope

Cette PR contient **trois sous-PR empilées** ; idéalement à splitter avant merge :

1. **Bug fixes + alignement Metabase 0.49 → 0.61** (modifs sur `main_methods`, `_rest_methods`, `_helper_methods`, `copy_methods`, `create_methods`, `modify_methods`).
2. **`spark_metabase_api.iac`** — Infrastructure-as-Code (export/plan/apply YAML, CLI `spark-metabase`).
3. **`spark_metabase_api.chatbot`** + frontend Streamlit (`streamlit_app.py`) — agent Claude Opus 4.7 / tool-use qui produit un `CollectionSpec` à partir d'un brief en langage naturel.

Bump version : 0.1.13.1 → **0.3.0**.

---

## ⚠️ Changements de comportement (existing endpoints)

| Endpoint | Avant | Après | Risque caller |
|---|---|---|---|
| `add_card_to_dashboard` | retour `dict \| False` | retour `dict \| None \| int` (status_code en fallback PUT) | callers qui lisaient `.id` cassent sur Metabase ≥ 0.51 |
| `__init__(email=..., password=None)` | `ValueError` immédiate | prompt `getpass` interactif | bloque les flux headless / CI |
| `_rest_methods` (get/post/put/delete) | pas de timeout | timeout 30 s par défaut (override via `timeout=None`) | requêtes longues (grosses `get_card_data`) cassent si pas overridées |
| `clone_card` MBQL remap | regex + `eval` sur `['field', X, ...]` | tree-walk sur `('field', int, ...)` et `('field-id', int, ...)` | silencieusement nop sur d'autres formes de nœuds MBQL (expressions, aggregations) |
| `create_collection`, `restrict_collection_access` | `print` + `TypeError` tardive en cas d'arg manquant | `ValueError` immédiate | type d'erreur change |

## Bug fixes (strictement améliorant)

- `__init__` : `self.password` n'était jamais stocké → corrigé.
- `clone_card` : typo `target_table_id` réassigné à `source_table_id`.
- `check_collection` : `NameError` sur la branche "plus d'une collection trouvée".
- `copy_dashboard` : `name.rstrip(' - Duplicate')` (set de caractères) → suppression de suffixe propre.
- `restrict_filter_with_card_values` : `column_base_type` paramétrable, `preserve_column_case=True` opt-in (default conservé pour Snowflake).
- `get_dashboard_question_ids` : lit `dashcards` ET `ordered_cards`.
- `get_card_data` : `parameters=None` ne crash plus.
- Suppression de tous les `eval()` (`clone_card`, `create_card`) — cassait sur quotes/unicode dans les noms.
- `requests.Session` partagée + erreurs réseau pendant `validate_session` tolérées.
- `validate_session` / `is_session_valid` dédupliqués.

## Alignement API Metabase

| Version MB | Changement upstream | Adaptation |
|---|---|---|
| 0.49 | `dataset` → `type` | pas d'action |
| 0.50 | `archived: true` envoie à la Trash | OK |
| 0.53 | params query-string interdits sur `/query/:format` | `get_card_data` envoie en form ✓ |
| 0.56.13 | `/api/collection/graph` ne renvoie plus les `none` | `restrict_collection_access` écrit la clé même si absente |
| 0.57 | MBQL 5 par défaut | `clone_card` fetch avec `?legacy-mbql=true` |
| diverses | `POST /api/dashboard/:id/cards` déprécié | `add_card_to_dashboard` fallback `PUT /api/dashboard/:id` |
| diverses | `color` non accepté sur les nouvelles versions | `create_collection` retente sans `color` sur 400 |
| ~0.48 | `ordered_cards` → `dashcards` | `get_dashboard_question_ids` lit les deux clés |

## Module IaC (`spark_metabase_api.iac`)

Déclare un arbre collections / dashboards / cards en YAML, applique idempotemment avec un diff style Terraform.

```bash
spark-metabase --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
    export "Acme Customer" specs/acme.yaml
spark-metabase plan specs/acme.yaml
spark-metabase apply specs/acme.yaml --yes
```

Surface Python : `iac.export`, `iac.load`, `iac.dump`, `iac.plan`, `iac.apply`, `iac.spec_from_dict`.

**Choix de design**
- Items identifiés par `(parent_path, kind, name)`. Renames = destructifs ; passer `entity_id` (nanoid stable depuis 0.46) pour binder un spec à un item live à travers un rename.
- `cards` / `dashboards` / `dashcards` opaques — pas d'interprétation MBQL côté lib.
- Forward-references `card_name → card_id` résolues à apply time (un même spec crée cards + dashboard qui les référence par nom).
- PyYAML extra : `pip install spark-metabase-api[iac]`. Fallback JSON natif.
- Wrapping autour de `create_collection`, `create_card`, `post`, `put` — pas de duplication.

## Module Chatbot + Streamlit

Agent Claude Opus 4.7 / tool-use, 5 outils read-only (`list_databases`, `list_tables`, `describe_table`, `search_metabase`, `find_cards_using_table`) qui produisent un `CollectionSpec`. Surface : `chat()` (blocking) et `stream()` (générateur d'events `text` / `tool_call` / `tool_result` / `proposed`).

Frontend Streamlit single-file avec sidebar credentials, streaming des tool-calls, review YAML, bouton Apply (passe par `iac.plan` / `iac.apply`).

Extras : `pip install spark-metabase-api[chatbot]` ou `[streamlit]`. Requiert `ANTHROPIC_API_KEY`.

## Tests

`tests/integration_test.py` exerce le package contre une Metabase live, en 4 phases (read-only → sandbox writes → chatbot opt-in → cleanup avec archive dans un `finally`).

```bash
python tests/integration_test.py \
    --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
    --collection "My Reports" --source-dashboard-id 42 --chatbot
```

## Test plan

- [x] AST + import smoke test
- [x] Round-trip `dump → load` JSON et YAML
- [x] `plan → apply → plan = all skips` (idempotence) sur fake in-memory
- [x] CLI `--help` propre
- [ ] **Tester contre Metabase 0.49 / 0.51 / 0.57 / 0.61** (cf. tableau alignement)
- [ ] Vérifier `clone_card` sur cards avec MBQL non-trivial (expressions, aggregations)
- [ ] Vérifier non-régression `add_card_to_dashboard` chez les callers existants
- [ ] Vérifier qu'un caller passant `email=` sans `password=` n'est pas bloqué en CI

## Bugs connus dans le nouveau code (à fixer avant merge)

- **iac** : `_plan_collection` peut faire matcher une collection homonyme à la racine comme enfant d'un parent à créer (faux update au lieu de create propre).
- **iac** : `_significant_card_diff` ne diffe que 4 clés sur les 9 que `_CARD_OPAQUE_KEYS` exporte → plan/apply divergent sur `parameters`, `parameter_mappings`, `cache_ttl`, `archived`.
- **iac** : `result_metadata` exporté puis re-PUT écrase la version Metabase fraîchement calculée → drift à chaque round-trip.
- **iac** : `apply()` re-fait toute la discovery déjà faite par `plan()` → coût réseau doublé, fenêtre TOCTOU.
- **chatbot** : `cache_control` passé en kwarg top-level de `tool_runner` au lieu de bloc-level → cache hit jamais déclenché.
- **add_card_to_dashboard** : docstring dit "modern endpoint then legacy fallback" mais code fait l'inverse.

## Limites / dette laissée

- 3 modules en 1 PR — **à splitter**.
- Aucun test unitaire (uniquement intégration live + smoke).
- Licence incohérente (MIT dans `setup.py`, GPLv3 dans le badge README).
- Pas de pyproject.toml / type hints / ruff / mypy.
- CHANGELOG : entrées 0.2.0 et 0.3.0 même date, ordre inversé — à reranger.