### PR TITLE
Chatbot module + Streamlit frontend (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,10 @@
 * Forward references in dashcards: a dashcard can reference a card created by the same spec via `card_name: "<name>"`; the applier resolves it to a `card_id` at apply time.
 * Integration test script `tests/integration_test.py` with read-only / sandbox / cleanup phases.
 * README rewritten with a worked IaC example.
+## 0.3.0 (2026-05-08)
+### Added
+* New **chatbot** module `spark_metabase_api.chatbot`: Claude Opus 4.7 with tool-use that inspects a live Metabase instance and emits a `CollectionSpec` from a natural-language brief. Exposes `chat()` (blocking) and `stream()` (generator yielding `text` / `tool_call` / `tool_result` / `proposed` events for live UIs). `anthropic` is an optional extra (`pip install spark-metabase-api[chatbot]`).
+* New **Streamlit** frontend (`streamlit_app.py`): live chat UX with sidebar credentials, expandable tool-call results, spec review, and Apply button. Optional extra (`pip install spark-metabase-api[streamlit]`).
+* `tests/integration_test.py` gains an optional Phase 3 (`--chatbot`) that runs the agent end-to-end without applying the spec.
+### Fixed
+* `chatbot.stream` passes `cache_control` on the system block (per Anthropic SDK docs) instead of as a top-level kwarg to `tool_runner` (where it was silently ignored — no cache hit, larger bills).

--- a/README.md
+++ b/README.md
@@ -99,22 +99,77 @@ A dashcard can reference a card created by the same spec via
 the cards present (or just created) inside the same collection and rewrites
 the dashcard with the real id.
 
+## Natural-language dashboard authoring
+
+```bash
+pip install "spark-metabase-api[chatbot]"
+```
+
+Describe what you want; Claude inspects the live Metabase via read-only tools
+(`list_databases`, `list_tables`, `describe_table`, `search_metabase`,
+`find_cards_using_table`) and emits a `CollectionSpec`:
+
+```python
+from spark_metabase_api import Metabase_API, iac
+from spark_metabase_api.chatbot import chat
+
+mb = Metabase_API(domain=..., session_id=...)
+spec = chat(mb, "Build an Acme dashboard with monthly revenue and top accounts")
+print(iac.plan(mb, spec).render())
+iac.apply(mb, spec)
+```
+
+For UIs (Streamlit, Slack, etc.) use the streaming generator:
+
+```python
+from spark_metabase_api.chatbot import stream
+
+for event_type, payload in stream(mb, "..."):
+    if event_type == "text":          render_assistant_text(payload)
+    elif event_type == "tool_call":   render_tool_call(payload)      # {name, input}
+    elif event_type == "tool_result": render_tool_result(payload)    # {name, input, result}
+    elif event_type == "proposed":    save_spec(payload)             # CollectionSpec dict
+```
+
+Powered by Claude Opus 4.7 with adaptive thinking; the model needs an
+`ANTHROPIC_API_KEY` environment variable.
+
+### Streamlit frontend
+
+A single-file Streamlit app that wires the chatbot to a chat UI with live
+tool-call rendering, plan diffing, and an Apply button.
+
+```bash
+pip install "spark-metabase-api[streamlit]"
+streamlit run streamlit_app.py
+```
+
+The app:
+- collects Metabase + Anthropic credentials in the sidebar,
+- streams Claude's progress (text, tool calls, expandable tool results) as
+  the agent works,
+- renders the proposed spec as YAML,
+- previews the diff via `iac.plan` and applies it on demand.
+
 ## Integration tests
 
 A standalone script exercises the package against a live Metabase instance,
-in three phases with a sandboxed write area that's archived on exit:
+in four phases with a sandboxed write area that's archived on exit:
 
 ```bash
 python tests/integration_test.py \
     --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" \
     --collection "My Reports" \
-    --source-dashboard-id 42
+    --source-dashboard-id 42 \
+    --chatbot
 ```
 
 Phase 1 is fully read-only. Phase 2 creates a uniquely-named throwaway
 collection, applies a tiny spec, exercises `add_card_to_dashboard` and
 `copy_dashboard(deepcopy=True)`, then archives the sandbox in a `finally`
 block (use `--keep-sandbox` to keep it around for manual inspection).
+Phase 3 (opt-in via `--chatbot`) runs the Claude agent but does *not*
+apply the spec it proposes.
 
 ## Acknowledgements
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spark-metabase-api",
-    version="0.2.0",
+    version="0.3.0",
     author="Larry Page",
     author_email="tech@spark.do",
     description="A Python wrapper for the Metabase API developed by the ⭐️ Spark Tech team",
@@ -18,6 +18,8 @@ setuptools.setup(
     ],
     extras_require={
         "iac": ["PyYAML>=5.1"],
+        "chatbot": ["anthropic>=0.40.0"],
+        "streamlit": ["streamlit>=1.30", "PyYAML>=5.1", "anthropic>=0.40.0"],
     },
     entry_points={
         "console_scripts": [

--- a/spark_metabase_api/chatbot.py
+++ b/spark_metabase_api/chatbot.py
@@ -1,0 +1,419 @@
+"""Natural-language dashboard authoring for Metabase.
+
+Powered by Claude with tool-use (Anthropic SDK). Takes a natural-language
+brief, inspects a live Metabase instance via read-only tools, and produces a
+`spark_metabase_api.iac.CollectionSpec` you can review and apply.
+
+This module is an optional extra:
+
+    pip install "spark-metabase-api[chatbot]"
+
+Typical usage:
+
+    from spark_metabase_api import Metabase_API, iac
+    from spark_metabase_api.chatbot import chat
+
+    mb = Metabase_API(domain=..., session_id=...)
+    spec = chat(mb, "Build an Acme dashboard with monthly revenue and top accounts")
+    print(iac.plan(mb, spec).render())
+    iac.apply(mb, spec)
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+
+try:  # anthropic is an optional extra
+    import anthropic  # type: ignore
+    from anthropic import beta_tool  # type: ignore
+except ImportError:  # pragma: no cover - exercised when anthropic absent
+    anthropic = None  # type: ignore
+    beta_tool = None  # type: ignore
+
+from . import iac
+from .iac import CollectionSpec
+
+
+SYSTEM_PROMPT = """You are a Metabase dashboard architect.
+
+Given a natural-language brief, you inspect a live Metabase instance via
+read-only tools, then emit a complete dashboard spec for the user to review
+and apply. You operate on real data: never invent column names or table ids.
+
+# Workflow (in order)
+1. `list_databases` — see what databases are connected.
+2. `list_tables(database_id)` — explore the relevant database.
+3. `describe_table(table_id)` — get column names, types, and ids. **Always do
+   this before writing SQL — never guess column names.**
+4. (optional) `search_metabase(query)` and
+   `find_cards_using_table(schema_name, table_name)` — check whether suitable
+   cards already exist before duplicating work.
+5. `propose_dashboard_spec(spec)` — call this exactly once at the end with
+   the complete spec. After this tool returns, your job is done.
+
+# Rules
+- Never hallucinate column names. If `describe_table` did not confirm a name,
+  it does not exist.
+- Prefer native SQL queries (`type: "native"`) — simpler and more durable
+  than MBQL. Match the database's SQL dialect (engine field).
+- A typical dashboard has 4-12 cards. Prefer a few well-chosen cards over
+  many redundant ones.
+- Metabase's dashboard grid is 24 columns wide. Stack cards vertically with
+  `row`/`col`/`size_x`/`size_y`. A full-width card is `size_x: 24, size_y: 8`.
+- Reference cards in dashcards either by `card_id: <int>` (an existing
+  Metabase card) or `card_name: "<name>"` (forward-reference to a card you
+  define in the same `cards` array).
+
+# CollectionSpec shape
+```json
+{
+  "name": "string (collection name)",
+  "description": "optional string",
+  "authority_level": null,
+  "collections": [],
+  "cards": [
+    {
+      "name": "Daily revenue",
+      "description": "optional",
+      "definition": {
+        "dataset_query": {
+          "type": "native",
+          "database": 1,
+          "native": {"query": "SELECT day, sum(amount) FROM sales GROUP BY 1"}
+        },
+        "display": "line",
+        "visualization_settings": {}
+      }
+    }
+  ],
+  "dashboards": [
+    {
+      "name": "Acme Overview",
+      "description": "optional",
+      "parameters": [],
+      "dashcards": [
+        {
+          "id": -1,
+          "card_name": "Daily revenue",
+          "row": 0, "col": 0, "size_x": 24, "size_y": 8,
+          "parameter_mappings": [],
+          "visualization_settings": {}
+        }
+      ]
+    }
+  ]
+}
+```
+"""
+
+
+def _require_anthropic() -> None:
+    if anthropic is None:
+        raise ImportError(
+            "The chatbot module requires the 'anthropic' package. "
+            "Install with: pip install spark-metabase-api[chatbot]"
+        )
+
+
+def _build_tools(
+    metabase,
+    on_propose: Callable[[Dict[str, Any]], None],
+    on_tool_call: Optional[Callable[[str, Dict[str, Any], str], None]] = None,
+) -> List[Any]:
+    """Build the agent's read-only inspection tools + the propose-spec sink.
+
+    `on_propose(spec)` is called when the agent emits the final spec.
+    `on_tool_call(name, input, result)` (optional) is called after every
+    inspection tool returns, for UI logging.
+    """
+
+    def _record(name: str, input: Dict[str, Any], result: str) -> str:
+        if on_tool_call is not None:
+            on_tool_call(name, input, result)
+        return result
+
+    @beta_tool
+    def list_databases() -> str:
+        """List the Metabase-connected databases.
+
+        Returns a JSON array of {id, name, engine, description} entries.
+        Use the engine field to know which SQL dialect to write."""
+        res = metabase.get("/api/database/")
+        if isinstance(res, dict):
+            res = res.get("data", [])
+        items = [
+            {
+                "id": d.get("id"),
+                "name": d.get("name"),
+                "engine": d.get("engine"),
+                "description": d.get("description"),
+            }
+            for d in (res or [])
+        ]
+        return _record("list_databases", {}, json.dumps(items, ensure_ascii=False))
+
+    @beta_tool
+    def list_tables(database_id: int) -> str:
+        """List tables for a Metabase database.
+
+        Args:
+            database_id: id of the database (from list_databases)
+
+        Returns a JSON array of {id, name, schema, display_name, description}."""
+        info = metabase.get(
+            "/api/database/{}".format(database_id),
+            params={"include": "tables"},
+        ) or {}
+        tables = info.get("tables") or []
+        items = [
+            {
+                "id": t.get("id"),
+                "name": t.get("name"),
+                "schema": t.get("schema"),
+                "display_name": t.get("display_name"),
+                "description": t.get("description"),
+            }
+            for t in tables
+        ]
+        return _record(
+            "list_tables",
+            {"database_id": database_id},
+            json.dumps(items, ensure_ascii=False),
+        )
+
+    @beta_tool
+    def describe_table(table_id: int) -> str:
+        """Get the columns of a Metabase table.
+
+        Args:
+            table_id: id of the table (from list_tables)
+
+        Returns JSON {table: {...}, fields: [{id, name, base_type,
+        semantic_type, description}, ...]}. Use the exact column names from
+        this response in any SQL you write — never guess."""
+        meta = metabase.get_table_metadata(table_id=table_id) or {}
+        fields = [
+            {
+                "id": f.get("id"),
+                "name": f.get("name"),
+                "base_type": f.get("base_type"),
+                "semantic_type": f.get("semantic_type"),
+                "description": f.get("description"),
+            }
+            for f in (meta.get("fields") or [])
+        ]
+        payload = {
+            "table": {
+                "id": meta.get("id"),
+                "name": meta.get("name"),
+                "schema": meta.get("schema"),
+                "description": meta.get("description"),
+                "db_id": meta.get("db_id"),
+            },
+            "fields": fields,
+        }
+        return _record(
+            "describe_table",
+            {"table_id": table_id},
+            json.dumps(payload, ensure_ascii=False),
+        )
+
+    @beta_tool
+    def search_metabase(query: str, item_type: Optional[str] = None) -> str:
+        """Search existing Metabase items by name.
+
+        Args:
+            query: search string
+            item_type: optional filter ('card', 'dashboard', 'collection',
+                       'table', 'segment', 'metric')
+
+        Returns a JSON array of {id, name, model, collection_id} entries."""
+        results = metabase.search(query, item_type=item_type) or []
+        items = [
+            {
+                "id": r.get("id"),
+                "name": r.get("name"),
+                "model": r.get("model"),
+                "collection_id": r.get("collection_id"),
+            }
+            for r in results
+        ]
+        return _record(
+            "search_metabase",
+            {"query": query, "item_type": item_type},
+            json.dumps(items, ensure_ascii=False),
+        )
+
+    @beta_tool
+    def find_cards_using_table(schema_name: str, table_name: str) -> str:
+        """Find existing native-SQL cards that reference schema.table.
+
+        Useful before authoring new SQL — if a card already provides what
+        the brief asks for, reuse it instead of duplicating it.
+
+        Args:
+            schema_name: database schema name
+            table_name: table name
+
+        Returns a JSON array of {id, name} for matching cards."""
+        infos = metabase.find_cards_via_db_object(
+            schema_name=schema_name, table_name=table_name,
+        ) or []
+        return _record(
+            "find_cards_using_table",
+            {"schema_name": schema_name, "table_name": table_name},
+            json.dumps(infos, ensure_ascii=False),
+        )
+
+    @beta_tool
+    def propose_dashboard_spec(spec: Dict[str, Any]) -> str:
+        """Emit the final CollectionSpec. Call this exactly once.
+
+        Args:
+            spec: a dict matching the CollectionSpec shape from the system
+                  prompt. Must include 'name'. Should include at least one
+                  card or dashboard.
+
+        Returns 'ok' on success, an error string otherwise."""
+        if not isinstance(spec, dict):
+            return "Error: spec must be a JSON object."
+        if not spec.get("name"):
+            return "Error: spec must include a 'name' field."
+        if not (spec.get("cards") or spec.get("dashboards") or spec.get("collections")):
+            return ("Error: spec must include at least one card, dashboard, "
+                    "or nested collection — empty specs are not useful.")
+        on_propose(spec)
+        return "ok"
+
+    return [
+        list_databases,
+        list_tables,
+        describe_table,
+        search_metabase,
+        find_cards_using_table,
+        propose_dashboard_spec,
+    ]
+
+
+# Event tuple types yielded by `stream`. Kept as plain tuples so callers don't
+# need to import any class — easy to pattern-match in a UI loop.
+ChatEvent = Tuple[str, Any]
+#   ("text",        str)              — assistant prose
+#   ("tool_call",   {"name", "input"}) — agent invoked a tool
+#   ("tool_result", {"name", "input", "result"}) — tool returned (truncated str)
+#   ("proposed",    dict)              — final CollectionSpec dict (last event)
+
+
+def stream(
+    metabase,
+    prompt: str,
+    *,
+    model: str = "claude-opus-4-7",
+    max_tokens: int = 8192,
+    anthropic_client: Optional[Any] = None,
+) -> Iterator[ChatEvent]:
+    """Run the agent and yield events as they happen.
+
+    Use this to drive a UI that updates as Claude works (e.g. Streamlit).
+    For a blocking call that just returns the final spec, use ``chat()``.
+    """
+    _require_anthropic()
+    client = anthropic_client or anthropic.Anthropic()
+
+    proposed: Dict[str, Any] = {}
+    pending_tool_results: List[Dict[str, Any]] = []
+
+    def _on_propose(spec: Dict[str, Any]) -> None:
+        proposed.clear()
+        proposed.update(spec)
+
+    def _on_tool_call(name: str, input: Dict[str, Any], result: str) -> None:
+        # Truncate large results so the UI stays readable; the agent still
+        # sees the full result via the tool runner.
+        snippet = result if len(result) <= 4000 else result[:4000] + "...[truncated]"
+        pending_tool_results.append({"name": name, "input": input, "result": snippet})
+
+    tools = _build_tools(metabase, on_propose=_on_propose, on_tool_call=_on_tool_call)
+
+    runner = client.beta.messages.tool_runner(
+        model=model,
+        max_tokens=max_tokens,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "xhigh"},
+        system=[{
+            "type": "text",
+            "text": SYSTEM_PROMPT,
+            "cache_control": {"type": "ephemeral"},
+        }],
+        tools=tools,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    for message in runner:
+        # Drain results from tool calls executed since the previous message.
+        while pending_tool_results:
+            yield ("tool_result", pending_tool_results.pop(0))
+        for block in message.content:
+            btype = getattr(block, "type", None)
+            if btype == "text" and getattr(block, "text", ""):
+                yield ("text", block.text)
+            elif btype == "tool_use":
+                yield ("tool_call", {
+                    "name": block.name,
+                    "input": dict(block.input or {}),
+                })
+
+    while pending_tool_results:
+        yield ("tool_result", pending_tool_results.pop(0))
+
+    if proposed:
+        yield ("proposed", dict(proposed))
+
+
+def chat(
+    metabase,
+    prompt: str,
+    *,
+    model: str = "claude-opus-4-7",
+    max_tokens: int = 8192,
+    anthropic_client: Optional[Any] = None,
+    verbose: bool = True,
+) -> CollectionSpec:
+    """Run a Claude tool-use session that produces a CollectionSpec.
+
+    Blocking convenience wrapper around ``stream()``. Returns the final spec.
+
+    Keyword arguments:
+    metabase -- a configured Metabase_API instance
+    prompt -- natural-language description of the dashboard to build
+    model -- Claude model id (default 'claude-opus-4-7')
+    max_tokens -- per-turn output cap (default 8192)
+    anthropic_client -- optional pre-built anthropic.Anthropic
+    verbose -- print Claude's progress to stdout (default True)
+
+    Raises RuntimeError if the agent finished without proposing a spec.
+    """
+    spec_dict: Optional[Dict[str, Any]] = None
+    for event_type, payload in stream(
+        metabase, prompt,
+        model=model, max_tokens=max_tokens,
+        anthropic_client=anthropic_client,
+    ):
+        if event_type == "proposed":
+            spec_dict = payload
+        elif verbose and event_type == "text":
+            print(payload)
+        elif verbose and event_type == "tool_call":
+            args = ", ".join(
+                "{}={}".format(k, json.dumps(v, ensure_ascii=False)[:80])
+                for k, v in payload["input"].items()
+            )
+            print("    → {}({})".format(payload["name"], args))
+
+    if spec_dict is None:
+        raise RuntimeError(
+            "The agent finished without calling propose_dashboard_spec. "
+            "Try a more concrete brief, or re-run with a higher max_tokens."
+        )
+
+    return iac.spec_from_dict(spec_dict)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,285 @@
+"""Streamlit frontend for the spark-metabase-api chatbot.
+
+Launch with:
+    pip install "spark-metabase-api[chatbot,streamlit,iac]"
+    streamlit run streamlit_app.py
+
+Workflow:
+    1. Configure Metabase + Anthropic credentials in the sidebar.
+    2. Type a natural-language brief in the chat box.
+    3. Watch Claude inspect the live Metabase metadata and emit a spec.
+    4. Review the proposed spec and the diff (iac.plan).
+    5. Click Apply to write the spec to Metabase.
+"""
+from __future__ import annotations
+
+import json
+import os
+import traceback
+from typing import Any, Dict, List, Tuple
+
+import streamlit as st
+
+try:  # anthropic is provided by the [streamlit] extra; fail clearly if missing
+    import anthropic
+except ImportError:  # pragma: no cover
+    anthropic = None  # type: ignore
+
+from spark_metabase_api import Metabase_API, chatbot, iac
+
+
+# ---------------------------------------------------------------------------
+# Page setup
+# ---------------------------------------------------------------------------
+
+st.set_page_config(
+    page_title="Metabase dashboard authoring",
+    page_icon=":chart_with_upwards_trend:",
+    layout="wide",
+)
+st.title("Metabase dashboard authoring")
+st.caption(
+    "Describe the dashboard you want; Claude inspects your Metabase, "
+    "proposes a spec, you review and apply."
+)
+
+
+# ---------------------------------------------------------------------------
+# Session state
+# ---------------------------------------------------------------------------
+
+def _init_state() -> None:
+    defaults: Dict[str, Any] = {
+        "metabase": None,         # connected Metabase_API instance
+        "anthropic_client": None, # configured anthropic.Anthropic (per session)
+        "history": [],            # list of (role, content) — chat transcript
+        "proposed_spec": None,    # CollectionSpec produced by Claude
+        "plan": None,             # iac.Plan computed from the spec
+        "applied": False,         # whether the spec was applied
+    }
+    for k, v in defaults.items():
+        st.session_state.setdefault(k, v)
+
+
+_init_state()
+
+
+# ---------------------------------------------------------------------------
+# Sidebar — credentials and connection
+# ---------------------------------------------------------------------------
+
+with st.sidebar:
+    st.header("Metabase")
+    domain = st.text_input(
+        "Metabase URL",
+        value=os.environ.get("METABASE_DOMAIN", ""),
+        placeholder="https://metabase.example.com",
+    )
+    auth_mode = st.radio(
+        "Auth mode",
+        options=["Email + password", "Session id"],
+        horizontal=True,
+    )
+    email = password = session_id = None
+    if auth_mode == "Email + password":
+        email = st.text_input(
+            "Email", value=os.environ.get("METABASE_EMAIL", "")
+        )
+        password = st.text_input(
+            "Password", type="password", value=os.environ.get("METABASE_PASSWORD", "")
+        )
+    else:
+        session_id = st.text_input(
+            "Session id", value=os.environ.get("METABASE_SESSION_ID", "")
+        )
+
+    if st.button("Connect to Metabase", use_container_width=True):
+        try:
+            st.session_state.metabase = Metabase_API(
+                domain=domain,
+                email=email or None,
+                password=password or None,
+                session_id=session_id or None,
+            )
+            st.success("Connected.")
+        except Exception as exc:  # pragma: no cover - UI feedback
+            st.session_state.metabase = None
+            st.error("Connection failed: {}".format(exc))
+
+    st.divider()
+    st.header("Anthropic")
+    if anthropic is None:
+        st.error(
+            "The `anthropic` package is not installed. "
+            "Run: pip install \"spark-metabase-api[streamlit]\""
+        )
+    api_key = st.text_input(
+        "API key",
+        type="password",
+        value=os.environ.get("ANTHROPIC_API_KEY", ""),
+        help="Stored only in this session's memory; never written to disk "
+             "or to the process environment.",
+    )
+    if api_key and anthropic is not None:
+        # Build a dedicated client for this session — do NOT touch os.environ
+        # (the Streamlit process is shared across user sessions in any
+        # multi-user deployment, so a global env var leaks across them).
+        st.session_state.anthropic_client = anthropic.Anthropic(api_key=api_key)
+    elif not api_key:
+        st.session_state.anthropic_client = None
+
+    model = st.selectbox(
+        "Model",
+        options=["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
+        index=0,
+        help="Opus 4.7 is the default; Sonnet 4.6 is cheaper for simpler briefs.",
+    )
+
+    st.divider()
+    if st.button("Reset conversation", use_container_width=True):
+        st.session_state.history = []
+        st.session_state.proposed_spec = None
+        st.session_state.plan = None
+        st.session_state.applied = False
+        st.rerun()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _format_args(input_dict: Dict[str, Any]) -> str:
+    parts = []
+    for k, v in input_dict.items():
+        rendered = json.dumps(v, ensure_ascii=False)
+        if len(rendered) > 80:
+            rendered = rendered[:77] + "..."
+        parts.append("{}={}".format(k, rendered))
+    return ", ".join(parts)
+
+
+def _render_event(event_type: str, payload: Any) -> None:
+    """Render a single chat event in the assistant's bubble."""
+    if event_type == "text":
+        st.markdown(payload)
+    elif event_type == "tool_call":
+        st.markdown(
+            ":wrench: **{}**({})".format(payload["name"], _format_args(payload["input"]))
+        )
+    elif event_type == "tool_result":
+        with st.expander(":receipt: {} returned".format(payload["name"]), expanded=False):
+            try:
+                parsed = json.loads(payload["result"])
+                st.json(parsed)
+            except (TypeError, ValueError):
+                st.code(payload["result"])
+    elif event_type == "proposed":
+        st.success(":white_check_mark: Spec proposed.")
+
+
+def _spec_to_yaml_or_json(spec: iac.CollectionSpec) -> str:
+    try:
+        import yaml  # type: ignore
+
+        return yaml.safe_dump(iac.spec_to_dict(spec), sort_keys=False, allow_unicode=True)
+    except ImportError:
+        return json.dumps(iac.spec_to_dict(spec), indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Replay the conversation
+# ---------------------------------------------------------------------------
+
+for role, blocks in st.session_state.history:
+    with st.chat_message(role):
+        if role == "user":
+            st.markdown(blocks)
+        else:
+            for ev_type, payload in blocks:
+                _render_event(ev_type, payload)
+
+
+# ---------------------------------------------------------------------------
+# Live agent run (only fires when user submits a new prompt)
+# ---------------------------------------------------------------------------
+
+prompt = st.chat_input(
+    "Describe the dashboard to build (e.g. 'Acme overview with monthly revenue and top accounts')"
+)
+
+if prompt:
+    if st.session_state.metabase is None:
+        st.error("Connect to Metabase first (sidebar).")
+        st.stop()
+    if st.session_state.anthropic_client is None:
+        st.error("Provide your Anthropic API key (sidebar).")
+        st.stop()
+
+    st.session_state.history.append(("user", prompt))
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    rendered_events: List[Tuple[str, Any]] = []
+    with st.chat_message("assistant"):
+        try:
+            for ev_type, payload in chatbot.stream(
+                st.session_state.metabase,
+                prompt,
+                model=model,
+                anthropic_client=st.session_state.anthropic_client,
+            ):
+                rendered_events.append((ev_type, payload))
+                _render_event(ev_type, payload)
+                if ev_type == "proposed":
+                    st.session_state.proposed_spec = iac.spec_from_dict(payload)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            st.error("Agent crashed: {}".format(exc))
+            with st.expander("Traceback"):
+                st.code(traceback.format_exc())
+
+    st.session_state.history.append(("assistant", rendered_events))
+    # Reset plan / apply state so the new spec gets a fresh review.
+    st.session_state.plan = None
+    st.session_state.applied = False
+
+
+# ---------------------------------------------------------------------------
+# Review & apply
+# ---------------------------------------------------------------------------
+
+spec = st.session_state.proposed_spec
+if spec is not None:
+    st.divider()
+    st.subheader("Proposed spec")
+    st.code(_spec_to_yaml_or_json(spec), language="yaml")
+
+    col_plan, col_apply = st.columns(2)
+
+    with col_plan:
+        if st.button("Compute plan", use_container_width=True):
+            try:
+                st.session_state.plan = iac.plan(st.session_state.metabase, spec)
+            except Exception as exc:  # pragma: no cover - UI feedback
+                st.error("plan() failed: {}".format(exc))
+                with st.expander("Traceback"):
+                    st.code(traceback.format_exc())
+
+    if st.session_state.plan is not None:
+        st.subheader("Plan")
+        st.code(st.session_state.plan.render(), language="text")
+
+    with col_apply:
+        disabled = (
+            st.session_state.plan is None
+            or all(a.op == "skip" for a in st.session_state.plan.actions)
+            or st.session_state.applied
+        )
+        if st.button("Apply", type="primary", use_container_width=True, disabled=disabled):
+            try:
+                iac.apply(st.session_state.metabase, spec)
+                st.session_state.applied = True
+                st.success("Applied. Re-run plan to confirm idempotency.")
+            except Exception as exc:  # pragma: no cover - UI feedback
+                st.error("apply() failed: {}".format(exc))
+                with st.expander("Traceback"):
+                    st.code(traceback.format_exc())

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Integration tests for spark-metabase-api against a live Metabase instance.
 
-The script runs in 3 phases, each with a clear safety boundary:
+The script runs in 4 phases, each with a clear safety boundary:
 
     Phase 1  read-only checks   (auth, search, iac.export idempotency)
     Phase 2  sandbox writes     (creates a throwaway collection, applies a
                                  mini-spec, exercises add_card_to_dashboard
                                  and copy_dashboard's deepcopy path)
-    Phase 3  cleanup            (archive the sandbox; runs even on failure)
+    Phase 3  optional chatbot   (Claude proposes a spec — NOT applied)
+    Phase 4  cleanup            (archive the sandbox; runs even on failure)
 
 The sandbox is archived in a finally block so a crash mid-test doesn't leave
 junk behind. Pass --keep-sandbox to keep it around for manual inspection.
@@ -30,6 +31,9 @@ Usage:
     # copy_dashboard is exercised if you pass an existing dashboard id (the
     # original is read-only; a deep copy is made inside the sandbox):
     python tests/integration_test.py ... --source-dashboard-id 42
+
+    # Opt in to the chatbot phase (requires ANTHROPIC_API_KEY in env):
+    python tests/integration_test.py ... --chatbot
 
 Exit code is 0 on success, 1 on any failed assertion.
 """
@@ -259,11 +263,42 @@ def phase2_sandbox(
 
 
 # ---------------------------------------------------------------------------
-# Phase 3 — cleanup
+# Phase 3 — optional chatbot
+# ---------------------------------------------------------------------------
+
+def phase3_chatbot(mb: Metabase_API) -> None:
+    _step("Phase 3: chatbot end-to-end (read-only)")
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        _skip("ANTHROPIC_API_KEY is not set")
+        return
+    try:
+        from spark_metabase_api.chatbot import chat
+    except ImportError:
+        _skip("anthropic not installed (pip install spark-metabase-api[chatbot])")
+        return
+
+    print("  ... running the agent (~30-90s, ~$0.50 in API tokens)")
+    spec = chat(
+        mb,
+        "Build the smallest possible test spec: one collection named "
+        "'chatbot smoke test', containing a single card whose native SQL "
+        "query is exactly 'SELECT 1 AS one'. Pick database id 1 if it "
+        "exists, otherwise the first database returned by list_databases. "
+        "Do NOT explore tables — keep the query as 'SELECT 1 AS one'.",
+        verbose=False,
+    )
+    assert spec.name, "chatbot returned a spec with no name"
+    assert spec.cards or spec.dashboards, "chatbot returned an empty spec"
+    _ok("chatbot proposed: {!r} ({} cards, {} dashboards) — NOT applied"
+        .format(spec.name, len(spec.cards), len(spec.dashboards)))
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — cleanup
 # ---------------------------------------------------------------------------
 
 def cleanup(mb: Metabase_API, sandbox_id: int, keep: bool) -> None:
-    _step("Phase 3: cleanup")
+    _step("Phase 4: cleanup")
     if keep:
         _skip("--keep-sandbox set; sandbox #{} left behind".format(sandbox_id))
         return
@@ -299,6 +334,10 @@ def main() -> int:
              "The original is read-only.",
     )
     parser.add_argument(
+        "--chatbot", action="store_true",
+        help="Also run the chatbot end-to-end (does NOT apply the spec)",
+    )
+    parser.add_argument(
         "--keep-sandbox", action="store_true",
         help="Don't archive the sandbox collection at the end",
     )
@@ -317,6 +356,8 @@ def main() -> int:
     try:
         phase1_readonly(mb, args.collection)
         sandbox_id = phase2_sandbox(mb, args.source_dashboard_id)
+        if args.chatbot:
+            phase3_chatbot(mb)
     except AssertionError as exc:
         _fail(str(exc))
         failed_with = exc


### PR DESCRIPTION
## Scope

**3/3 du split de #12.** Nouveau module `spark_metabase_api.chatbot` (agent Claude Opus 4.7 / tool-use) + frontend Streamlit single-file (`streamlit_app.py`).

> Cette PR est basée sur **#14** (IaC), elle-même basée sur **#13** (bugfixes). À merger en 3e.

Bump 0.2.0 → **0.3.0**.

## Surface

```python
from spark_metabase_api import Metabase_API, iac
from spark_metabase_api.chatbot import chat, stream

mb = Metabase_API(domain=..., session_id=...)

# Blocking
spec = chat(mb, "Build an Acme dashboard with monthly revenue and top accounts")
print(iac.plan(mb, spec).render())
iac.apply(mb, spec)

# Streaming (UI)
for event_type, payload in stream(mb, prompt):
    if event_type == "text":          render_text(payload)
    elif event_type == "tool_call":   render_tool_call(payload)
    elif event_type == "tool_result": render_tool_result(payload)
    elif event_type == "proposed":    save_spec(payload)
```

5 outils read-only exposés à Claude :
- `list_databases`
- `list_tables(database_id)`
- `describe_table(table_id)`
- `search_metabase(query, item_type=None)`
- `find_cards_using_table(schema_name, table_name)`

Plus le tool-sink final `propose_dashboard_spec(spec)` qui termine la session.

## Streamlit frontend

```bash
pip install "spark-metabase-api[streamlit]"
streamlit run streamlit_app.py
```

- credentials Metabase + Anthropic en sidebar (la clé Anthropic reste dans `st.session_state`, jamais en `os.environ` — safe pour un déploiement multi-user)
- streaming live des `text` / `tool_call` / `tool_result` au fur et à mesure
- review YAML du spec proposé
- bouton `Compute plan` (passe par `iac.plan`)
- bouton `Apply` (passe par `iac.apply`)

## Bug fixé vs. la version originale de #12

**`cache_control` mal placé.** Le code original passait `cache_control={"type": "ephemeral"}` en kwarg top-level de `tool_runner()` — silencieusement ignoré selon la doc Anthropic SDK (le param est attendu sur un content block, pas au top-level). Conséquence : aucun cache hit, factures Anthropic salées sur des sessions multi-tours.

Fix : `cache_control` posé sur le bloc `system` :
```python
system=[{
    "type": "text",
    "text": SYSTEM_PROMPT,
    "cache_control": {"type": "ephemeral"},
}]
```

Le system prompt fait ~1.5 kB de texte statique réutilisé à chaque tour de tool-use → cache hit massif.

## Extras

```bash
pip install "spark-metabase-api[chatbot]"   # anthropic
pip install "spark-metabase-api[streamlit]" # streamlit + anthropic + PyYAML
```

## Tests

Phase 3 ajoutée dans `tests/integration_test.py` :
```bash
python tests/integration_test.py ... --chatbot
```
Skip silencieux si `ANTHROPIC_API_KEY` absent ou si `anthropic` non installé. Ne fait que `chat()` puis assert sur le spec retourné — n'applique PAS le spec.

## Test plan

- [x] AST + import smoke test (chatbot importe sans `anthropic` installé)
- [x] `cache_control` retiré du top-level kwarg, posé sur le bloc system
- [x] `system=[{"type":"text",...}]` en list-of-blocks
- [x] `chat()` et `stream()` exposés
- [ ] Run `--chatbot` end-to-end sur Metabase de staging avec une vraie clé Anthropic
- [ ] Vérifier le cache hit dans les logs Anthropic (taux > 80% après le 1er tour)
- [ ] Vérifier que le Streamlit ne crash pas sur reset / reconnect
- [ ] Vérifier que la clé Anthropic ne fuite pas dans `os.environ` ni dans les logs

## Sécurité

⚠️ Le chatbot peut potentiellement émettre du SQL natif arbitraire dans le `dataset_query` du `CollectionSpec`. Si la connexion Metabase pointe sur une base où l'utilisateur a des droits d'écriture, un brief malveillant pourrait demander un `DROP TABLE`. Metabase n'autorise pas l'écriture en native SQL par défaut, mais à vérifier côté conf base avant déploiement public.

## Limites

- Pas de cap sur la sortie de `list_tables` (peut exploser le contexte sur des bases avec 1000+ tables).
- `cache_control` sur le bloc system uniquement — les `tools` (via `@beta_tool`) ne sont pas mis en cache (le décorateur ne porte pas le hint). À itérer si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)