### PR TITLE
IaC module: declarative Metabase collections via YAML (0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,9 @@
 * `create_collection`: `color` is sent for older Metabase but transparently dropped on a 400 from newer Metabase
 * Hardened `_rest_methods`: shared `requests.Session`, default 30s timeout (override via `timeout=None`), network errors during session validation no longer raise
 * `validate_session` and `is_session_valid` deduplicated
+## 0.2.0 (2026-05-08)
+### Added
+* New **Infrastructure-as-Code** module `spark_metabase_api.iac`: declare a Metabase collection tree in YAML/JSON and apply it idempotently with a Terraform-style diff. Exposes `export`, `plan`, `apply` and a CLI: `spark-metabase {export,plan,apply}`. PyYAML is an optional extra (`pip install spark-metabase-api[iac]`).
+* Forward references in dashcards: a dashcard can reference a card created by the same spec via `card_name: "<name>"`; the applier resolves it to a `card_id` at apply time.
+* Integration test script `tests/integration_test.py` with read-only / sandbox / cleanup phases.
+* README rewritten with a worked IaC example.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,123 @@
 [![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
-(to create)
 
 # Spark Metabase API
 
-A Python wrapper for the Metabase API \
-Developed by the [Spark Tech team](https://www.spark.do/) ⭐️
+A Python wrapper for the Metabase API, developed by the [Spark Tech team](https://www.spark.do/) ⭐️
 
 ## Installation
 
-In construction 🚧
+```bash
+pip install spark-metabase-api
+# Optional YAML support for the Infrastructure-as-Code module:
+pip install "spark-metabase-api[iac]"
+```
 
-## To-Do
+## Quick start
 
-- [ ] XXX
+```python
+from spark_metabase_api import Metabase_API
+
+mb = Metabase_API(
+    domain="https://metabase.example.com",
+    email="me@example.com",
+    password="hunter2",
+)
+
+mb.copy_dashboard(source_dashboard_id=42, destination_collection_name="Acme")
+```
+
+## Infrastructure-as-Code
+
+Define a Metabase collection tree in YAML, version it in git, and apply it
+idempotently with a Terraform-style diff.
+
+```bash
+# Pull the live state for an existing collection
+spark-metabase --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
+    export "Acme Customer" specs/acme.yaml
+
+# Show what would change after editing the spec
+spark-metabase plan specs/acme.yaml
+
+# Apply (with confirmation prompt unless --yes)
+spark-metabase apply specs/acme.yaml
+```
+
+Example spec:
+
+```yaml
+name: "Acme Customer"
+description: "Customer-facing dashboards"
+authority_level: official
+collections:
+  - name: "Questions"
+    cards:
+      - name: "Daily revenue"
+        definition:
+          dataset_query:
+            type: native
+            database: 2
+            native:
+              query: "SELECT day, sum(amount) FROM sales GROUP BY 1"
+          display: line
+          visualization_settings: {}
+dashboards:
+  - name: "Acme Dashboard"
+    description: "Top-level KPIs"
+    parameters: []
+    dashcards: []  # populated automatically by `export`
+```
+
+The Python API is also exposed:
+
+```python
+from spark_metabase_api import Metabase_API, iac
+
+mb = Metabase_API(domain=..., session_id=...)
+
+# Export to YAML
+spec = iac.export(mb, "Acme Customer")
+iac.dump(spec, "specs/acme.yaml")
+
+# Edit the file in git, then in CI:
+spec = iac.load("specs/acme.yaml")
+print(iac.plan(mb, spec).render())
+iac.apply(mb, spec)
+```
+
+### Natural keys & renames
+
+Items are identified by `(parent_path, kind, name)` within the spec. Renaming
+an item is therefore a destructive change (delete + create). To bind a spec
+entry to a specific live item across renames, set `entity_id` (Metabase's
+stable nanoid, available since v0.46) on the entry.
+
+### Forward references in dashcards
+
+A dashcard can reference a card created by the same spec via
+`card_name: "<name>"` instead of `card_id`. The applier looks the name up in
+the cards present (or just created) inside the same collection and rewrites
+the dashcard with the real id.
+
+## Integration tests
+
+A standalone script exercises the package against a live Metabase instance,
+in three phases with a sandboxed write area that's archived on exit:
+
+```bash
+python tests/integration_test.py \
+    --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
+    --collection "My Reports" \
+    --source-dashboard-id 42
+```
+
+Phase 1 is fully read-only. Phase 2 creates a uniquely-named throwaway
+collection, applies a tiny spec, exercises `add_card_to_dashboard` and
+`copy_dashboard(deepcopy=True)`, then archives the sandbox in a `finally`
+block (use `--keep-sandbox` to keep it around for manual inspection).
 
 ## Acknowledgements
 
 - [Metabase API documentation](https://www.metabase.com/docs/latest/api-documentation)
+- [Metabase API changelog](https://www.metabase.com/docs/latest/developers-guide/api-changelog)
 - Inspired from [metabase_api_python](https://github.com/vvaezian/metabase_api_python)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.1.14",
+    version="0.2.0",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",
@@ -16,6 +16,14 @@ setuptools.setup(
     install_requires=[
         "requests",
     ],
+    extras_require={
+        "iac": ["PyYAML>=5.1"],
+    },
+    entry_points={
+        "console_scripts": [
+            "spark-metabase=spark_metabase_api.iac:main",
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -1,0 +1,740 @@
+"""
+Infrastructure-as-Code for Metabase.
+
+Define a tree of collections / dashboards / cards in YAML (or JSON) and apply
+it idempotently to a Metabase instance, with a Terraform-style diff first.
+
+Natural keys: items are identified by (parent_path, kind, name). Renames are
+therefore destructive (delete + create); use the optional `entity_id` field
+to bind a spec entry to an existing item across a rename.
+
+Public surface:
+    Spec, CollectionSpec, DashboardSpec, CardSpec
+    spec_to_dict(spec) / spec_from_dict(data) — plain-dict round-trip
+    load(path) -> Spec
+    dump(spec, path) -> None
+    export(client, root_collection) -> CollectionSpec
+    plan(client, spec) -> Plan
+    apply(client, spec, dry_run=False) -> Plan
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+try:  # pyyaml is an optional extra
+    import yaml as _yaml  # type: ignore
+except ImportError:  # pragma: no cover - exercised when pyyaml absent
+    _yaml = None
+
+
+# ---------------------------------------------------------------------------
+# Spec data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CardSpec:
+    """A Metabase card (question or model). `definition` is the opaque payload
+    sent to POST/PUT /api/card/, minus the collection_id (resolved on apply)."""
+
+    name: str
+    definition: Dict[str, Any] = field(default_factory=dict)
+    entity_id: Optional[str] = None
+    description: Optional[str] = None
+
+    @property
+    def kind(self) -> str:
+        return "card"
+
+
+@dataclass
+class DashboardSpec:
+    """A Metabase dashboard.
+
+    `dashcards` is preserved verbatim and re-applied as-is. Card ids inside
+    dashcards are NOT rewritten in this version; if a dashboard references a
+    card created by the same spec run, set the dashcard's `card_id` manually
+    after the first apply (or wait for a future release that resolves
+    cross-references)."""
+
+    name: str
+    description: Optional[str] = None
+    dashcards: List[Dict[str, Any]] = field(default_factory=list)
+    parameters: List[Dict[str, Any]] = field(default_factory=list)
+    entity_id: Optional[str] = None
+
+    @property
+    def kind(self) -> str:
+        return "dashboard"
+
+
+@dataclass
+class CollectionSpec:
+    """A Metabase collection. Children are nested; the parent of the root is
+    resolved on apply via parent_path or parent_id."""
+
+    name: str
+    description: Optional[str] = None
+    authority_level: Optional[str] = None  # 'official' or None
+    entity_id: Optional[str] = None
+    parent_path: Optional[str] = None  # absolute path of the parent at apply
+    collections: List["CollectionSpec"] = field(default_factory=list)
+    dashboards: List[DashboardSpec] = field(default_factory=list)
+    cards: List[CardSpec] = field(default_factory=list)
+
+    @property
+    def kind(self) -> str:
+        return "collection"
+
+
+# Top-level Spec is just a CollectionSpec with parent_path defaulting to "/".
+Spec = CollectionSpec
+
+
+# ---------------------------------------------------------------------------
+# (De)serialization
+# ---------------------------------------------------------------------------
+
+
+def spec_to_dict(spec: CollectionSpec) -> Dict[str, Any]:
+    """Serialize a CollectionSpec to a plain dict (round-trip with spec_from_dict)."""
+    return asdict(spec)
+
+
+def spec_from_dict(data: Dict[str, Any]) -> CollectionSpec:
+    """Deserialize a CollectionSpec from a plain dict (e.g. parsed YAML/JSON)."""
+    children = [spec_from_dict(c) for c in data.get("collections") or []]
+    dashboards = [
+        DashboardSpec(
+            name=d["name"],
+            description=d.get("description"),
+            dashcards=d.get("dashcards") or [],
+            parameters=d.get("parameters") or [],
+            entity_id=d.get("entity_id"),
+        )
+        for d in data.get("dashboards") or []
+    ]
+    cards = [
+        CardSpec(
+            name=c["name"],
+            definition=c.get("definition") or {},
+            entity_id=c.get("entity_id"),
+            description=c.get("description"),
+        )
+        for c in data.get("cards") or []
+    ]
+    return CollectionSpec(
+        name=data["name"],
+        description=data.get("description"),
+        authority_level=data.get("authority_level"),
+        entity_id=data.get("entity_id"),
+        parent_path=data.get("parent_path"),
+        collections=children,
+        dashboards=dashboards,
+        cards=cards,
+    )
+
+
+def load(path: str) -> CollectionSpec:
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    if path.endswith((".yaml", ".yml")):
+        if _yaml is None:
+            raise ImportError(
+                "PyYAML is required to load YAML specs. "
+                "Install with: pip install spark-metabase-api[iac]"
+            )
+        data = _yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    return spec_from_dict(data)
+
+
+def dump(spec: CollectionSpec, path: str) -> None:
+    data = spec_to_dict(spec)
+    if path.endswith((".yaml", ".yml")):
+        if _yaml is None:
+            raise ImportError(
+                "PyYAML is required to dump YAML specs. "
+                "Install with: pip install spark-metabase-api[iac]"
+            )
+        text = _yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    else:
+        text = json.dumps(data, indent=2, ensure_ascii=False)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+# ---------------------------------------------------------------------------
+# Exporter
+# ---------------------------------------------------------------------------
+
+
+def _collection_items(client, collection_id: Union[int, str, None]) -> List[Dict[str, Any]]:
+    # The synthetic Root collection is addressed as 'root' by the Metabase API.
+    cid = "root" if collection_id is None or collection_id == "root" else collection_id
+    res = client.get("/api/collection/{}/items".format(cid))
+    if isinstance(res, dict):  # paginated shape introduced in 0.40
+        return res.get("data", [])
+    return res or []
+
+
+def export(client, root_collection: Union[int, str]) -> CollectionSpec:
+    """Pull a collection tree from a live Metabase into a Spec.
+
+    `root_collection` is either a collection id, the literal string 'root', or
+    a collection name (resolved via get_item_id).
+    """
+    if isinstance(root_collection, str) and root_collection.lower() != "root":
+        try:
+            root_collection = int(root_collection)
+        except ValueError:
+            root_collection = client.get_item_id("collection", root_collection)
+    return _export_collection(client, root_collection)
+
+
+def _export_collection(client, collection_id: Union[int, str, None]) -> CollectionSpec:
+    is_root = collection_id is None or collection_id == "root"
+    if is_root:
+        info: Dict[str, Any] = {
+            "name": "Root", "description": None,
+            "authority_level": None, "entity_id": None,
+        }
+    else:
+        info = client.get("/api/collection/{}".format(collection_id)) or {}
+        if not info:
+            raise RuntimeError(
+                "Failed to fetch collection {} — aborting export to avoid "
+                "silently producing an incomplete spec.".format(collection_id)
+            )
+
+    spec = CollectionSpec(
+        name=info.get("name") or "Root",
+        description=info.get("description"),
+        authority_level=info.get("authority_level"),
+        entity_id=info.get("entity_id"),
+    )
+    for item in _collection_items(client, collection_id):
+        if item.get("archived"):
+            continue
+        model = item.get("model")
+        if model == "collection":
+            spec.collections.append(_export_collection(client, item["id"]))
+        elif model == "dashboard":
+            spec.dashboards.append(_export_dashboard(client, item["id"]))
+        elif model == "card":
+            spec.cards.append(_export_card(client, item["id"]))
+        # other models (pulse, metric, ...) are ignored on purpose
+    return spec
+
+
+_CARD_OPAQUE_KEYS = (
+    "dataset_query", "display", "visualization_settings", "type",
+    "parameters", "parameter_mappings", "cache_ttl",
+)
+# Intentionally excluded:
+#   result_metadata — server-computed (column types/sem types). Re-PUTting it
+#                     overwrites Metabase's freshly-computed copy and creates
+#                     spectral diffs at every export.
+#   archived        — _collection_items already filters out archived items at
+#                     export, so this would always be False on round-trip.
+
+
+def _export_card(client, card_id: int) -> CardSpec:
+    # MBQL 4 shapes are easier to round-trip through the API on Metabase 0.57+
+    info = client.get("/api/card/{}".format(card_id), params={"legacy-mbql": "true"}) or {}
+    return CardSpec(
+        name=info.get("name") or "",
+        description=info.get("description"),
+        entity_id=info.get("entity_id"),
+        definition={k: info.get(k) for k in _CARD_OPAQUE_KEYS if k in info},
+    )
+
+
+def _export_dashboard(client, dashboard_id: int) -> DashboardSpec:
+    info = client.get("/api/dashboard/{}".format(dashboard_id)) or {}
+    dashcards = info.get("dashcards") or info.get("ordered_cards") or []
+    return DashboardSpec(
+        name=info.get("name") or "",
+        description=info.get("description"),
+        entity_id=info.get("entity_id"),
+        parameters=info.get("parameters") or [],
+        dashcards=dashcards,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan / Apply
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Action:
+    op: str  # 'create' | 'update' | 'skip'
+    kind: str  # 'collection' | 'dashboard' | 'card'
+    path: str
+    reason: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+    existing_id: Optional[int] = None
+
+
+@dataclass
+class Plan:
+    actions: List[Action] = field(default_factory=list)
+
+    def summary(self) -> str:
+        counts: Dict[str, int] = {}
+        for a in self.actions:
+            counts[a.op] = counts.get(a.op, 0) + 1
+        parts = ["{} {}".format(v, k) for k, v in sorted(counts.items())]
+        return ", ".join(parts) or "no changes"
+
+    def render(self) -> str:
+        glyph = {"create": "+", "update": "~", "skip": "="}
+        lines = []
+        for a in self.actions:
+            lines.append("  {}  {:<10} {}{}".format(
+                glyph.get(a.op, "?"), a.kind, a.path,
+                "  [{}]".format(a.reason) if a.reason else "",
+            ))
+        return "\n".join(lines) + ("\n" if lines else "") + "Plan: " + self.summary()
+
+
+def _join(parent_path: str, name: str) -> str:
+    if parent_path == "/" or parent_path == "":
+        return "/" + name
+    return parent_path.rstrip("/") + "/" + name
+
+
+def _index_collection_children(client, collection_id) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    out: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    for item in _collection_items(client, collection_id):
+        if item.get("archived"):
+            continue
+        model = item.get("model")
+        if model in ("collection", "dashboard", "card"):
+            out[(model, item["name"])] = item
+    return out
+
+
+def _significant_card_diff(local: CardSpec, remote: Dict[str, Any]) -> List[str]:
+    diffs = []
+    if (local.description or None) != (remote.get("description") or None):
+        diffs.append("description")
+    for key in _CARD_OPAQUE_KEYS:
+        if key in local.definition and local.definition[key] != remote.get(key):
+            diffs.append(key)
+    return diffs
+
+
+def _significant_dashboard_diff(
+    local: DashboardSpec,
+    remote: Dict[str, Any],
+    resolved_dashcards: Optional[List[Dict[str, Any]]] = None,
+) -> List[str]:
+    diffs = []
+    if (local.description or None) != (remote.get("description") or None):
+        diffs.append("description")
+    if (local.parameters or []) != (remote.get("parameters") or []):
+        diffs.append("parameters")
+    if resolved_dashcards is None:
+        # Spec carries card_name forward references that can't be resolved
+        # yet (cards not created at plan time). Force an update.
+        diffs.append("dashcards")
+    else:
+        remote_dc = remote.get("dashcards") or remote.get("ordered_cards") or []
+        if resolved_dashcards != remote_dc:
+            diffs.append("dashcards")
+    return diffs
+
+
+def _significant_collection_diff(local: CollectionSpec, remote: Dict[str, Any]) -> List[str]:
+    diffs = []
+    if (local.description or None) != (remote.get("description") or None):
+        diffs.append("description")
+    if (local.authority_level or None) != (remote.get("authority_level") or None):
+        diffs.append("authority_level")
+    return diffs
+
+
+def _plan_creates_only(spec: CollectionSpec, path: str, p: Plan) -> None:
+    """Emit create actions for the entire subtree without consulting Metabase.
+
+    Used when the spec's parent collection is itself going to be created in
+    the same apply run, so by construction nothing below exists yet."""
+    p.actions.append(Action(
+        op="create", kind="collection", path=path,
+        payload={
+            "name": spec.name,
+            "description": spec.description,
+            "authority_level": spec.authority_level,
+        },
+    ))
+    for child in spec.collections:
+        _plan_creates_only(child, _join(path, child.name), p)
+    for d in spec.dashboards:
+        p.actions.append(Action(op="create", kind="dashboard", path=_join(path, d.name)))
+    for c in spec.cards:
+        p.actions.append(Action(op="create", kind="card", path=_join(path, c.name)))
+
+
+def plan(client, spec: CollectionSpec, parent_id: Optional[int] = None) -> Plan:
+    """Compute a plan to make Metabase match the spec.
+
+    The plan is read-only; pass the same arguments to `apply` to execute it.
+
+    Keyword arguments:
+    client -- a configured Metabase_API instance
+    spec -- the root CollectionSpec to apply
+    parent_id -- id of the Metabase collection that should host `spec`. None
+                 means the root collection.
+    """
+    p = Plan()
+    _plan_collection(client, spec, parent_id, parent_path="", p=p)
+    return p
+
+
+def _plan_collection(client, spec: CollectionSpec, parent_id: Optional[int],
+                     parent_path: str, p: Plan,
+                     parent_pending: bool = False) -> None:
+    path = _join(parent_path or "/", spec.name)
+
+    if parent_pending:
+        # Parent collection is itself going to be created in the same apply
+        # run, so by construction nothing in this subtree exists yet. We must
+        # NOT call _index_collection_children here — with parent_id=None it
+        # would scan the root collection and falsely match a homonymous
+        # sibling living at the root.
+        _plan_creates_only(spec, path, p)
+        return
+
+    existing_id = None
+    if parent_id is None and spec.name.lower() == "root":
+        existing_id = "root"
+        existing = {"name": "Root"}
+    else:
+        siblings = _index_collection_children(client, parent_id if parent_id is not None else "root")
+        match = siblings.get(("collection", spec.name))
+        if match:
+            existing_id = match["id"]
+            existing = client.get("/api/collection/{}".format(existing_id)) or match
+        else:
+            existing = None
+
+    if existing is None:
+        p.actions.append(Action(
+            op="create", kind="collection", path=path,
+            payload={
+                "name": spec.name,
+                "description": spec.description,
+                "authority_level": spec.authority_level,
+                "parent_id": parent_id,
+            },
+        ))
+        for child in spec.collections:
+            _plan_collection(client, child, parent_id=None,
+                             parent_path=path, p=p, parent_pending=True)
+        for d in spec.dashboards:
+            p.actions.append(Action(op="create", kind="dashboard", path=_join(path, d.name)))
+        for c in spec.cards:
+            p.actions.append(Action(op="create", kind="card", path=_join(path, c.name)))
+        return
+
+    diffs = _significant_collection_diff(spec, existing)
+    p.actions.append(Action(
+        op="update" if diffs else "skip",
+        kind="collection", path=path,
+        reason=",".join(diffs),
+        existing_id=existing_id if isinstance(existing_id, int) else None,
+        payload={
+            "description": spec.description,
+            "authority_level": spec.authority_level,
+        } if diffs else {},
+    ))
+
+    children = _index_collection_children(client, existing_id) if existing_id != "root" else \
+        _index_collection_children(client, "root")
+
+    for child in spec.collections:
+        _plan_collection(
+            client, child,
+            parent_id=existing_id if isinstance(existing_id, int) else None,
+            parent_path=path, p=p,
+        )
+
+    # name_to_id for cards in this collection — also used to resolve
+    # card_name forward references in spec dashcards before we diff them
+    # against the live state (which carries card_id).
+    existing_name_to_id = {
+        name: item["id"]
+        for (kind, name), item in children.items()
+        if kind == "card"
+    }
+
+    for d in spec.dashboards:
+        match = children.get(("dashboard", d.name))
+        d_path = _join(path, d.name)
+        if not match:
+            p.actions.append(Action(op="create", kind="dashboard", path=d_path))
+            continue
+        remote = client.get("/api/dashboard/{}".format(match["id"])) or match
+        try:
+            resolved_dashcards = _resolve_card_names(d.dashcards, existing_name_to_id)
+        except ValueError:
+            # The spec references a card_name that doesn't exist yet (will be
+            # created in the same apply). Treat as needing an update; the
+            # executor will resolve it once the card is materialised.
+            resolved_dashcards = None
+        diffs = _significant_dashboard_diff(d, remote, resolved_dashcards)
+        p.actions.append(Action(
+            op="update" if diffs else "skip",
+            kind="dashboard", path=d_path,
+            reason=",".join(diffs),
+            existing_id=match["id"],
+        ))
+
+    for c in spec.cards:
+        match = children.get(("card", c.name))
+        c_path = _join(path, c.name)
+        if not match:
+            p.actions.append(Action(op="create", kind="card", path=c_path))
+            continue
+        remote = client.get("/api/card/{}".format(match["id"]),
+                            params={"legacy-mbql": "true"}) or match
+        diffs = _significant_card_diff(c, remote)
+        p.actions.append(Action(
+            op="update" if diffs else "skip",
+            kind="card", path=c_path,
+            reason=",".join(diffs),
+            existing_id=match["id"],
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Applier
+# ---------------------------------------------------------------------------
+
+
+def apply(client, spec: CollectionSpec, parent_id: Optional[int] = None,
+          dry_run: bool = False) -> Plan:
+    """Apply the spec to Metabase so the live state matches the spec.
+
+    Returns the executed plan. With dry_run=True nothing is written and the
+    returned plan is exactly what `plan(client, spec, parent_id)` would return.
+    """
+    p = plan(client, spec, parent_id=parent_id)
+    if dry_run:
+        return p
+    by_path = {a.path: a for a in p.actions}
+    _execute_collection(client, spec, parent_id, parent_path="", by_path=by_path)
+    return p
+
+
+def _resolve_card_names(dashcards: List[Dict[str, Any]],
+                        name_to_id: Dict[str, int]) -> List[Dict[str, Any]]:
+    """Replace `card_name` forward references in dashcards with `card_id`.
+
+    Dashcards that already have a `card_id` are left alone. A dashcard with
+    `card_name` set and no `card_id` is rewritten to point at the live id;
+    if the name doesn't match any card created or found in the same scope,
+    a ValueError is raised with the offending name.
+    """
+    out = []
+    for dc in dashcards or []:
+        if dc.get("card_name") and not dc.get("card_id"):
+            cid = name_to_id.get(dc["card_name"])
+            if cid is None:
+                raise ValueError(
+                    "Dashcard references card_name {!r}, but no card with "
+                    "that name was created or found in the same collection."
+                    .format(dc["card_name"])
+                )
+            resolved = dict(dc)
+            resolved["card_id"] = cid
+            resolved.pop("card_name")
+            out.append(resolved)
+        else:
+            out.append(dc)
+    return out
+
+
+def _execute_collection(client, spec: CollectionSpec, parent_id: Optional[int],
+                        parent_path: str, by_path: Dict[str, Action]) -> int:
+    path = _join(parent_path or "/", spec.name)
+    action = by_path.get(path)
+    if action is None:
+        # Defensive: if the plan lost track, skip silently.
+        return 0
+
+    if action.op == "create":
+        new = client.create_collection(
+            collection_name=spec.name,
+            parent_collection_id=parent_id,
+            parent_collection_name="Root" if parent_id is None else None,
+            official=(spec.authority_level == "official"),
+            return_results=True,
+        )
+        collection_id = new["id"] if isinstance(new, dict) else new
+        if not collection_id:
+            raise RuntimeError(
+                "Failed to create collection {!r} under parent {}: aborting "
+                "the apply to avoid orphaning its children at the root."
+                .format(spec.name, parent_id)
+            )
+        if spec.description:
+            client.put("/api/collection/{}".format(collection_id),
+                       json={"description": spec.description})
+    elif action.op == "update" and action.existing_id is not None:
+        collection_id = action.existing_id
+        client.put("/api/collection/{}".format(collection_id), json=action.payload)
+    else:
+        collection_id = action.existing_id  # may be None for the synthetic Root
+
+    # Walk children
+    for child in spec.collections:
+        _execute_collection(client, child, collection_id, path, by_path)
+
+    # Track card names → ids in this collection so dashcards can reference
+    # cards by name. Pre-populate with cards that already exist (skip ops).
+    name_to_id: Dict[str, int] = {}
+    if collection_id and collection_id != "root":
+        for (kind, name), item in _index_collection_children(client, collection_id).items():
+            if kind == "card":
+                name_to_id[name] = item["id"]
+
+    # Cards must be processed before dashboards so name_to_id is populated.
+    for c in spec.cards:
+        c_path = _join(path, c.name)
+        c_action = by_path.get(c_path)
+        if c_action is None:
+            continue
+        if c_action.op == "create":
+            payload = dict(c.definition)
+            payload.update({
+                "name": c.name,
+                "collection_id": collection_id,
+                "description": c.description,
+            })
+            res = client.create_card(custom_json=payload, return_card=True)
+            if not isinstance(res, dict) or "id" not in res:
+                raise RuntimeError(
+                    "Failed to create card {!r} in collection {}: {}"
+                    .format(c.name, collection_id, res)
+                )
+            name_to_id[c.name] = res["id"]
+        elif c_action.op == "update" and c_action.existing_id is not None:
+            payload = dict(c.definition)
+            payload["description"] = c.description
+            client.put("/api/card/{}".format(c_action.existing_id), json=payload)
+            name_to_id[c.name] = c_action.existing_id
+        elif c_action.existing_id is not None:  # skip
+            name_to_id[c.name] = c_action.existing_id
+
+    for d in spec.dashboards:
+        d_path = _join(path, d.name)
+        d_action = by_path.get(d_path)
+        if d_action is None:
+            continue
+        dashcards = _resolve_card_names(d.dashcards, name_to_id)
+        if d_action.op == "create":
+            payload = {
+                "name": d.name,
+                "description": d.description,
+                "collection_id": collection_id,
+                "parameters": d.parameters or [],
+            }
+            res = client.post("/api/dashboard/", json=payload)
+            if res and dashcards:
+                client.put(
+                    "/api/dashboard/{}".format(res["id"]),
+                    json={"dashcards": dashcards, "parameters": d.parameters or []},
+                )
+        elif d_action.op == "update" and d_action.existing_id is not None:
+            client.put(
+                "/api/dashboard/{}".format(d_action.existing_id),
+                json={
+                    "description": d.description,
+                    "parameters": d.parameters or [],
+                    "dashcards": dashcards,
+                },
+            )
+
+    return collection_id or 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_client(args) -> Any:
+    from .main_methods import Metabase_API
+    return Metabase_API(
+        domain=args.domain or os.environ["METABASE_DOMAIN"],
+        email=args.email or os.environ.get("METABASE_EMAIL"),
+        password=args.password or os.environ.get("METABASE_PASSWORD"),
+        session_id=args.session_id or os.environ.get("METABASE_SESSION_ID"),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="python -m spark_metabase_api.iac")
+    parser.add_argument("--domain", help="Metabase URL (or METABASE_DOMAIN)")
+    parser.add_argument("--email", help="Metabase email (or METABASE_EMAIL)")
+    parser.add_argument("--password", help="Metabase password (or METABASE_PASSWORD)")
+    parser.add_argument("--session-id", help="Metabase session id (or METABASE_SESSION_ID)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_export = sub.add_parser("export", help="Pull a collection tree to a YAML/JSON spec")
+    p_export.add_argument("collection", help="Collection id, name, or 'root'")
+    p_export.add_argument("output", help="Output path (.yaml/.yml/.json)")
+
+    p_plan = sub.add_parser("plan", help="Show what would change if the spec was applied")
+    p_plan.add_argument("spec", help="Path to the spec file")
+
+    p_apply = sub.add_parser("apply", help="Apply the spec to Metabase")
+    p_apply.add_argument("spec", help="Path to the spec file")
+    p_apply.add_argument("--yes", action="store_true",
+                         help="Skip the interactive confirmation")
+
+    args = parser.parse_args(argv)
+    client = _build_client(args)
+
+    if args.cmd == "export":
+        spec = export(client, args.collection)
+        dump(spec, args.output)
+        print("Exported to {}".format(args.output))
+        return 0
+
+    if args.cmd == "plan":
+        spec = load(args.spec)
+        the_plan = plan(client, spec)
+        print(the_plan.render())
+        return 0
+
+    if args.cmd == "apply":
+        spec = load(args.spec)
+        the_plan = plan(client, spec)
+        print(the_plan.render())
+        if any(a.op != "skip" for a in the_plan.actions):
+            if not args.yes:
+                answer = input("\nApply these changes? [y/N] ").strip().lower()
+                if answer not in ("y", "yes"):
+                    print("Aborted.")
+                    return 1
+            apply(client, spec)
+            print("\nApplied.")
+        else:
+            print("\nNothing to do.")
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -254,15 +254,60 @@ def _export_card(client, card_id: int) -> CardSpec:
     )
 
 
+# Fields kept in the persisted dashcard. 'id' is preserved so that on
+# re-apply of a previously-exported spec, Metabase maps each dashcard back to
+# the same row (no churn). Anything else returned by the server (notably the
+# embedded 'card' object full of view_count / cache_invalidated_at /
+# last_used_at) is dropped — keeping it would break export → plan idempotency.
+_DASHCARD_PERSIST_KEYS = (
+    "id", "card_id",
+    "row", "col", "size_x", "size_y",
+    "parameter_mappings", "visualization_settings",
+    "series", "action_id", "dashboard_tab_id",
+    "entity_id",
+)
+
+# Fields compared during diff. 'id' is intentionally excluded: a fresh spec
+# uses 'id: -1' to signal "create me", but post-apply the remote has a real
+# positive id assigned by Metabase. Excluding it makes plan-after-apply a
+# clean skip without forcing the user to re-export.
+_DASHCARD_DIFF_KEYS = tuple(k for k in _DASHCARD_PERSIST_KEYS if k != "id")
+
+
+def _normalize_dashcard(dc: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist-time normalize: keep only canonical, non-server-derived fields."""
+    return {k: dc[k] for k in _DASHCARD_PERSIST_KEYS if k in dc}
+
+
+def _normalize_dashcard_for_diff(dc: Dict[str, Any]) -> Dict[str, Any]:
+    """Diff-time normalize.
+
+    - Drops 'id' so id=-1 (fresh spec) matches a real id (post-apply remote).
+    - Drops 'entity_id' (Metabase generates it on create — not user-meaningful).
+    - Treats missing keys as default values so a hand-written dashcard that
+      omits 'series', 'action_id', 'dashboard_tab_id' compares equal to its
+      post-apply remote where Metabase has auto-filled those.
+    """
+    out = {k: dc.get(k) for k in _DASHCARD_DIFF_KEYS}
+    out.pop("entity_id", None)
+    if out.get("parameter_mappings") is None:
+        out["parameter_mappings"] = []
+    if out.get("visualization_settings") is None:
+        out["visualization_settings"] = {}
+    if out.get("series") is None:
+        out["series"] = []
+    return out
+
+
 def _export_dashboard(client, dashboard_id: int) -> DashboardSpec:
     info = client.get("/api/dashboard/{}".format(dashboard_id)) or {}
-    dashcards = info.get("dashcards") or info.get("ordered_cards") or []
+    raw_dashcards = info.get("dashcards") or info.get("ordered_cards") or []
     return DashboardSpec(
         name=info.get("name") or "",
         description=info.get("description"),
         entity_id=info.get("entity_id"),
         parameters=info.get("parameters") or [],
-        dashcards=dashcards,
+        dashcards=[_normalize_dashcard(dc) for dc in raw_dashcards],
     )
 
 
@@ -345,8 +390,13 @@ def _significant_dashboard_diff(
         # yet (cards not created at plan time). Force an update.
         diffs.append("dashcards")
     else:
-        remote_dc = remote.get("dashcards") or remote.get("ordered_cards") or []
-        if resolved_dashcards != remote_dc:
+        # Normalize both sides — strip server-derived fields like the embedded
+        # 'card' object that changes between calls, plus 'id' so a fresh spec
+        # with id=-1 matches its post-apply remote with a real id.
+        remote_raw = remote.get("dashcards") or remote.get("ordered_cards") or []
+        remote_norm = [_normalize_dashcard_for_diff(dc) for dc in remote_raw]
+        local_norm = [_normalize_dashcard_for_diff(dc) for dc in resolved_dashcards]
+        if local_norm != remote_norm:
             diffs.append("dashcards")
     return diffs
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Integration tests for spark-metabase-api against a live Metabase instance.
+
+The script runs in 3 phases, each with a clear safety boundary:
+
+    Phase 1  read-only checks   (auth, search, iac.export idempotency)
+    Phase 2  sandbox writes     (creates a throwaway collection, applies a
+                                 mini-spec, exercises add_card_to_dashboard
+                                 and copy_dashboard's deepcopy path)
+    Phase 3  cleanup            (archive the sandbox; runs even on failure)
+
+The sandbox is archived in a finally block so a crash mid-test doesn't leave
+junk behind. Pass --keep-sandbox to keep it around for manual inspection.
+
+Usage:
+    python tests/integration_test.py \\
+        --domain https://metabase.example.com \\
+        --email me@example.com \\
+        --password '...'
+
+    # Or with a session id:
+    python tests/integration_test.py \\
+        --domain https://metabase.example.com \\
+        --session-id <session>
+
+    # Phase 1 also runs the iac round-trip on a real collection if you pass
+    # one (read-only — never modified):
+    python tests/integration_test.py ... --collection "My Reports"
+
+    # copy_dashboard is exercised if you pass an existing dashboard id (the
+    # original is read-only; a deep copy is made inside the sandbox):
+    python tests/integration_test.py ... --source-dashboard-id 42
+
+Exit code is 0 on success, 1 on any failed assertion.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+# Allow running straight from a checkout (`python tests/integration_test.py`)
+# without `pip install -e .` first.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from spark_metabase_api import Metabase_API, iac  # noqa: E402
+
+
+SANDBOX_NAME_PREFIX = "spark-metabase-api integration test"
+
+
+# ---------------------------------------------------------------------------
+# Status output
+# ---------------------------------------------------------------------------
+
+def _step(label: str) -> None:
+    print("\n=== {} ===".format(label))
+
+
+def _ok(msg: str) -> None:
+    print("  [ok]   {}".format(msg))
+
+
+def _skip(msg: str) -> None:
+    print("  [skip] {}".format(msg))
+
+
+def _fail(msg: str) -> None:
+    print("  [FAIL] {}".format(msg))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_parent_id(mb: Metabase_API, collection_ref: Any) -> Optional[int]:
+    """Return the parent collection id of `collection_ref`, or None for Root.
+
+    iac.plan/apply need to know where the spec lives so they diff against the
+    right sibling set. Metabase returns the parent path on a collection as
+    `location`: "/" for Root, "/5/" for a child of #5, "/5/10/" for a
+    grandchild.
+    """
+    if collection_ref in (None, "root", "Root"):
+        return None
+    if isinstance(collection_ref, int) or (
+        isinstance(collection_ref, str) and collection_ref.isdigit()
+    ):
+        cid = int(collection_ref)
+    else:
+        cid = mb.get_item_id("collection", collection_ref)
+    info = mb.get("/api/collection/{}".format(cid)) or {}
+    location = info.get("location") or "/"
+    parts = [p for p in location.strip("/").split("/") if p]
+    return int(parts[-1]) if parts else None
+
+
+def _pick_first_db(mb: Metabase_API) -> int:
+    res = mb.get("/api/database/")
+    dbs = res.get("data", res) if isinstance(res, dict) else res
+    if not dbs:
+        raise RuntimeError("No databases configured on this Metabase instance.")
+    return dbs[0]["id"]
+
+
+def _find_child(
+    mb: Metabase_API, collection_id: int, kind: str, name: str,
+) -> int:
+    res = mb.get("/api/collection/{}/items".format(collection_id))
+    items = res.get("data", res) if isinstance(res, dict) else res
+    for item in items or []:
+        if item.get("model") == kind and item.get("name") == name:
+            return item["id"]
+    raise LookupError(
+        "no {} named {!r} in collection {}".format(kind, name, collection_id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — read-only
+# ---------------------------------------------------------------------------
+
+def phase1_readonly(mb: Metabase_API, sample_collection: Optional[str]) -> None:
+    _step("Phase 1: read-only checks")
+
+    info = mb.get("/api/user/current")
+    assert info and info.get("email"), "auth check returned empty"
+    _ok("authenticated as {}".format(info["email"]))
+
+    results = mb.search("a", item_type=None)
+    assert isinstance(results, list), "search did not return a list"
+    _ok("search('a') returned {} items".format(len(results)))
+
+    dashboards = [r for r in results if r.get("model") == "dashboard"]
+    if dashboards:
+        dash_id = dashboards[0]["id"]
+        cards = mb.get_dashboard_question_ids(dashboard_id=dash_id)
+        _ok("get_dashboard_question_ids({}) -> {} cards".format(dash_id, len(cards)))
+    else:
+        _skip("get_dashboard_question_ids: no dashboard surfaced by search")
+
+    if sample_collection is None:
+        _skip("iac.export idempotency: no --collection passed")
+        return
+
+    print("  ... exporting {!r} (may take a while for large collections)"
+          .format(sample_collection))
+    spec = iac.export(mb, sample_collection)
+    parent_id = _resolve_parent_id(mb, sample_collection)
+    p = iac.plan(mb, spec, parent_id=parent_id)
+    if all(a.op == "skip" for a in p.actions):
+        _ok("iac.export({!r}) -> {} items, plan all-skip (idempotent)"
+            .format(sample_collection, len(p.actions)))
+    else:
+        non_skip = [(a.op, a.path, a.reason) for a in p.actions if a.op != "skip"]
+        raise AssertionError(
+            "iac.plan on freshly exported spec is NOT idempotent. "
+            "Non-skip actions: {}".format(non_skip)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — sandbox writes
+# ---------------------------------------------------------------------------
+
+def phase2_sandbox(
+    mb: Metabase_API, source_dashboard_id: Optional[int],
+) -> int:
+    _step("Phase 2: sandbox writes")
+    sandbox_name = "{} ({})".format(SANDBOX_NAME_PREFIX, int(time.time()))
+
+    # 1. create_collection — covers the color-retry fix.
+    res = mb.create_collection(
+        sandbox_name, parent_collection_name="Root", return_results=True,
+    )
+    assert isinstance(res, dict) and res.get("id"), \
+        "create_collection returned {!r}".format(res)
+    sandbox_id = res["id"]
+    _ok("created sandbox collection #{} {!r}".format(sandbox_id, sandbox_name))
+
+    # 2. iac.apply with a card + a dashboard that forward-references the card
+    #    by name — covers card_name resolution, executor reorder, and the
+    #    end-to-end create path.
+    db_id = _pick_first_db(mb)
+    spec = iac.CollectionSpec(
+        name=sandbox_name,                      # match the live sandbox
+        cards=[iac.CardSpec(
+            name="Test card",
+            definition={
+                "dataset_query": {
+                    "type": "native",
+                    "database": db_id,
+                    "native": {"query": "SELECT 1 AS one"},
+                },
+                "display": "scalar",
+                "visualization_settings": {},
+            },
+        )],
+        dashboards=[iac.DashboardSpec(
+            name="Test dashboard",
+            parameters=[],
+            dashcards=[{
+                "id": -1,
+                "card_name": "Test card",       # forward reference
+                "row": 0, "col": 0, "size_x": 24, "size_y": 8,
+                "parameter_mappings": [],
+                "visualization_settings": {},
+            }],
+        )],
+    )
+    parent_id = None  # sandbox lives at Root
+    p = iac.apply(mb, spec, parent_id=parent_id)
+    assert any(a.op == "create" for a in p.actions), \
+        "expected creates in fresh apply, got: {}".format(p.summary())
+    _ok("iac.apply -> {}".format(p.summary()))
+
+    # 3. Re-plan must be all-skip (idempotency on a live instance — covers
+    #    the dashcard card_name resolution at plan time).
+    p2 = iac.plan(mb, spec, parent_id=parent_id)
+    if not all(a.op == "skip" for a in p2.actions):
+        raise AssertionError(
+            "iac.plan after apply is NOT idempotent:\n{}".format(p2.render())
+        )
+    _ok("re-plan: all-skip (idempotent on live)")
+
+    # 4. add_card_to_dashboard — exercises the legacy POST or the modern PUT
+    #    fallback, depending on the Metabase version. We append a SECOND
+    #    dashcard pointing at the same card.
+    test_dash_id = _find_child(mb, sandbox_id, "dashboard", "Test dashboard")
+    test_card_id = _find_child(mb, sandbox_id, "card", "Test card")
+    mb.add_card_to_dashboard(card_id=test_card_id, dashboard_id=test_dash_id)
+    refreshed = mb.get("/api/dashboard/{}".format(test_dash_id)) or {}
+    dashcards = refreshed.get("dashcards") or refreshed.get("ordered_cards") or []
+    assert len(dashcards) >= 2, (
+        "add_card_to_dashboard didn't append a card; "
+        "dashcards={}".format(len(dashcards))
+    )
+    _ok("add_card_to_dashboard appended a card; dashboard now has {} dashcards"
+        .format(len(dashcards)))
+
+    # 5. (optional) copy_dashboard with deepcopy — covers the rstrip → suffix
+    #    fix. The source dashboard is read-only.
+    if source_dashboard_id is not None:
+        copied_id, q_coll_id, q_ids = mb.copy_dashboard(
+            source_dashboard_id=source_dashboard_id,
+            destination_collection_id=sandbox_id,
+            destination_dashboard_name="Copied dashboard",
+            deepcopy=True,
+        )
+        _ok("copy_dashboard deepcopy: dashboard #{} + {} questions in "
+            "collection #{}".format(copied_id, len(q_ids or []), q_coll_id))
+    else:
+        _skip("copy_dashboard deepcopy: no --source-dashboard-id passed")
+
+    return sandbox_id
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — cleanup
+# ---------------------------------------------------------------------------
+
+def cleanup(mb: Metabase_API, sandbox_id: int, keep: bool) -> None:
+    _step("Phase 3: cleanup")
+    if keep:
+        _skip("--keep-sandbox set; sandbox #{} left behind".format(sandbox_id))
+        return
+    try:
+        mb.move_to_archive("collection", item_id=sandbox_id)
+        _ok("sandbox collection #{} archived".format(sandbox_id))
+    except Exception as exc:
+        _fail("could not archive sandbox #{}: {}. Archive it manually."
+              .format(sandbox_id, exc))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--domain", required=True, help="Metabase URL")
+    parser.add_argument("--email", help="Metabase email (or METABASE_EMAIL)")
+    parser.add_argument("--password", help="Metabase password (or METABASE_PASSWORD)")
+    parser.add_argument("--session-id", help="Session id (or METABASE_SESSION_ID)")
+    parser.add_argument(
+        "--collection",
+        help="Existing collection name or id, used for the iac.export "
+             "idempotency check (read-only)",
+    )
+    parser.add_argument(
+        "--source-dashboard-id", type=int,
+        help="An existing dashboard id to test copy_dashboard(deepcopy=True). "
+             "The original is read-only.",
+    )
+    parser.add_argument(
+        "--keep-sandbox", action="store_true",
+        help="Don't archive the sandbox collection at the end",
+    )
+    args = parser.parse_args()
+
+    print("Connecting to {} ...".format(args.domain))
+    mb = Metabase_API(
+        domain=args.domain,
+        email=args.email or os.environ.get("METABASE_EMAIL") or None,
+        password=args.password or os.environ.get("METABASE_PASSWORD") or None,
+        session_id=args.session_id or os.environ.get("METABASE_SESSION_ID") or None,
+    )
+
+    sandbox_id: Optional[int] = None
+    failed_with: Optional[BaseException] = None
+    try:
+        phase1_readonly(mb, args.collection)
+        sandbox_id = phase2_sandbox(mb, args.source_dashboard_id)
+    except AssertionError as exc:
+        _fail(str(exc))
+        failed_with = exc
+    except Exception as exc:  # noqa: BLE001 — we want to surface anything
+        _fail("unexpected error: {}: {}".format(type(exc).__name__, exc))
+        failed_with = exc
+    finally:
+        if sandbox_id is not None:
+            cleanup(mb, sandbox_id, keep=args.keep_sandbox)
+
+    print()
+    if failed_with is not None:
+        print("Integration tests FAILED.")
+        return 1
+    print("All integration tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope

**2/3 du split de #12.** Nouveau module `spark_metabase_api.iac` : déclare un arbre collections / dashboards / cards en YAML, applique idempotemment avec un diff style Terraform.

> Cette PR est basée sur **#13** (bugfixes + alignement Metabase). À merger en 2e.

Bump 0.1.14 → **0.2.0**.

## Surface

```python
from spark_metabase_api import Metabase_API, iac

mb = Metabase_API(domain=..., session_id=...)

# Pull
spec = iac.export(mb, "Acme Customer")
iac.dump(spec, "specs/acme.yaml")

# Edit + plan
spec = iac.load("specs/acme.yaml")
print(iac.plan(mb, spec).render())

# Apply
iac.apply(mb, spec)
```

CLI :

```bash
pip install "spark-metabase-api[iac]"  # PyYAML — sinon fallback JSON
spark-metabase --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
    export "Acme Customer" specs/acme.yaml
spark-metabase plan specs/acme.yaml
spark-metabase apply specs/acme.yaml --yes
```

## Choix de design

- Items identifiés par `(parent_path, kind, name)`. Renames = destructifs ; passer `entity_id` (nanoid stable Metabase depuis 0.46) pour binder un spec à un item live à travers un rename.
- `cards` / `dashboards` / `dashcards` opaques — pas d'interprétation MBQL côté lib.
- Forward-references `card_name → card_id` résolues à apply time : un même spec peut créer des cards et un dashboard qui les référence par nom.
- PyYAML extra : `pip install spark-metabase-api[iac]`. Fallback JSON natif sinon.
- Wrapping autour de `create_collection`, `create_card`, `post`, `put` — pas de duplication de la surface existante.

## Bugs fixés vs. la version originale de #12

1. **Phantom-sibling matching** : `_plan_collection` avec `parent_id=None` faisait scanner la racine, ce qui pouvait fausser-matcher un homonyme. Refacto : helper `_plan_creates_only` qui émet tout le subtree pending en `create` sans interroger Metabase. Couvert par smoke test in-memory.
2. **`_significant_card_diff` étendu** : itère désormais sur `_CARD_OPAQUE_KEYS` (au lieu de 4 clés hardcodées). Plan et apply ne divergent plus sur `parameters`, `parameter_mappings`, `cache_ttl`.
3. **`result_metadata` retiré** de `_CARD_OPAQUE_KEYS` (server-computed, écrasait la version fraîchement calculée). `archived` aussi retiré (filtré à l'export, toujours False sur round-trip).

## Tests

- `tests/integration_test.py` (3 phases : read-only / sandbox writes / cleanup avec archive dans un `finally`).
- Smoke tests in-memory pour les 3 fixes ci-dessus (validés localement, à transformer en pytest dans une PR de cleanup).

## Test plan

- [x] AST + import smoke test
- [x] CLI `--help` propre
- [x] Round-trip `dump → load` JSON
- [x] Phantom-sibling smoke test (Parent inexistant + homonyme à la racine ⇒ create+create, pas create+skip)
- [x] `_significant_card_diff` détecte un changement de `parameters`
- [x] `result_metadata` et `archived` absents de `_CARD_OPAQUE_KEYS`
- [ ] Run intégration sur Metabase 0.49 / 0.51 / 0.57 / 0.61 via `tests/integration_test.py`
- [ ] `iac export → plan → apply → plan = all skips` sur une vraie collection de staging

## Limites laissées

- `apply()` redécouvre une partie de l'arbre déjà parcouru par `plan()` (perf, pas correctness).
- Pas de tests unitaires pytest formels (uniquement script d'intégration live).
- `_resolve_card_names` ne supporte pas les forward-references inter-collections (uniquement intra-collection).

## Hors scope (PR à venir)

- Chatbot + Streamlit → #12c (basée sur cette branche).

🤖 Generated with [Claude Code](https://claude.com/claude-code)