### PR TITLE
feat: couche de validation pré-apply (validate.py) + préservation des campagnes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,7 @@ migration/audit-cache/
 migration/archive-empty-collections-*.json
 migration/empty-collections-review-*.csv
 migration/archive-collections-*.json
+migration/archive-stale-cards-*.json
+migration/stale-cards-review-*.csv
 # Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
 docs/audits/

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,7 @@ migration/rename-snapshot-*.json
 migration/xplat-snapshot-*.json
 migration/prune-candidates-*.json
 migration/dupes-report-*.json
+migration/audit-findings-*.json
+migration/audit-cache/
+# Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
+docs/audits/

--- a/.gitignore
+++ b/.gitignore
@@ -126,5 +126,6 @@ migration/audit-findings-*.json
 migration/audit-cache/
 migration/archive-empty-collections-*.json
 migration/empty-collections-review-*.csv
+migration/archive-collections-*.json
 # Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
 docs/audits/

--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,6 @@ migration/empty-collections-review-*.csv
 migration/archive-collections-*.json
 migration/archive-stale-cards-*.json
 migration/stale-cards-review-*.csv
+migration/swap-snapshot-*.json
 # Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
 docs/audits/

--- a/.gitignore
+++ b/.gitignore
@@ -124,5 +124,7 @@ migration/prune-candidates-*.json
 migration/dupes-report-*.json
 migration/audit-findings-*.json
 migration/audit-cache/
+migration/archive-empty-collections-*.json
+migration/empty-collections-review-*.csv
 # Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
 docs/audits/

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ migration/families.json
 migration/rename-snapshot-*.json
 migration/xplat-snapshot-*.json
 migration/prune-candidates-*.json
+migration/dupes-report-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,10 @@ migration/stale-cards-review-*.csv
 migration/swap-snapshot-*.json
 # Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
 docs/audits/
+# migration/ = runtime artifacts (snapshots, backups, before/after dumps, task SQL).
+# Ignore the data; keep the few real source files + the Airtable client mapping.
+migration/*
+!migration/*.py
+!migration/*.js
+!migration/*.yaml
+!migration/conv-client-mapping.json

--- a/docs/cleaning-roadmap.md
+++ b/docs/cleaning-roadmap.md
@@ -16,6 +16,7 @@
 - `scripts/audit.py` — `scan` → `deep` (cache reprenable) → `report`. Usage-aware (`last_used_at`/`view_count`/`average_query_time`).
 - `scripts/audit_lib.py` / `audit_report.py` — détecteurs, empreinte v2, scoring, rendu. 18 tests (`tests/test_audit_lib.py`, `test_audit_report.py`).
 - Exécuteurs (dry-run, re-vérif live, CSV de relecture, rollback) : `archive_empty_collections.py`, `archive_collections.py`, `archive_stale_cards.py`.
+- `swap_card_on_dashboards.py` + `swap_lib.py` (8 tests) : remplace une carte par sa canonique sur ses dashboards en recâblant les filtres, puis archive. Dry-run, `--difftest`, snapshot rollback, garde-fou tuile-en-double. **Dashboard-safe.**
 
 ## Campagnes par vague
 
@@ -25,7 +26,7 @@
 | 4 | Fourre-tout (set vert) | ✅ | 5 archivées | `archive_collections.py` ; test/POC dormants |
 | 5 | Cartes inutilisées périmées | ✅ | 315 archivées (≥1 an) | `archive_stale_cards.py` ; re-vérif live, exclut frozen ☠️ |
 | — | Usage replié dans l'audit | ✅ | — | `last_used_at`/`view_count`/`avg_query_time` ; 433 périmées repérées, #11 rempli |
-| 6 | Doublons fonctionnels | 🚧 | 156 groupes | fusion : archiver copies inutilisées d'abord, repointage dashboards ensuite (test diff.) |
+| 6 | Doublons fonctionnels | 🚧 | 156 groupes | **reframé** : 3 vrais doublons isolés (entangled), 39 en zone sensible, 111 cross-location = structure de propagation → relève de #8. Outil de swap prêt (dashboard-safe). Appliquer = décisions par-paire + cas tuile-en-double |
 | 11 | Cartes lentes | ⬜ | 213 | perf : fix-or-kill (plus lente = 224 s) |
 | 10 | Nommage hors template | ⬜ | 1919 | normalisation (étend Phase 1.5) |
 | 2 | Sprawl perso | ⬜ | 162 clients | sensible : sortir le travail client de l'espace perso |
@@ -46,6 +47,8 @@
 ## Garde-fous
 
 Toutes actions autorisées **mais validation avant chaque action** ; réversible d'abord (archivage, jamais suppression sans accord). Snapshot → (test différentiel) → échantillon → batch → invariant.
+
+**Invariant dashboard** : une carte sur ≥1 dashboard n'est JAMAIS archivée sans (a) la remplacer sur chaque dashboard par la canonique à la même place, (b) re-câbler les filtres (`parameter_mappings`), (c) test différentiel. Sinon, on ne touche que `dashboard_count == 0`. (→ `swap_card_on_dashboards.py`.)
 
 ## TODO outillage
 

--- a/docs/cleaning-roadmap.md
+++ b/docs/cleaning-roadmap.md
@@ -27,7 +27,7 @@
 | 5 | Cartes inutilisées périmées | ✅ | 315 archivées (≥1 an) | `archive_stale_cards.py` ; re-vérif live, exclut frozen ☠️ |
 | — | Usage replié dans l'audit | ✅ | — | `last_used_at`/`view_count`/`avg_query_time` ; 433 périmées repérées, #11 rempli |
 | 6 | Doublons fonctionnels | 🚧 | 156 groupes | **reframé** : 3 vrais doublons isolés (entangled), 39 en zone sensible, 111 cross-location = structure de propagation → relève de #8. Outil de swap prêt (dashboard-safe). Appliquer = décisions par-paire + cas tuile-en-double |
-| 11 | Cartes lentes | ⬜ | 213 | perf : fix-or-kill (plus lente = 224 s) |
+| 11 | Cartes lentes | 🔎 triagé | 212 actives | **toutes sur dashboard → optimiser en place (pas d'archivage)**. ROI réel = famille **benchmark "client vs industry vs global"** (~14 s × 20-33k vues : #2116/2187/2115/2097/2240-2243). Les GSC 224 s sont lentes mais peu vues (faible ROI). Optimisation = matérialiser/pré-agréger les benchmarks industrie+global (requête Snowflake multi-CTE) + test différentiel. Discipline distincte → session dédiée. Alerte #2510 (99 s × 2496 vues) à part. |
 | 10 | Nommage hors template | ⬜ | 1919 | normalisation (étend Phase 1.5) |
 | 2 | Sprawl perso | ⬜ | 162 clients | sensible : sortir le travail client de l'espace perso |
 | 3 | Noms de collections dupliqués | ⬜ | 45 | |

--- a/docs/cleaning-roadmap.md
+++ b/docs/cleaning-roadmap.md
@@ -1,0 +1,52 @@
+# Metabase Cleaning — Roadmap
+
+> Tracker vivant du nettoyage instance-wide. Design : `docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md`.
+> Légende : ✅ fait · 🚧 en cours · ⬜ à faire · ⏸️ tenu de côté
+> **Maj : 2026-05-29**
+
+## Progression globale (réversible — tout en archivage)
+
+| | Départ (2026-05-29) | Actuel |
+|---|---|---|
+| Collections actives | 868 | **773** (−95) |
+| Cartes actives | 5654 | **5329** (−325) |
+
+## Outillage (sur master, testé)
+
+- `scripts/audit.py` — `scan` → `deep` (cache reprenable) → `report`. Usage-aware (`last_used_at`/`view_count`/`average_query_time`).
+- `scripts/audit_lib.py` / `audit_report.py` — détecteurs, empreinte v2, scoring, rendu. 18 tests (`tests/test_audit_lib.py`, `test_audit_report.py`).
+- Exécuteurs (dry-run, re-vérif live, CSV de relecture, rollback) : `archive_empty_collections.py`, `archive_collections.py`, `archive_stale_cards.py`.
+
+## Campagnes par vague
+
+| # | Campagne | Statut | Volume | Exécuteur / note |
+|---|----------|--------|--------|------------------|
+| 1 | Collections vides | ✅ | 90 archivées | `archive_empty_collections.py` ; exclut template/perso/système |
+| 4 | Fourre-tout (set vert) | ✅ | 5 archivées | `archive_collections.py` ; test/POC dormants |
+| 5 | Cartes inutilisées périmées | ✅ | 315 archivées (≥1 an) | `archive_stale_cards.py` ; re-vérif live, exclut frozen ☠️ |
+| — | Usage replié dans l'audit | ✅ | — | `last_used_at`/`view_count`/`avg_query_time` ; 433 périmées repérées, #11 rempli |
+| 6 | Doublons fonctionnels | 🚧 | 156 groupes | fusion : archiver copies inutilisées d'abord, repointage dashboards ensuite (test diff.) |
+| 11 | Cartes lentes | ⬜ | 213 | perf : fix-or-kill (plus lente = 224 s) |
+| 10 | Nommage hors template | ⬜ | 1919 | normalisation (étend Phase 1.5) |
+| 2 | Sprawl perso | ⬜ | 162 clients | sensible : sortir le travail client de l'espace perso |
+| 3 | Noms de collections dupliqués | ⬜ | 45 | |
+| 8 | Dérive template | ⬜ | 279 | copies clientes divergentes du maître 215 |
+| 9 | Familles de variantes | ⬜ | 20 | paramétrer en 1 carte (ex. `breakdown`) |
+| 7 | Backlog archivé | ⏸️ | 1803 collections | suppression DÉFINITIVE — prudence, ou laisser |
+
+## Tenu de côté (ne pas archiver sans décision)
+
+- `Old audit questions` (#3918) — 1 carte encore active (les 164 dormantes archivées).
+- `[WIP] Presento | Questions` (#10980) — 1904 vues.
+- `Quitoque-Dashboards-Temp` (#1461) — dashboards clients vus récemment.
+- Collections `DO NOT MODIFY ☠️` (Presento) — marqueur humain explicite.
+- `#17584 Fields` — `can_write=False` (permissions).
+- 5 collections vides nichées en perso — relèvent de la campagne sprawl (#2).
+
+## Garde-fous
+
+Toutes actions autorisées **mais validation avant chaque action** ; réversible d'abord (archivage, jamais suppression sans accord). Snapshot → (test différentiel) → échantillon → batch → invariant.
+
+## TODO outillage
+
+- ⬜ Purge du cache deep avant un nouveau scan (les cartes archivées y figurent encore comme actives) — ajouter `audit` cache-clean ou skip-archivés.

--- a/docs/conversion-migration-HANDOFF.md
+++ b/docs/conversion-migration-HANDOFF.md
@@ -1,0 +1,170 @@
+# Migration conversions Metabase — PASSATION (lis-moi en premier)
+
+> Doc d'onboarding pour un agent frais qui reprend ce chantier.
+> Lis aussi : **`conversion-migration-clients.md`** (qui est fait, où on en est, par client),
+> le mémo `memory/conversion_migration.md` (log détaillé chronologique), et la spec
+> `docs/superpowers/specs/2026-06-03-conversion-migration-design.md`.
+> **Dernière mise à jour : 2026-06-13.**
+
+---
+
+## 1. L'objectif (en une phrase)
+Sur les dashboards **custom** des clients (collection 317, ~110 clients), remplacer chaque tuile branchée sur
+une **ancienne** conversion (colonnes positionnelles Snowflake `CONVERSIONS`, `CONVERSIONS_1..19`, valeurs,
+db 144 / `global.*`) par la **nouvelle** équivalente nommée (`PURCHASES`, `CUSTOM_CONVERSIONS_1..15`, …) déjà
+existante dans la collection **11673**, en préservant mise en page / filtres / valeurs ; PUIS basculer le
+filtre de période du dashboard de l'ancien mécanisme (texte/category) vers le **temporal-unit** Metabase.
+
+## 2. Règles d'or (NON négociables)
+1. **TOUJOURS sur des COPIES.** Les liens de partage **Nanga** pointent sur les originaux → on ne touche
+   JAMAIS un original. Copie SHALLOW : `POST /api/dashboard/<id>/copy {"is_deep_copy": false, "collection_id": <test>}`.
+2. **RÉUTILISER les cartes existantes (11673 / famille mixte 13884). JAMAIS de doublon par dashboard.**
+3. **Vérif avant/après par tuile.** On ne migre une tuile que si les valeurs sont identiques (tolérance
+   relative ~1e-9 ; les floats Snowflake bougent au 15e chiffre), ou si la différence est **assumée+validée**
+   (flag `--accept-diffs`).
+4. **Airtable = source de vérité** du mapping (slot ancien → conversion nommée), par client. **Conflit** =
+   un slot mélange plusieurs événements/conversions → **STOP, demander à Gaby** (ne pas deviner).
+5. **En cas de doute : STOP et pose la question.** L'utilisateur préfère ça à une « décision naze ».
+6. **Réponds en français, simple et visuel** (l'utilisateur pense en systèmes ; schémas/tableaux). **Pas de
+   commits sans qu'il le demande.**
+
+## 3. La chaîne d'outils (LE pipeline, par dashboard COPIE)
+Tous dans `scripts/`. Connexion qui marche : `from archive_collections import connect_resilient; mb = connect_resilient()`
+(NE PAS utiliser reorg_phase1.connect : session_id périmé). Dry-run d'abord (sans `--yes`).
+
+**Raccourci (orchestrateur) :** `migrate_client.py --client "<Nom>" --dashboards <ids ORIGINAUX> [--yes]`
+copie chaque dashboard puis enchaîne les **5 étapes** ci-dessous (--accept-diffs partout, --auto-prepare).
+Onglets SUPPORTÉS. Sinon, étapes manuelles :
+
+```
+0. COPIER l'original (shallow) dans une collection de test.
+1. migrate_dashboard_reuse.py --copy <C> --source <ORIG> --client "<Nom>" --planned-temporal-unit [--accept-diffs] [--yes]
+      → migre les TUILES conversion vers 11673 (résolution unique via mapping client × colonne × breakdown ×
+        KPI-set × brand × source ; masquage de séries en trop ; --accept-diffs = accepte un écart de valeurs
+        connu/validé). Laisse sur l'ancien ce qu'il ne sait pas (statut « À DÉCIDER »).
+2. swap_tables.py --copy <C> --client "<Nom>" [--accept-diffs] [--yes]
+      → swappe les TABLEAUX multi-slot vers la famille mixte 13884 (résolveur breakdown→carte auto :
+        type/channel/category/network/product/name/location/device/url/date). Mappe les colonnes visibles +
+        reprend les renommages ; vérifie cellule par cellule (aligné par libellé, brand=yes inerte).
+3. bascule_time_filter.py --copy <C> --client "<Nom>" --auto-prepare [--yes]
+      → bascule le param 'Time period' (category) → temporal-unit (MÊME id, les câblages survivent).
+        --auto-prepare : convertit le mécanisme temps de CHAQUE carte bloquante (conversion ou non : Cost,
+        Clicks, Magento, charts orphelins) en copie temporal-unit (sandbox 13885, via convert_card).
+        Fallback : carte non convertible AVEC filtre date séparé ET breakdown≠date (granularité vestigiale,
+        ex. table 2-dim) → DÉBRANCHÉE du filtre temps. Nettoie les câblages morts.
+4. generate_fallback.py --copy <C> --client "<Nom>" [--yes]   ← OBJECTIF 100%
+      → pour chaque tuile ENCORE sur l'ancien (pas d'équivalent 11673), GÉNÈRE une copie de la vieille carte
+        avec substitution de colonnes (substitution_map + generate_card), dédupliquée (1 par vieille carte×
+        client) dans coll 13950. Slots non mappés/conflit restent vieux (colonnes cachées OK ; VISIBLES = pas
+        100%, besoin Gaby). Ne vérifie que l'exécution (render KO réel = erreur SQL ; timeout = on garde).
+5. polish_generated_viz.py --copy <C> --client "<Nom>" [--yes]
+      → substitue la viz du DASHCARD (table.columns/column_settings/series) pour les cartes générées (13950)
+        : titres/ordre/visibilité des colonnes reprennent les bons noms.
+```
+⚠️ **APRÈS génération : les cartes naissent dans 13950 (sandbox /13851/ = NON lisible par les consultants).
+Il FAUT déplacer les cartes migrées (13950 + copies temporal-unit 13885) vers une collection accessible**
+(sous-collection « Conversions migrées » dans la collection client /317/, ou collection partagée pour les
+génériques) — SINON les tuiles s'affichent VIDES pour le consultant (bug vécu Shopinvest Focus Marge).
+cf. `conversion-migration-clients.md` § LEÇON PERMISSIONS. À automatiser dans les outils.
+
+## 4. Bibliothèques & helpers (testés)
+- **`conv_lib.py`** (tests `tests/test_conv_lib.py`, 54/54) : logique pure. Clés : `native_and_tags`,
+  `old/new_conversion_columns`, `resolve_new_card`, `series_display_map`, `map_table_columns` (gère colonnes
+  `_EVOLUTION`, alias REVENUE/CONVERSION_RATE/AVG_REVENUE, dimensions nues CHANNEL/NETWORK/…),
+  `fix_brand_clause`/`strip_brand_atoms`, `card_breakdown`, `kpi_signature`.
+- **`bascule_lib.py`** (tests `tests/test_bascule_lib.py`, 12/12) : `bascule_plan`, `apply_bascule`,
+  `build_temporal_unit_param`, `time_param_payload`.
+- **`convert_generic_temporal.py`** : `convert_card(mb, cid, client, window)` — copie temporal-unit (sandbox
+  13885) de N'IMPORTE QUELLE carte time-driven ; baseline INLINE fiable (`name='<g>'`) ; vérif 4 granularités ;
+  registre `migration/tu-generic-<id>.json` (lu par la bascule) ; idempotent.
+- Brand fix (FAIT sur 11673) : `audit_brand_clause.py`, `fix_brand_clause_cards.py`, `batch_brand_fix.py`,
+  `validate_brand_batch.py`.
+
+## 5. Faits techniques NON-OBVIES (pièges qui ont coûté du temps)
+- **Le swap conversions est facile ; la BASCULE du filtre temps est le vrai goulot** : elle est atomique
+  (tout-ou-rien par dashboard) et exige que CHAQUE carte time-driven ait une version temporal-unit. Chaque
+  dashboard a une « longue traîne » d'oddités (Magento, tableaux 2-dim, charts orphelins) → c'est `--auto-prepare`
+  qui la couvre.
+- **pMBQL** : cartes récentes → `dataset_query = {database, lib/type, stages}` ; SQL+tags dans
+  `stages[0].native` / `.template-tags` (PAS `dataset_query.native`). Utiliser `conv_lib.native_and_tags`.
+- **Param client** : certains templates (magento) utilisent un tag `client` SINGULIER type `string/=`
+  (pas `clients`/category) → toujours lire le `widget-type` du tag pour construire le param.
+- **Ancien filtre time_period souvent CASSÉ** (texte) : passer une valeur → 400, non renseigné → granularité
+  aléatoire. Donc pour les baselines on INLINE la granularité (`name='week'`) via /api/dataset, on ne se fie
+  PAS au field-filter.
+- **Recette temporal-unit** : préfixer la CTE `granularity` (sonde l'unité via le tag temporal-unit sur
+  `utils.calendar.date` = field **419201**) + remplacer chaque `LATERAL(... metabase_filters.time_periods ...
+  {{time_period}} ... LIMIT 1)` par `LATERAL(SELECT name FROM granularity LIMIT 1)`. `temporal_units` =
+  `[day,week,month,year]` (comme l'ancien ; pas de quarter sauf besoin).
+- **Règle BRAND** (validée) : une campagne est « brand » si `campaign_type LIKE '%brand%'` **OU**
+  `TRIM(LOWER(campaign_category)) = 'brand'` (égalité STRICTE — un LIKE attrape « Push Brand To Media » à tort).
+  Appliquée à 1967 cartes de 11673 (0 régression). `conv_lib.fix_brand_clause`.
+- **mb.put/mb.post** renvoient `False` sur erreur HTTP ; passer `'raw'` pour voir le corps. **PUT d'un dash à
+  ONGLETS DOIT inclure `tabs`** (sinon 500) — les 3 scripts le font désormais (onglets supportés).
+- **Index 11673** : `migration/conv-new-index.json` restreint au sous-arbre 11673 (le mode cache polluait).
+  Régénérer : `build_new_conv_index.py --live --root 11673`. (NB : 41329 archivé, index à régénérer.)
+
+## 6. Décisions produit DÉJÀ tranchées (ne pas re-litiger)
+- Filtre temps : **tout en temporal-unit**, bascule PAR DASHBOARD (jamais 2 filtres temps en final).
+- Tableaux multi-slot : **famille mixte « toutes conversions »** (option b) créée dans 13884 (cartes
+  49098–49129, 10 breakdowns). Filtre de lignes : on garde **`cost != 0`** (le neuf), pas `impressions>0`.
+- Conventions time series : axe X timeseries/no-label/ticks ; `temporal_units` [day,week,month,quarter,year] ;
+  défaut `week` (mais contrainte défaut relâchée — pas bloquant). cf. memory `metabase-timeseries-conventions`.
+
+## 7. Limites connues / reste à faire
+- **Graphes multi-conversion** (2+ conversions sur un même graphe) et **tableaux 2-dimensions** : pas
+  d'équivalent propre → restent sur l'ancien système (sans casse) ou débranchés du filtre temps.
+- **Cartes « filter choice »** (sélecteur de métrique, ex. card 87) : transform OK mais convert_card/reuse ne
+  savent pas les VÉRIFIER (param sélecteur requis → baseline vide) → restent sur l'ancien. À outiller.
+- **ONGLETS : SUPPORTÉS** (2026-06-13). Les 3 scripts gèrent `tabs` (PUT inclut `tabs`, dashcards gardent
+  `dashboard_tab_id`) ; le reuse apparie source↔copie par INDEX d'onglet (ids différents). migrate_client.py
+  les passe aussi.
+- **Appliquer aux ORIGINAUX** : tout est sur copies. Définir/faire l'étape finale (appliquer sur l'original
+  ou repointer le partage Nanga) APRÈS validation consultant — PAS encore fait.
+  **Décision 2026-06-17 : le partage / repoint Nanga reste MANUEL (fait par les GM, pas d'automatisation) —
+  cf. memory `dashboard-app-sharing`. Étape finale prod = appliquer sur les ORIGINAUX ; le partage = GM.**
+- **GA4 / analytics.*** : ~242 tuiles bloquées amont (pipeline data).
+- **15 cartes cassées** (orphelines, 0 dashboard) repérées dans 11673 → archivage proposé, en attente GO.
+- Subagents/workflows : quota hebdo (reset ~ven 21h) — sinon travailler inline.
+
+## 8. Repères Airtable / mapping
+- Mapping = `migration/conv-client-mapping.json` (régénérable). Source : base **apptzpE1FqCMGH0dw**, table
+  **tbliHOIPYGJCvLvas** (champs : `client` linked, `type`=slot positionnel `fldKwKgjtULTSjX6g`,
+  `new_type` `fldAOmPth76Vsd7AX`, event `fld6VHk3nAgHmRSP7`, platform `fld1VYy5IjpCPSsus`).
+- `conv_lib.build_client_mappings` flague `__CONFLICT__` quand un slot a plusieurs `new_type` distincts.
+  Re-vérifier en LIVE avant chaque client (Gaby corrige au fil de l'eau).
+
+## 9. Prochaine action
+**MAJ 2026-06-17.** Étapes 1+2 FAITES : PN (validé Lucas) + 4 clients Gaby (Goodiespub, Father&Sons,
+Shopinvest, Rivadouce) migrés, **rétro-tagués `[conv-2026-06]`**, suivis dans
+`docs/conversion-migration-tracker.md` (18 lignes). **Partage app Nanga = MANUEL (GM), pas d'automatisation**
+(prototype construit puis rollback complet — cf. memory `dashboard-app-sharing`).
+
+**ÉTAPE 3 = migrer les ~92 clients restants (ads `global.*`).** Triage préflight (`conv-preflight.csv`) :
+**49 prêts** (0 conflit, mappable — démarrer par les petits propres : Toploc, 100% Print, Figaret,
+France Toner, Jerome Dreyfuss), **9 à compléter Airtable** (no_client_mapping → Gaby), **34 lourds**
+(conflits/unmapped → Gaby). Dérouler via `migrate_client.py` (auto-tag + écrit le registre). En parallèle :
+demande groupée Gaby (9 Airtable + conflits restants des 5 faits : F&S slot 1, Rivadouce slots).
+
+**GA4** : bloqué amont (pipeline data en cours d'ajout des colonnes nommées à `analytics.*`). Les 18 migrés
+ont **0 tuile GA4**. Catch-up des déjà-migrés tracké en `ga4_pending` : PN #14049, Rivadouce #15372,
+Shopinvest #863 (Goodiespub + F&S = aucun GA4). **Archivage des anciens** : `archive_superseded.py` après
+validation consultant (opt-in `archive_old:true` par ligne ; dry-run ; réversible). cf. §10.
+
+## 10. Ancre de campagne, suivi & archivage des anciens (2026-06-17)
+- **Ancre `[conv-2026-06]`** = marqueur de **CAMPAGNE** (pas date de création). Ajoutée en **suffixe** au nom
+  de CHAQUE copie par `migrate_client.py` (via `conv_tracker.apply_tag`). Survit à la promotion (quand on
+  droppera le préfixe `[TEST conv]`). Rôle : marqueur humain + **garde-fou** anti-archivage.
+- **Tracker / registre** = `migration/conv-migration-tracker.json` (vue lisible :
+  `docs/conversion-migration-tracker.md`, régénérée par `conv_tracker.py --render`). 1 ligne par dashboard
+  migré : `client, dashboard, copy_id, original_id, tagged, status, archive_old, old_archived, notes`.
+  `migrate_client.py` y consigne chaque paire **ancien→copie** automatiquement. Lib pure testée :
+  `tests/test_conv_tracker.py` (9/9). Seedé avec les copies déjà faites (PN + 4 clients Gaby).
+- **Archivage des anciens = delete-by-PRESENCE (jamais par absence).** `scripts/archive_superseded.py`
+  (dry-run par défaut ; `--yes` applique) archive UNIQUEMENT les originaux des lignes marquées
+  **`archive_old: true`** (opt-in explicite, à poser à la main après validation), réversible
+  (PUT `archived:true`), + garde-fou : refuse tout nom portant `[conv-2026-06]`. → on n'archive jamais
+  « tout ce qui n'a pas le tag ».
+- **Workflow** : migrer (auto-tag + registre) → consultant valide → poser `archive_old:true` sur la ligne →
+  `archive_superseded.py` (dry-run puis `--yes`). Le **partage app reste MANUEL (GM)** — cf. memory
+  `dashboard-app-sharing`.

--- a/docs/conversion-migration-clients.md
+++ b/docs/conversion-migration-clients.md
@@ -1,0 +1,116 @@
+# Migration conversions — SUIVI PAR CLIENT (état vivant)
+
+> Mis à jour : **2026-06-15**. Une ligne par client. Tout est sur des **COPIES** (les
+> originaux + liens de partage Nanga ne sont JAMAIS touchés tant que non validé).
+> Voir `conversion-migration-HANDOFF.md` pour le mode d'emploi des outils.
+>
+> **ÉTAT GLOBAL 2026-06-15 : les 4 clients de Gaby sont migrés sur copies** (Goodiespub, F&S, Shopinvest,
+> Rivadouce — chaîne complète : reuse → swap_tables → bascule → generate_fallback → polish, via l'orchestrateur
+> `scripts/migrate_client.py`). Gaby a validé l'ensemble SAUF le rendu (corrigé depuis : voir LEÇON permissions
+> ci-dessous). Non-100% résiduel = GA4 (data amont), conflits de slots (Gaby), slots non mappés VISIBLES sur
+> gros tableaux (Gaby doit mapper), ~3 cartes « filter choice »/edge render-KO (à déboguer).
+
+## 🔑 LEÇON CRITIQUE — PERMISSIONS DE COLLECTION (2026-06-15)
+Les cartes migrées (générées + copies temporal-unit) étaient dans **13885/13950 sous 13851 « ZZ - Migration
+test »** = collection NON partagée → les consultants (Gaby) voyaient les **tuiles VIDES** (« graphes n'affichent
+rien » sur Shopinvest Focus Marge ; les scalaires en 11673 s'affichaient car 11673 est partagée). Les cartes
+marchent (admin les voit) — c'était purement un **accès collection**.
+**FIX appliqué (user a choisi option b)** : 89 cartes déplacées → sous-collection **« Conversions migrées »**
+dans CHAQUE collection client (sous /317/, accessible) : PN 13983, Goodiespub 13984, Father&Sons 13985,
+Shopinvest 13986, Rivadouce 13987 ; + 7 cartes **génériques partagées** (Cost/Clicks by date, multi-clients)
+→ coll **13988** sous 11673. Vérifié : 0 tuile ne pointe plus vers le sandbox.
+**RÈGLE pour la suite** : les cartes migrées DOIVENT vivre dans une collection lisible par le consultant
+(arbre client /317/ ou 11673), JAMAIS dans un sandbox /13851/. À intégrer dans generate_fallback /
+convert_card (créer/cibler la bonne collection dès la génération). (orphelins restants dans 13885/13950 =
+non utilisés, à archiver plus tard).
+
+## ⏳ EN ATTENTE / À RELANCER (ne pas oublier)
+- **🔴 purchases META sous-compte — CAUSE CONFIRMÉE par Gaby + vérifiée au compte près (2026-06-15).**
+  C'est un trou de **mapping/config Airtable**, pas un bug outil ni une mauvaise migration :
+  · **Rivadouce / FB −135 = EXACTEMENT** Milton-Main (old 125, new **0**) + Auriège-Main (old 10, new 0) :
+    leur event meta omni_purchase a type=Main mais **new_type VIDE** → compté dans l'ancien `conversions`,
+    absent du nouveau `purchases`. (Rivadouce Meta, lui, est mappé → delta 0.) → Gaby remplit new_type=Purchases.
+  · **Shopinvest / social −135 ≈** 3 Suisses (−104, seul compte meta, events purchase/unique_purchase/
+    onsite_web_purchase vides en type ET new_type + compte retrieve_account_data=0 non ingéré) + petits
+    deltas sur Bijourama/MenCorner/Lemon Curve/Comptoir/Fitancy (−32). → corriger Airtable/config compte.
+  · **F&S Pinterest (0 achats)** : la ligne checkout EST bien mappée (type=Main, new_type=Purchases — vérifié)
+    → le 0 n'est PAS un trou de mapping : soit pas re-synchronisé, soit aucun volume checkout ne remonte.
+    Cause AVAL (sync/volume), à creuser côté data.
+  → Une fois ces fixes Airtable/sync faits par Gaby/data, les 2 clients migrent proprement (outil OK).
+- **Conflits de mapping slots secondaires** (Gaby) : Goodiespub slot 2 (réglé), Father&Sons slot 1,
+  Rivadouce slots 1 & 2 (+ slot 3 « Content views OR View Item » ambigu). Même type : un slot positionnel
+  mélange plusieurs events/conversions nommées. Trancher par slot et par client.
+- **Father and Sons** — relancer **Gaby** sur le conflit slot 1 (1ère conversion mélange tiktok `follows` /
+  pinterest `page_visit` / meta `page_engagement` → conversions nommées différentes). Idem Goodiespub : quelle
+  conversion nommée pour la « 1ère conversion » ? (peu de tuiles concernées ; non bloquant pour les 3 faits.)
+- ✅ **ONGLETS désormais SUPPORTÉS** (codé 2026-06-13, testé sur F&S Shopify 22860→25836 : PUT OK, onglets
+  intacts). Appariement par index d'onglet (les ids diffèrent entre source et copie). Gaps restants :
+  carte « filter choice » (sélecteur de métrique : convert_card/reuse ne sait pas la vérifier) ;
+  trou data Pinterest (purchases pinterest = 0 dans le neuf, cf. F&S Sponso) → Gaby/data.
+
+## Statuts
+- ✅ **fait** : copies migrées + basculées, vérifiées.
+- 🟡 **en cours** / partiel.
+- ⛔ **bloqué** (raison).
+- ⬜ **à faire**.
+
+## Étape 1 — Pilote Pro Nutrition (validé par Lucas ✅)
+
+| Dashboard | Original | Copie | État | Notes |
+|---|---|---|---|---|
+| Home | 14118 | 25566 | ✅ basculé | 1/1 tuile |
+| Ecommerce Sopral | 16557 | 25567 | ✅ basculé | 6/6 tuiles |
+| Global perf (14016) | 14016 | 25632 | ✅ basculé | 14/14 tuiles + 3 tableaux (49098/49104/49129) |
+
+Mapping PN : `{0:Purchases, 1:Custom 1, 3:Custom 2}`. Écart connu montré à Lucas : tableau by-network,
+1 campagne FB (+2 achats) car filtre `cost!=0` (neuf) vs `impressions>0` (ancien) — validé, on garde `cost!=0`.
+
+## 🎯 Objectif 100% (user 2026-06-15) : « génère-tout » = réutilise 11673 si la carte existe, SINON génère
+une copie avec substitution de colonnes (`conversions_N`→colonne nommée), dédupliquée (1 par vieille
+carte×client) dans collection **13950**. Outil : `scripts/generate_fallback.py` (à lancer APRÈS reuse+swap+
+bascule). Onglets gérés, substitue aussi la viz du DASHCARD (titres/ordre/visibilité des colonnes).
+**État Gaby (post-génération 2026-06-15) : les 6 dashboards prêts affichent 100% de NOUVELLES conversions
+(0 colonne ancienne VISIBLE, vérifié).** Limite : 5 cartes-tableaux gardent des colonnes CACHÉES pour des
+slots que le client ne mappe pas (4-7) — invisibles, pas de cible de migration ; strict-0-ancien impossible
+sans que Gaby mappe ces slots OU qu'on drope les colonnes cachées. Outils de génération : `generate_fallback.py`
+(génère + dédup dans 13950), `polish_generated_viz.py` (substitue la viz du dashcard : titres/ordre/visibilité),
+intégrés à `migrate_client.py`. ⚠️ Les cartes générées naissent dans 13950 (sandbox) → DOIVENT être déplacées
+en collection accessible après (cf. LEÇON permissions en tête).
+
+## Étape 2 — Clients de Gaby
+
+| # | Client | Clé mapping | Dashboards (orig → copie) | État | Reste / notes |
+|---|---|---|---|---|---|
+| 1 | **Goodiespub** | `Goodiespub` | 12734 Home → **25764**, 12716 Pilotage → **25765** | ✅ **100% visible** | Toutes tuiles affichent du neuf (combos + tables 2-dim générés via fallback + repolis). Reste invisible : slots 4-7 cachés non mappés. Mapping : `{0:Purchases, 1:Custom 1, 2:MQL, 3:Custom 3}`. |
+| 2 | **Shopinvest** | `Shopinvest` | 10 dashboards (coll 304), copies 258xx/259xx | 🟢 **7/9 à 100% visible** (écarts meta acceptés, user: Gaby gère son mapping) | ✅ 100% : 422 (25896), 8803 (25897), 918 (25900), 6855 (25901), 8703 (25929), 23 (25902), 421 (25899). ⛔ 186 (25898) : 1 tuile #4577 «Perf by verticales with targets» rendu KO à la génération (à finir). ⛔ **863 Analytics (25930) : 5 tuiles GA4** (`analytics.*`) NON migrables — pas de colonnes nommées côté GA4 (blocage data amont) + qq globales render-KO. 8934 = 0 conv (skip). Tables : slots cachés non mappés (invisible). |
+| 3 | **Father and Sons** | `Father and Sons` | 6 dashboards (coll 5404), copies 2583x | ✅ **4/6 à 100% visible** | **✅ Ecomm Home 25831, Ecomm Pilotage 25833, Noto Home 25834, Shopify 25836 (onglets)** = 100% visible (génération+repolissage). Reste invisible : slots cachés sur tables. ⛔ Annonces Meta 25832 (carte 87 « filter choice » : génération à vérifier) + Sponso 25835 (trou data Pinterest = sync aval, à finir). |
+| 4 | **Rivadouce** | `Rivadouce` | 9 dashboards migrés (coll 8109), copies **25931-25939** | 🟢 **~6/9 à 100% visible** (écarts meta acceptés) | ✅ 100% : Perfs globales 25931, Perfs par levier 25932, Perfs par campagne 25933, Perf campagne 25937, Perf campagne(dup) 25938, Home 25939. ❌ tables avec slots NON mappés VISIBLES : Home Custom 25934 (slots 1-19), Perf annonces 25935, Ads&Audiences 25936 (CONVERSIONS_2). ⛔ **CONFLITS slot 1/2** (Gaby) : Home 25939 a 4 tuiles « conversion 1 » (266/1293/1307/1612 = Conversions 1 / CR / ROAS) NON substituables (slot 1 = Leads vs Custom 1) ; slot 2 (Initiate checkouts vs Sign ups) ; slot 3 « Content views OR View Item » ambigu. Écart meta −135 (Milton-Main/Auriège-Main new_type vide) accepté. ⚠️ scan a un angle mort smartscalar : 25939 « 100% » à reconfirmer (les 4 conflit-tuiles peuvent être visibles). 21210 Brand Monitoring = 0 conv (skip). |
+
+## Étape 3 — Reste de la collection 317 (~110 clients)
+
+⬜ Non commencé. Prérequis (ce fichier + HANDOFF à jour = en place). Dérouler client par client avec la
+chaîne d'outils rodée. Préflight global : `migration/conv-preflight.csv`.
+
+## ⚠️ À retenir transverse
+- **GA4 / analytics.* bloqué amont** (colonnes nommées pas encore dans le pipeline data) — ~242 tuiles.
+- **Conflits de mapping Airtable** = un slot positionnel qui mélange plusieurs événements → plusieurs
+  conversions nommées. → demander à Gaby de trancher (ou corriger l'Airtable). NE PAS deviner.
+- **Limites outils connues** (restent sur l'ancien système, sans casse) : graphes multi-conversion
+  (2+ conversions sur un même graphe), tableaux à 2 dimensions (ex. produit×canal). Pas d'outil propre.
+- **Rien n'est appliqué aux ORIGINAUX** : tout sur copies. L'étape « appliquer sur l'original » (ou
+  basculer le partage Nanga vers la copie) reste à définir/faire APRÈS validation par le consultant.
+  **MAJ 2026-06-17 : le partage Nanga n'est PAS automatisé — les GM le font à la main (responsabilisation +
+  pratique). Étape prod = appliquer sur les ORIGINAUX ; le partage reste au GM.** cf. memory `dashboard-app-sharing`.
+
+## Collections clés
+- **11673** Nouvelles Conversions (cartes par conversion, PARTAGÉE) · **13884** Tables « toutes conversions »
+  (mixtes 49098–49129, sous 11673 = accessible) · **317** dashboards custom clients (cibles) · **13917** copies
+  de test des clients Gaby.
+- **Collections de cartes migrées (post-fix permissions 2026-06-15, ACCESSIBLES) :** sous-collections
+  « Conversions migrées » par client → PN **13983**, Goodiespub **13984**, Father&Sons **13985**,
+  Shopinvest **13986**, Rivadouce **13987** (toutes sous /317/) ; génériques partagées **13988** (sous 11673).
+- **Sandbox À NE PLUS UTILISER comme destination finale** (non lisibles par consultants) : **13851**
+  « ZZ - Migration test » + ses enfants **13885** (copies temporal-unit génériques), **13950** (cartes générées).
+  Les cartes utilisées ont été déplacées hors de là ; restent quelques orphelins (à archiver).
+- Clés collections clients (parents sous /317/) : PN 4314 · Goodiespub 6940 · Father&Sons 5404 · Shopinvest 304
+  · Rivadouce 8109.

--- a/docs/conversion-migration-roadmap.md
+++ b/docs/conversion-migration-roadmap.md
@@ -1,0 +1,124 @@
+# Conversion Migration — Roadmap (tracker vivant)
+
+> **Objectif unique :** sur les dashboards **custom** des clients (sous collection **317**),
+> remplacer chaque tuile branchée sur une conversion **ancien système** (colonnes positionnelles
+> `CONVERSIONS`, `CONVERSIONS_1..19`, `CONVERSION_*_VALUE`) par son équivalent **nouveau système**
+> (colonnes nommées `CUSTOM_CONVERSIONS_1..15`, `PURCHASES`, `LEADS`, …), en **préservant la mise en
+> page et le câblage des filtres**, mapping **par client** (Airtable), réversible (snapshots).
+> Design : `docs/superpowers/specs/2026-06-03-conversion-migration-design.md` ·
+> Plan : `docs/superpowers/plans/2026-06-03-conversion-migration.md`.
+> Légende : ✅ fait · 🚧 en cours · ⬜ à faire · ⛔ bloquant/décision · **Maj : 2026-06-03**
+
+## Garde-fous (non négociables)
+Snapshot → réconciliation Snowflake par tuile → échantillon → batch. Copy-first pour tester.
+**Jamais** d'archivage de carte template partagée. Une tuile non-`ok` n'est **jamais** appliquée
+automatiquement (file de revue). In-place seulement après pilote sur copie validé.
+
+## Outillage (sur master, NON commité — décision commit en attente)
+| Composant | État |
+|---|---|
+| `scripts/conv_lib.py` (+ `tests/test_conv_lib.py`) | ✅ **20/20**, revu + durci |
+| `scripts/export_conv_mapping.py` → `migration/conv-client-mapping.json` | ✅ 173 clients |
+| `scripts/build_new_conv_index.py` → `migration/conv-new-index.json` | ✅ 2422 clés (col,forme) |
+| `scripts/discover_conversion_targets.py` → `migration/conv-targets.json` | 🚧 crawl en cours |
+| `scripts/migrate_conversions_on_dashboard.py` | ✅ résout/valide ; dry-run OK |
+| `scripts/conv_preflight.py` → `migration/conv-preflight.csv` (file de revue) | ⬜ après crawl |
+| `scripts/migrate_conversions_wave.py` (runner de vague) | ⬜ |
+
+## Taxonomie de résolution (par tuile)
+`ok` (1 carte cible, garde-fous verts → applicable) · `multi` (plusieurs cibles → revue) ·
+`review` (aucune forme correspondante, ou combo multi-slot → revue) · `unmapped` (slot sans
+`new_type` chez ce client → revue) · `conflict` (mapping incohérent entre comptes → revue) ·
+`blocked` (garde-fou échoue) · `skip` (pas de colonne ancienne).
+
+## Mapping (Airtable `apptzpE1FqCMGH0dw / tbliHOIPYGJCvLvas`)
+- 173 clients ; **214 slots UNMAPPED + 35 slots CONFLICT** (→ revue, jamais devinés).
+- Clé = `brand_name` = défaut du param `Client` du dashboard. Slot ≠ numéro Custom (ex. PN `3rd→Custom 2`).
+- ⛔ **Hors périmètre positionnel** : types `Add to cart` / `App install` / `runs` (colonnes déjà
+  nommées `ADD_TO_CARTS`/`APP_INSTALLS`) — décision : migrer le rename `*_NEW` ou laisser ? (à trancher)
+
+## État réel — preflight (2026-06-04, `migration/conv-preflight.csv`)
+**516 dashboards · 5 557 tuiles · 97 clients.** Statuts :
+| statut | tuiles | % | lecture |
+|---|---:|---:|---|
+| review | 2363 | 42 % | dont **tables multi-slot 1488** (qq cartes distinctes réutilisées), **source GA4/autre 364**, **forme absente 447** |
+| multi | 1519 | 27 % | ambiguïté même-source (candidats surtout **2–3**) → désambiguïsation |
+| ok | 603 | 11 % | applicable maintenant |
+| conflict | 459 | 8 % | slot → ≠ new_types selon le compte |
+| unmapped | 349 | 6 % | slot sans new_type chez ce client |
+| no_client_mapping | 264 | 5 % | client absent d'Airtable (**Upway 166**, Little Worker 35, Fogal 23…) |
+
+**⚠️ Fait structurant : le nouveau système (colonnes nommées) n'existe QUE dans les tables ads
+`global.*`** (toutes ont `purchases`/`custom_conversions_*`/`leads`), **PAS dans `analytics.*` (GA4)**
+(qui n'ont que `conversions`/`conversion_value`). L'arbre 11673 n'a 0 carte analytics. ⇒ la migration
+est **un chantier tables-ads**. Le swap reste **table-pour-table** (granularités : campaign_daily_metrics,
+geographical, url, social_ad, search_adgroup…).
+
+Répartition par famille de source (5 557 tuiles) :
+| famille | tuiles | détail |
+|---|---:|---|
+| **ads** `global.*` | 3 229 | multi 1476 · **ok 573** · conflict 422 · review 415 · unmapped 343 |
+| **None** (source non résolue) | 2 086 | review 1723 (≈ tables perf multi-slot) · no_client_mapping 264 · … |
+| **analytics** GA4 | 242 | **bloqué en amont** (pas de colonnes nommées dans `analytics.*`) — à remonter à la data |
+
+- **Cœur ads migrable = 3 229 tuiles** ; **ok+multi = 2 049** (désambiguïsation = le levier principal).
+- **Leviers** : (1) désambiguïsation multi (1476, surtout 2–3 candidats) → ~+1 400 ok ; (2) **carte table
+  perf nouvelle** (clôt ~1 488 tuiles « None » via qq cartes) ; (3) compléter Airtable (conflict 422 +
+  unmapped 343 + no_client 264 dont **Upway 166**) ; (4) **GA4/analytics (242) = bloqué amont** (pipeline).
+
+## Dashboards testés (pilotes)
+| Dash | Client | Tiles conv | Résultat | Notes |
+|---|---|---|---|---|
+| 14118 Home Pro Nutrition | Pro Nutrition | 1 | ✅ `266→42635` (copie 25302, réconcilié exact Snowflake) | slot-1→Custom 1 |
+| 16557 Ecommerce Sopral | Pro Nutrition | 6 | ✅ 3 `ok` · 2 `multi` (CAC) · 1 `review` (CAC bar/date) | rename `location→campaign_location` géré |
+| 673 Global \| 900.care | 900.care | 12 | 9 `multi` · 2 `review` (tables multi-slot) · 1 `blocked` | slot-0→Purchases ; cf. décision matcher |
+
+## ⛔ Décisions ouvertes (alignement)
+1. **Désambiguïsation `multi`** *(la grosse)* — l'arbre « Conversions génériques » a **plusieurs**
+   cartes par (colonne × forme) (ex. 900.care « Main conversions » → 6 candidats, « CAC » → 5).
+   La forme `(display, métrique, breakdown)` est trop grossière pour les conversions standard.
+   Options : (a) préférer la carte dont le **nom canonique** = `new_type` ; (b) restreindre l'index
+   aux cartes du **dossier** de la conversion (ancêtre 11673) ; (c) `multi` → toujours revue.
+   → **décision produit nécessaire** avant un preflight massif fiable.
+2. **Carte par défaut des variantes** — `with/without brand`, `- leads/- purchases`, `| social` :
+   choisir la canonique vs revue.
+3. **Auto-détection client** — rendre `--client` optionnel (lu du param `Client`). ⬜ petit.
+4. **Tables multi-slot** (perf tables, ex. cartes 19/5940) — pas de swap 1-carte ; nécessitent une
+   **nouvelle table perf** nommée. → traitement dédié (revue/manuel).
+5. **Périmètre platform** — ces 3 dashboards ne sont pas scopés plateforme (`network` vide) ; le
+   littéral `meta` en SQL est incident. Vérifier les dashboards réellement scopés plateforme.
+
+## Audit bulletproof (2026-06-10, 4 agents parallèles) — corrigé dans la foulée
+- ⛔→✅ **Index pollué** : 134/2095 cartes hors-11673 (dont 29 cartes d'AUTRES clients : LA Bruket,
+  J.Dreyfuss…) → rebuild live restreint au sous-arbre 11673.
+- ⛔→✅ **`time_period` incompatible** (dimension → temporal-unit sur les nouvelles combo/line) : le
+  param « Time period » ne pilote plus la granularité → garde-fou `incompatible_wired_tags` (refus).
+  ⚠️ Décision produit en attente (cf. questions).
+- ⛔→✅ **PUT non vérifié** (mb.put avale l'erreur) → PUT `raw` + abort. **Onglets** refusés pour l'instant.
+- ⛔→✅ **Fenêtre vide ⇒ faux « identique »** (`[]==[]`) → statut « À VÉRIFIER », jamais migré.
+- ⛔→✅ Noms FR (Taux/Coût par/Valeur/Moyen) reconnus ; AVG/VALUE alignés série↔nom ; littéraux SQL
+  masqués (détection + substitution) ; `conversion_source` déterministe + alias ; snippets/cartes
+  sources détectés (`has_opaque_refs`) ; filtres orphelins → refus ; payload PUT whitelisté.
+- 📌 **Tables 11874** : les remplaçantes des grands tableaux existent (41336–41354, custom-only) —
+  substitution à contenu différent, à faire valider (pas d'égalité avant/après possible).
+- Tests : **37/37**.
+
+## Corrections déjà intégrées (durcissement via tests)
+- ✅ Combos **multi-slot → review** (jamais de swap erroné). 
+- ✅ Tuiles scalaires : ignore `graph.dimensions` résiduel (formes cohérentes).
+- ✅ `AVG` avant `VALUE` (pas de collision « Avg…value »).
+- ✅ **Rewire structurel des filtres renommés** par field-id (`location→campaign_location`).
+- ✅ Migrateur écrit `migration/conv-report-<dash>.json` (sortie propre pour le runner).
+
+## Vagues (rollout)
+| # | Périmètre | Statut | Note |
+|---|-----------|--------|------|
+| 0 | Pilotes Pro Nutrition + 900.care (copies) | 🚧 | 14118 ✅ ; 16557/673 résolus en dry-run |
+| 1 | Pro Nutrition in-place | ⬜ | après revue vague 0 + désambiguïsation |
+| 2 | 5 clients échantillon (copies→revue→in-place) | ⬜ | |
+| 3 | Reste (~105 clients) par lots de ~10 | ⬜ | gate : réconciliation verte par tuile |
+
+## Artefacts de suivi (CSV)
+- `migration/conv-targets.json` — **toute la charge** : (client, dashboard, tuiles). 🚧 (crawl).
+- `migration/conv-preflight.csv` — worklist par tuile + statut (la file de revue). ⬜ après crawl.
+- `migration/conv-report-<dash>.json` — rapport/rollback par dashboard migré.

--- a/docs/conversion-migration-tracker.md
+++ b/docs/conversion-migration-tracker.md
@@ -1,0 +1,31 @@
+# Migration conversions — SUIVI (généré, ne pas éditer à la main)
+
+> Source : `migration/conv-migration-tracker.json` · régénérer : `conv_tracker.py --render`.
+> Ancre de campagne : `[conv-2026-06]`. **21 dashboards** · 18 taggés · 0 anciens archivés.
+> Clients : Pro Nutrition (4), Goodiespub (2), Father & Sons (4), Shopinvest (7), Rivadouce (4).
+
+Statuts : `migré` (copie faite) · `validé` (consultant OK) · `archive_old:true` (opt-in pour archiver l'ancien) · `old_archived` (ancien archivé). L'archivage des anciens est piloté par `archive_superseded.py` et ne touche QUE les lignes `archive_old:true`.
+
+| Client | Dashboard | Copie | Original | Taggé | Statut | Archiver ancien | Ancien archivé | Notes |
+|---|---|---|---|---|---|---|---|---|
+| Pro Nutrition | Home | 25566 | 14118 | ✅ | validé (Lucas) | — | — | pilote étape 1 |
+| Pro Nutrition | Ecommerce Sopral | 25567 | 16557 | ✅ | validé (Lucas) | — | — | pilote étape 1 |
+| Pro Nutrition | Global perf (14016) | 25632 | 14016 | ✅ | validé (Lucas) | — | — | pilote étape 1 |
+| Goodiespub | Home | 25764 | 12734 | ✅ | migré | — | — |  |
+| Goodiespub | Pilotage | 25765 | 12716 | ✅ | migré | — | — |  |
+| Father & Sons | Ecomm \| Home | 25831 | 13323 | ✅ | migré | — | — | le plus complet, tout est migré |
+| Father & Sons | Ecomm \| Pilotage | 25833 | 11804 | ✅ | migré | — | — |  |
+| Father & Sons | Noto \| Home | 25834 | 15963 | ✅ | migré | — | — |  |
+| Father & Sons | Shopify | 25836 | 22860 | ✅ | migré | — | — | à onglets |
+| Shopinvest | Global | 25896 | 422 | ✅ | migré | — | — |  |
+| Shopinvest | Focus Marge | 25897 | 8803 | ✅ | migré | — | — |  |
+| Shopinvest | Verticales | 25900 | 918 | ✅ | migré | — | — |  |
+| Shopinvest | Focus levier | 25901 | 6855 | ✅ | migré | — | — |  |
+| Shopinvest | Global (2) | 25902 | 23 | ✅ | migré | — | — |  |
+| Shopinvest | MOAS | 25929 | 8703 | ✅ | migré | — | — |  |
+| Rivadouce | Perfs globales | 25931 | 16458 | ✅ | migré | — | — |  |
+| Rivadouce | Perfs par levier | 25932 | 16459 | ✅ | migré | — | — |  |
+| Rivadouce | Perf par campagne | 25937 | 17780 | ✅ | migré | — | — |  |
+| Pro Nutrition | Google Analytics 4 - Spec |  | 14049 | — | GA4 — à migrer (bloqué amont) | — | — | 8 tuiles GA4 — rattraper quand analytics.* aura les colonnes nommées |
+| Rivadouce | GA4 Overview |  | 15372 | — | GA4 — à migrer (bloqué amont) | — | — | 4 tuiles GA4 — rattraper quand analytics.* aura les colonnes nommées |
+| Shopinvest | Analytics - Main |  | 863 | — | GA4 — à migrer (bloqué amont) | — | — | 5 tuiles GA4 — rattraper quand analytics.* aura les colonnes nommées |

--- a/docs/quiz-room-utm-HANDOFF.md
+++ b/docs/quiz-room-utm-HANDOFF.md
@@ -1,0 +1,97 @@
+# Quiz Room — UTM Tracker : ce qui est corrigé & ce qui reste côté com
+
+**Pour : Robin** — à relayer à l'équipe com (qui maintient le gsheet des liens) et au client.
+**Date :** 2026-06-20 · **Dashboard :** Acquisition multi-domaines Quiz Room → onglet *UTM Tracker*.
+
+---
+
+## 1. Résolu côté tech ✅
+
+Le bug « campagnes à 0 / absentes » (métro, Quotidien Matin, Voxe…) est **corrigé et en production**.
+
+| | Avant | Après |
+|---|--:|--:|
+| Sessions (sur la période) | 1 090 | **6 693** (×6) |
+| Réservations | 22 | **78** |
+
+Campagnes récupérées : **Quotidien Matin 2 555**, Story Quotidien 1 545, Leboncoin Lyon 809, **Métro 550**, Voxe 455, L'Équipe 32.
+
+**Cause du bug (pour info) :** le tracker comparait les colonnes UTM *tapées à la main* dans le gsheet aux données GA4. Quand ces colonnes étaient vides, fausses, ou contenaient des accents, le rapprochement ratait silencieusement. **Désormais le tracker lit directement l'URL complète du lien** (= ce que GA4 voit réellement).
+
+> 🔑 **Règle d'or pour la com maintenant :** ce qui compte, c'est que la colonne **`url_complete`** du gsheet contienne **exactement le lien réellement diffusé** (avec tous ses `utm_…`). C'est cette URL qui sert au rapprochement — les colonnes source/medium/campaign séparées ne sont plus la source de vérité. Si l'URL est bonne, ça matchera.
+
+---
+
+## 2. Ce qui reste — actions côté com 🟡
+
+### A) Liens à compléter / ajouter dans le gsheet
+
+Lignes présentes mais **sans URL exploitable** → ajouter l'URL trackée réelle si on veut les suivre :
+
+| Campagne | Type | État actuel |
+|---|---|---|
+| BRUXELLES SECRETE I ARTICLE | Média Web | URL vide |
+| L'ESSENTIEL I NEWSLETTER | Newsletter | URL vide |
+| Vivre Bordeaux | Influence | URL vide |
+| Voxe - NL hors-série | Newsletter | `même lien qu'en dessous` (placeholder à remplacer) |
+
+Campagnes **vues par GA4 mais absentes du gsheet** → à ajouter :
+
+| Campagne (vue dans GA4) | Sessions | Action |
+|---|--:|---|
+| `metro / OOH / activite qui fait le buzz` | 123 | ajouter la ligne (variante métro non cataloguée) |
+| _(liste exhaustive : voir requête en annexe)_ | — | à compléter |
+
+### B) Liens du gsheet qui ne ramènent rien (0 session) → à vérifier
+
+Ces liens existent dans le gsheet mais GA4 n'a **aucune visite sous leurs UTM exacts**. Deux cas :
+
+**B1 — Le trafic existe, mais sous un libellé différent** → corriger le gsheet pour coller au lien réellement diffusé :
+
+| Campagne | UTM dans le gsheet | Réalité GA4 |
+|---|---|---|
+| Article Le Bonbon | `…campaign=meilleure_activité_fin_annee` | GA4 a `…meilleure_activité_en_famille` (source `articlelille`) — **libellé différent** |
+| Voxe | `…medium=newsletter2` | typo probable (vs `newsletter`) |
+| Petit Fûté | lien tagué `petitfûté / ficheSEO / 2026` | son trafic réel arrive en **referral** (non tagué) |
+
+**B2 — Probablement jamais cliqués** (à confirmer ; sinon rien à faire) :
+Leboncoin Lyon `nativeadweb` (les 2 autres placements ont bien matché), Sortir à Paris ×3 articles (`sapvillette`, `sapodeon`, `sapbn`), Lyon City Crunch, Culture Quizz.
+
+---
+
+## 3. Non-trackable par nature — à expliquer au client (pas un bug) ℹ️
+
+Le tracker UTM ne montre **que** les liens taggés UTM pointant vers le site Quiz Room. Ne pourront **jamais** y apparaître :
+
+- **Réseaux sociaux** (Lea Influ, Paris Immersif, Sortir à Paris stories…) : pas de lien UTM possible.
+- **Articles sur sites tiers** (Quoi faire à Bordeaux…) : c'est du **referral** → visible dans le canal « referral » de GA4, pas dans le tracker UTM.
+- ⚠️ **Important pour Le Bonbon / Petit Fûté :** l'essentiel de leur trafic vers Quiz Room est du **referral non taggé** (des milliers de sessions), pas des liens UTM. Ils paraîtront donc *petits* dans le tracker même s'ils performent bien. Pour les suivre réellement : soit regarder le canal referral de GA4, soit taguer systématiquement leurs liens en UTM.
+
+---
+
+## Annexe — requête de réconciliation (à lancer côté Snowflake, accès FIVETRAN)
+
+Liste exhaustive du trafic UTM vu par GA4 **mais absent du gsheet** (= liens à ajouter / réconcilier) :
+
+```sql
+WITH ga4 AS (
+  SELECT LOWER(session_manual_source) src, LOWER(session_manual_medium) med,
+         LOWER(session_campaign_name)  camp, SUM(sessions) sessions
+  FROM FIVETRAN_DB.google_analytics_4_20260205_quizzroom.daily_report_per_url_utm
+  WHERE event_name = 'session_start'
+    AND session_campaign_name IS NOT NULL
+    AND session_campaign_name NOT IN ('(not set)', '')
+    AND LOWER(session_manual_medium) NOT IN
+        ('referral','organic','(none)','(not set)','','cpc','ppc','paid','display','paidsearch','paid_search')
+  GROUP BY 1, 2, 3
+),
+cat AS (
+  SELECT DISTINCT LOWER(utm_source) src, LOWER(utm_medium) med, LOWER(utm_campaign) camp
+  FROM REPORTING_DB.client_data.stg_quiz_room_utms
+)
+SELECT g.src AS utm_source, g.med AS utm_medium, g.camp AS utm_campaign, g.sessions
+FROM ga4 g
+LEFT JOIN cat c ON g.src = c.src AND g.med = c.med AND g.camp = c.camp
+WHERE c.src IS NULL
+ORDER BY g.sessions DESC;
+```

--- a/docs/seo-manucurist-HANDOFF.md
+++ b/docs/seo-manucurist-HANDOFF.md
@@ -1,0 +1,136 @@
+# Handoff — Suivi SEO mots-clés Manucurist (Metabase)
+
+> État au 2026-06-15. Projet : dashboard de suivi SEO pour le client **Manucurist** (pod Nanga),
+> issu de l'issue Airtable `base app8gA9M46hqIfBPO / table tblOkJO3J4H7C15au / record rec7dqswb7JefIvPf`
+> (« Manucurist | Suivi des mots-clés », projet *Manucurist | Upsell GEO*).
+> Demandeurs : **Geoffrey Jestin** (client Manucurist, SEO), relayé par **Thibaut de Louvencourt** (SEO Nanga) et **Geoffrey Couette / Robin Trefcon** (Spark). Dev : Louis Monier (tech).
+
+## 0. TL;DR — où en est-on
+- **V3 livrée et QA-validée dans le navigateur** (2026-06-15). Dashboard dédié opérationnel.
+- Le brief a évolué V1 → V2 → V3 via un **gsheet** (onglet `V3`, le plus récent) + commentaires Thibaut.
+- 2 points en attente de validation client (voir §7).
+- **V3.1 (2026-06-17, retour Loom collègue → client)** : (1) toggle de pliage `+/−` par Marché rétabli sur Positions (#48634) & Saisonnalité (#49426) via `pivot.show_column_totals=True` ; (2) liens template #13489 **retirés** de la section Saisonnalité (cassaient hors embed → login Metabase ; le client ne voit que l'embed Nanga `app.nanga.tech`). Scripts : `scripts/seo_collapse_fix.py` + `seo_collapse_probe.py` (probe/backup). QA Chrome OK (pliage testé, liens absents).
+
+## 1. Sources externes du besoin
+- **Gsheet** (fait foi) : `https://docs.google.com/spreadsheets/d/1i8eoNISq4masLKAoC7Oh5Mp7MNdzwv6ynYAkN_cY5_Y`
+  - Onglet **`V3`** = cible actuelle. Onglets V2/V1 = historiques.
+  - Lecture des **cellules** via MCP Google Drive `read_file_content(fileId, includeComments=true)`. Les **commentaires** ne sortent PAS de l'API Drive → les lire via Chrome (panneau Commentaires).
+- **Airtable** issue (ci-dessus) : description + lien gsheet dans le champ `fldH74qsETt5xSngc`.
+
+## 2. Objets Metabase (instance https://spark.metabaseapp.com, compte louis.monier@spark.do)
+DB Snowflake = **database id 144**.
+
+| ID | Type | Nom | Rôle |
+|---|---|---|---|
+| **13752** | collection | **Manucurist** | foyer du livrable (créée à la racine) |
+| **25137** | dashboard | Suivi mensuel des mots-clés SEO \| Manucurist | **LE livrable** (8 tuiles, 7 filtres) |
+| **48633** | model | SEO Keyword Monitoring — Manucurist (model) | **modèle mots-clés V3** (cœur) |
+| 48635 | card (table) | SEO — Snapshot mots-clés (mois courant) | tuile snapshot (15 col) |
+| 48634 | card (pivot) | SEO — Positions mois par mois (grille) | tuile grille positions |
+| 49062 | model | SEO Pages Monitoring — Manucurist (model) | modèle pages (clics/gabarit) |
+| 49063 | card (pivot) | SEO — Clics par gabarit de page, mois par mois | tuile pages |
+| 49064 | card (table) | SEO — Δ 6 mois par gabarit | tuile Δ pages |
+| 49425 | model | SEO Saisonnalité — Manucurist (model) | modèle saisonnalité (volume kp 24 mois) |
+| 49426 | card (pivot) | SEO — Saisonnalité (volume de recherche / mois) | tuile saisonnalité |
+| 13489 | dashboard | SEO Historical Search Volume - Template | **template EXISTANT** (pas à nous) lié pour la saisonnalité 48 mois |
+| 32496 | card (table) | Keywords average ranking by date (SERP) | ancienne carte de prod, **optimisée** (voir §6), dans collection SERP #4809, sur dashboard #17250 [IN DEV] |
+
+**Archivés** (prototypes V1/V2 superflus, ne pas réutiliser) : 48501, 48567, 48568, 48600, 48601.
+
+## 3. Le dashboard #25137 (V3) en détail
+3 sections (titres = text cards) :
+- **📊 Vision par mots-clés** : snapshot (#48635) + grille positions (#48634).
+- **🗓️ Saisonnalité** : text card (descriptif seul — **liens #13489 retirés le 2026-06-17**, cassaient hors embed) + pivot saisonnalité (#49426).
+- **📄 Vision par pages** : pivot pages (#49063) + table Δ gabarit (#49064).
+
+**7 filtres** (paramètres dashboard) :
+| slug | type | dropdown | mappé sur (colonne) |
+|---|---|---|---|
+| marche | string/= | FR/US/UK/AUTRES | tuiles kw + pages → `MARCHE` |
+| gamme | string/= | Gel Polish/Nail Polish/Nailcare | tuiles kw → `GAMME` |
+| categorie | string/= | Transactionnel/Générique/Clean / Engagement/Produit/Informationnel | snapshot+grille → `CATEGORIE` |
+| marque | string/= | Marque/Hors Marque | tuiles pages → `MARQUE` |
+| pattern_keyword | string/contains | — | tuiles kw → `KEYWORD` |
+| exact_keyword | string/= | — | tuiles kw → `KEYWORD` |
+| date | date/all-options (défaut `past6months`) | — | grille + saisonnalité + pages → `MONTH_DATE` (PAS le snapshot) |
+
+**Template saisonnalité #13489** : a un filtre **Corpus Name OBLIGATOIRE**. Corpus à passer :
+- US → `Corpus transactionnel US`
+- FR → `Corpus transactionnel FR - Mots clés stratégiques`
+Lien type : `…/dashboard/13489?client=Manucurist&corpus_name=<urlencoded>&date=past48months`.
+> ⚠️ Ces liens ont été **retirés du dashboard client #25137 le 2026-06-17** : ils pointent vers `spark.metabaseapp.com`, hors du périmètre d'auth de l'embed Nanga (`app.nanga.tech`) → le client tombe sur un mur de login. Template encore dispo en interne ; ré-exposer au client = routage côté app Nanga (pas Metabase).
+
+## 4. Modèle mots-clés #48633 (V3) — logique
+Script source : **`scripts/build_seo_monitoring_v3.py`** (relancer = rebuild + PUT + validation snapshot).
+Grain : (marche, gamme, categorie, keyword) × mois (13 mois). 34 kw = 16 US + 18 FR → ~476 lignes.
+Colonnes produites : `MONTH_DATE, MARCHE, GAMME, CATEGORIE, KEYWORD, URL_POSITIONNEE, POSITION, POSITION_SERP, POSITION_GSC, SEARCH_VOLUME, CLICKS, IMPRESSIONS, CLICKS_FR, CLICKS_UK, CLICKS_US, CLICKS_AUTRES, POTENTIEL_TRAFIC, DELTA_M1, DELTA_M3, DELTA_CLICKS_M1`.
+
+Sources & calculs :
+- **POSITION** = `LEAST(COALESCE(<SERP DataForSEO best rank pour la zone du kw>, <GSC avg position pondérée impressions>), 100)`. **100 = non classé**. (SERP = `google_serp.serp_requests ⋈ serp_history ⋈ serp__keyword_metrics`, dédoublonné meilleure position par url/run **partition incluant client_id+corpus_name** sinon collapse cross-client ; filtre `url ILIKE '%'||client_domain||'%'`).
+- **SEARCH_VOLUME** = dernier `COALESCE(adjusted_avg_searches, avg_monthly_searches)` de `google_keyword_planner.kp__keyword_monthly_metrics` (zone du kw). kp **lague ~2 mois** → on prend le dernier connu.
+- **POTENTIEL_TRAFIC** = `ROUND(volume × ctr_medium)` où ctr depuis `metabase_filters.serp_ctr_scenarios` (`name='Default'`, position 0-100, on joint sur `ROUND(position)`).
+- **URL_POSITIONNEE** = URL client de la meilleure position (la plus récente), query string retirée (`REGEXP_REPLACE(url,'[?].*$','')`).
+- **CLICKS** = total GSC par kw/mois (tous marchés) ; **CLICKS_FR/UK/US/AUTRES** = split par marché via la **section de site** (URL) — voir §5.
+- **DELTA_M1/M3** = `LAG(position,n) - position` (+ = positions gagnées) ; **DELTA_CLICKS_M1** = `clicks - LAG(clicks)`.
+
+Mapping **Gamme/Catégorie** : hardcodé dans le script (listes `US` et `FR`). **US = repris du gsheet ; FR = proposition perso à valider.**
+
+## 5. Modèle pages #49062 — logique
+Script : **`scripts/build_seo_pages_model.py`**. Source unique : `google_search_console.gsc__page_keyword_daily_metrics` (~27M lignes, hist. 2024-02→).
+Grain : (marche, gabarit, marque) × mois. Colonnes : `MONTH_DATE, MARCHE, GABARIT, MARQUE, CLICKS, IMPRESSIONS, DELTA_6M_PCT, TENDANCE`.
+- **Marché** = section de site via URL : `us.manucurist.com`→US, `uk.`→UK, `www.manucurist.com/{en,es,it,de,nl,el,pt}`→AUTRES, sinon `www.`→FR.
+- **Gabarit** : `/blogs/`→Blog, `/collections/`→Collections, `/products/`→Produits, sinon Autres pages.
+- **Marque** : requête contient un radical de `gsc__brand_keywords` (manucuri, mancurist…) → Marque, sinon Hors Marque.
+- ⚠️ granularité requête GSC = **échantillonnée** (requêtes anonymisées exclues) → totaux < clics page réels ; fiable en tendance.
+
+## 6. Carte #32496 (optimisée, séparée du livrable V3)
+Ancienne carte de prod corrigée le 2026-05-29 (scripts `apply_fixes_32496.py` + `serp_difftest.py`) :
+- suppr. INNER JOIN `serp_ctr_scenarios` filtrant (perdait positions > 100), suppr. code mort, dédup déterministe `ORDER BY rank_absolute`. Backup : `migration/card-32496-backup-*.json`.
+
+## 7. ⚠️ À VALIDER avec Thibaut/Geoffrey (bloquants métier)
+1. **Mapping Gamme/Catégorie des 18 mots-clés FR** = ma proposition (le gsheet ne les renseigne pas). Voir liste `FR` dans `build_seo_monitoring_v3.py`.
+2. **« led gel polish » (US)** ré-ajouté (présent onglet V3) — OK ?
+3. **Liste des 34 kw figée en dur** → à terme la brancher sur un Sheet/Airtable maintenu par l'équipe SEO.
+- Message de retour à Thibaut **rédigé mais pas envoyé** (dans l'historique conv).
+
+## 8. Conventions & décisions arrêtées
+- **Cadence = mensuelle** (tranché via gsheet V3).
+- **Snapshot = dernier mois COMPLET** (`time-interval -1 month`), pas le mois courant partiel.
+- **Marché = section du site** (le pays du chercheur GSC n'est PAS ingéré : `country='other'` partout pour Manucurist ; table `country_device` vide). Si vrai géo-chercheur voulu = chantier pipeline data.
+- **100 = non classé** (hors top 100), comme le gsheet.
+- **Pliage des pivots** : le toggle `+/−` par groupe (Marché) n'apparaît **que si `pivot.show_column_totals=True`** (le sous-total de groupe le porte ; cf. Pages #49063 qui l'a au défaut, vs Positions/Saiso qui l'avaient à False). Sur Positions ce sous-total = **position moyenne du marché** (compromis assumé pour avoir le pliage) ; `show_row_totals` laissé False (pas de colonne « Row totals » across-mois superflue).
+
+## 9. Gotchas techniques (IMPORTANT pour un agent frais)
+- **Lancer** : `/Users/louismonier/Dev/Pro/spark-metabase-api/.venv/bin/python scripts/<x>.py`. Connexion via `Metabase_API(domain,email,password)` lu de `.env` par `reorg_phase1._load_env`. Mettre une **boucle de retry** (instance lente/instable, timeouts fréquents).
+- **Exécuter du SQL** : `mb.post("/api/dataset","raw",json={"database":144,"type":"native","native":{"query":sql}}, timeout=240+)`. **Le timeout par défaut est 30 s (trop court)** — le passer explicitement (les jointures GSC/SERP prennent 40-600 s).
+- **Tout lancer en background bash + poller le fichier output** (les requêtes sont longues).
+- **`legacy_query` renvoyé par GET /api/card est souvent stale/vide** → ne pas s'y fier pour vérifier le SQL stocké ; vérifier en **runnant** la carte/donnée.
+- **SQL natif ≠ pivot** : une question en SQL natif **ne peut pas** utiliser la viz Pivot Table (« only supported for query builder »). → faire un **modèle** (type=model) puis une **question MBQL** par-dessus (`source-card`).
+- **Redirection ad-hoc `/question#hash`** sur les questions MBQL basées sur un modèle : stocker le `dataset_query` au **format MLv2** (`{"lib/type":"mbql/query","stages":[{... "source-card": <id>, "lib/uuid": <uuid> par clause}]}`) — générer les uuid avec `uuid.uuid4()`. (Le format legacy `{type:query,query:{...}}` marche fonctionnellement mais provoque la redirection.)
+- **result_metadata** : le PUT d'un `dataset_query` la **réinitialise**. Pour la peupler : run via `/api/dataset` → récupérer `data.cols` → PUT **séparé** `{"result_metadata": cols}` (sans toucher dataset_query).
+- **Pivot** : `pivot_table.column_split` = colonnes par **nom** (string) ou field-ref ; désactiver les totaux parasites avec `pivot.show_row_totals=false` / `pivot.show_column_totals=false`. column_split simple `{"rows":["X"],"columns":["Y"],"values":[["aggregation",0]]}` marche pour source-card.
+- **Décimales** : `column_settings` `{"number_style":"decimal","decimals":0}` (clé `["name","<COL>"]` ; pour une valeur d'agrégat pivot, clé `["name","avg"]`/`["name","sum"]`).
+- **Dashboard PUT** : `{"parameters":[...], "dashcards":[...]}`. dashcards neufs = `id` négatif. Titre de tuile = `visualization_settings."card.title"`. Tuiles texte/section = `card_id:null` + `visualization_settings.text` + `virtual_card`. Filtres dropdown = `values_query_type:"list", values_source_type:"static-list", values_source_config.values:[...]`.
+- **Persistance des modèles** : activée globalement + sur DB 144 (le 2026-05-29). Après un rebuild de modèle, la table persistée se re-matérialise au cycle suivant → perf redevient bonne.
+- **Pas de pays/géo réel GSC** : `gsc__site_keyword`/`country_device` ont `country='other'` pour Manucurist → géo = section de site uniquement.
+- **QA navigateur** : Metabase exige une **session connectée dans Chrome** (SSO Google) ; je ne saisis pas d'identifiants — demander à l'utilisateur de se connecter. Ne jamais cliquer « Se connecter avec Google » si ça demande un mot de passe.
+- **Erreur transitoire « There was a problem displaying this chart »** sur la grille Positions (#48634, la + lourde : joints SERP+GSC) au **cold-load concurrent** des cartes → **recharger** la résout (vu en QA 2026-06-17). Ne pas conclure trop vite à une régression ; vérifier d'abord après reload. Renforce le besoin d'activer/fiabiliser la persistance des modèles.
+
+## 10. Inventaire des scripts (`scripts/`)
+Actuels / source de vérité V3 :
+- `build_seo_monitoring_v3.py` — modèle kw #48633 (relance = rebuild+PUT).
+- `build_seo_pages_model.py` — modèle pages #49062.
+- `build_seo_saisonnalite.py` — modèle #49425 + pivot #49426.
+- `build_seo_dashboard_v3.py` — assemble tuiles + 7 filtres + liens saisonnalité (#25137).
+- `probe_v3.py` / `probe_v2.py` — découverte data (réutilisables comme gabarits de sondage).
+Historiques (V1/V2, cartes archivées) : `build_seo_monitoring.py`, `build_seo_grid.py`, `build_seo_dashboard.py`, `build_seo_monitoring_v2.py`, `build_seo_dashboard_v2.py`.
+#32496 : `apply_fixes_32496.py`, `serp_difftest.py`.
+(NB : `scripts/` contient aussi des scripts d'AUTRES projets — find_dupes, prune_unused, reorg_*, rename_* — ne pas confondre.)
+
+## 11. Schéma data utile (Snowflake, db 144)
+- `google_serp.serp_requests` (VIEW : client_id, corpus_name, category, keyword, language, zone, domain) ⋈ `serp_history` ⋈ `serp__keyword_metrics` (keyword, url, request_date, rank_absolute, rank_group, type) → positions client.
+- `google_keyword_planner.kp__keyword_monthly_metrics` (keyword, category, language, zone, month 'YYYY-MM', avg_monthly_searches, adjusted_avg_searches) → volumes (lague ~2 mois).
+- `google_search_console.gsc__page_keyword_daily_metrics` (client_name, page, country['other'], keyword, date, clicks, impressions, position) → clics/impressions/position par page+kw.
+- `google_search_console.gsc__brand_keywords` (client_name, keyword) → radicaux marque.
+- `metabase_filters.serp_ctr_scenarios` (name, position 0-100, ctr_low/medium/high) → CTR par position.
+- `utils.clients` (id, name) — Manucurist id = `recwU4Px1lyw6vq16`.

--- a/docs/superpowers/plans/2026-05-20-generic-questions-reorg-phase1.md
+++ b/docs/superpowers/plans/2026-05-20-generic-questions-reorg-phase1.md
@@ -1,0 +1,1139 @@
+# Generic Questions Reorg — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construire un outil CLI qui réorganise en live la collection Metabase 215 (« 2. Generic Questions ») par déplacements seuls, sans casser aucun dashboard client, avec snapshot, dry-run, vérification d'invariant et rollback.
+
+**Architecture:** Deux fichiers Python sous `scripts/`. `reorg_lib.py` contient toute la logique pure (modèle d'état, chargement du plan déclaratif, calcul des lots d'opérations, vérification d'invariant) — testée unitairement. `reorg_phase1.py` est le CLI : il lit `.env`, appelle l'API Metabase via la librairie `spark_metabase_api`, et orchestre les sous-commandes `snapshot` / `plan` / `apply` / `verify` / `rollback`. Le plan déclaratif `migration/phase1-plan.yaml` est la seule source de vérité des opérations.
+
+**Tech Stack:** Python 3, `spark_metabase_api` (librairie du repo), `PyYAML`, `pytest` (tests), `dataclasses`.
+
+**Spec de référence:** `docs/superpowers/specs/2026-05-20-generic-questions-reorg-phase1-design.md` et `docs/generic-questions-reorg.md`.
+
+---
+
+## Périmètre de ce plan
+
+Les **Tâches 1 à 10 construisent et testent l'outil**. La **migration live elle-même**
+(générer le plan, dry-run, appliquer les lots) est décrite dans la section
+**« Runbook d'exécution »** en fin de document : elle comporte des points de
+validation humaine et **ne doit pas être exécutée automatiquement** par un worker.
+
+## File Structure
+
+| Fichier | Responsabilité |
+|---|---|
+| `scripts/reorg_lib.py` | Logique pure : `MetabaseState`, `CollectionNode`, `CardRef`, `load_plan`, `compute_lots`, `verify_invariant`. Aucun effet de bord, aucun import réseau. |
+| `scripts/reorg_phase1.py` | CLI : argparse, lecture `.env`, connexion Metabase, capture d'état live, exécution des lots, rollback. Importe `reorg_lib`. |
+| `tests/conftest.py` | Ajoute `scripts/` au `sys.path` pour que les tests importent `reorg_lib`. |
+| `tests/test_reorg_lib.py` | Tests unitaires pytest de toute la logique pure. |
+| `migration/phase1-plan.yaml` | Plan déclaratif (généré au runbook, relu par l'utilisateur). |
+| `migration/snapshot-<ts>.json` | État pré-vol capturé au runtime (baseline + rollback). |
+| `migration/families.json` | Map `clé de famille -> id de collection créée`, écrit par `apply lot-1`. |
+
+## Convention de test (adaptation)
+
+Le repo n'utilise aucun framework de test (`tests/integration_test.py` est un script
+autonome). `tests/test_reorg_lib.py` suit cette convention : un script lancé par
+`python3 tests/test_reorg_lib.py` qui exécute toutes ses fonctions `test_*` et sort
+en code ≠ 0 si l'une échoue. Conséquences sur les tâches ci-dessous :
+
+- Toute commande notée `pytest tests/test_reorg_lib.py::<nom>` se lit
+  **`python3 tests/test_reorg_lib.py`** (le runner exécute tous les tests ; on
+  vérifie la ligne `PASS`/`FAIL` de la fonction concernée).
+- Pas de `pytest`, pas de `conftest.py`, pas d'extra `dev` dans `setup.py`.
+- La fixture pytest `tmp_path` est remplacée par `tempfile.TemporaryDirectory()`.
+- `PyYAML` est déjà disponible (extra `iac` du paquet).
+
+## Constantes partagées
+
+Définies en tête de `scripts/reorg_lib.py`, réutilisées partout :
+
+```python
+ROOT_COLLECTION_ID = 215       # "2. Generic Questions"
+EXCLUDE_COLLECTION_ID = 11673  # "18. Nouvelles Conversions" — hors périmètre Phase 1
+TO_SORT_COLLECTION_ID = 7252   # "To sort"
+```
+
+---
+
+## Task 1: Harnais de test + modèle d'état
+
+**Files:**
+- Create: `scripts/reorg_lib.py`
+- Create: `tests/test_reorg_lib.py`
+
+- [ ] **Step 1: Créer `tests/test_reorg_lib.py` avec le harnais et le premier test**
+
+```python
+#!/usr/bin/env python3
+"""Tests unitaires de reorg_lib — script autonome (convention du repo).
+
+Usage : python3 tests/test_reorg_lib.py
+"""
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from reorg_lib import CollectionNode, CardRef, MetabaseState
+
+
+def test_metabase_state_roundtrip():
+    state = MetabaseState(
+        collections={
+            215: CollectionNode(id=215, name="2. Generic Questions", parent_id=None),
+            214: CollectionNode(id=214, name="01. Global", parent_id=215),
+        },
+        cards={
+            29: CardRef(id=29, name="CAC", collection_id=214,
+                        dashboard_count=1211, archived=False),
+        },
+    )
+    restored = MetabaseState.from_dict(state.to_dict())
+    assert restored == state
+    assert restored.cards[29].dashboard_count == 1211
+
+
+TESTS = [test_metabase_state_roundtrip]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()
+```
+
+Chaque tâche suivante **ajoute** sa fonction `test_*` et l'inscrit dans `TESTS`.
+
+- [ ] **Step 2: Lancer le test, vérifier qu'il échoue**
+
+Run: `python3 tests/test_reorg_lib.py`
+Expected: erreur — `ModuleNotFoundError: No module named 'reorg_lib'`.
+
+- [ ] **Step 3: Implémenter le modèle d'état dans `scripts/reorg_lib.py`**
+
+```python
+"""Logique pure de la migration Phase 1 — aucun effet de bord, aucun réseau."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ROOT_COLLECTION_ID = 215
+EXCLUDE_COLLECTION_ID = 11673
+TO_SORT_COLLECTION_ID = 7252
+
+
+@dataclass(frozen=True)
+class CollectionNode:
+    id: int
+    name: str
+    parent_id: int | None
+
+
+@dataclass(frozen=True)
+class CardRef:
+    id: int
+    name: str
+    collection_id: int
+    dashboard_count: int
+    archived: bool
+
+
+@dataclass
+class MetabaseState:
+    collections: dict[int, CollectionNode]
+    cards: dict[int, CardRef]
+
+    def to_dict(self) -> dict:
+        return {
+            "collections": [
+                {"id": c.id, "name": c.name, "parent_id": c.parent_id}
+                for c in self.collections.values()
+            ],
+            "cards": [
+                {"id": c.id, "name": c.name, "collection_id": c.collection_id,
+                 "dashboard_count": c.dashboard_count, "archived": c.archived}
+                for c in self.cards.values()
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "MetabaseState":
+        collections = {
+            c["id"]: CollectionNode(id=c["id"], name=c["name"],
+                                    parent_id=c["parent_id"])
+            for c in data["collections"]
+        }
+        cards = {
+            c["id"]: CardRef(id=c["id"], name=c["name"],
+                             collection_id=c["collection_id"],
+                             dashboard_count=c["dashboard_count"],
+                             archived=c["archived"])
+            for c in data["cards"]
+        }
+        return cls(collections=collections, cards=cards)
+```
+
+- [ ] **Step 4: Lancer le test, vérifier qu'il passe**
+
+Run: `python3 tests/test_reorg_lib.py`
+Expected: `PASS  test_metabase_state_roundtrip` ; `1/1 tests passés`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/reorg_lib.py tests/test_reorg_lib.py
+git commit -m "reorg: modèle d'état pour la migration Phase 1"
+```
+
+---
+
+## Task 2: Chargement du plan déclaratif
+
+**Files:**
+- Modify: `scripts/reorg_lib.py`
+- Test: `tests/test_reorg_lib.py`
+
+Le plan YAML a cette forme (exemple minimal) :
+
+```yaml
+families:
+  - key: ad_platforms
+    name: "Ad platforms"
+    description: "Questions spécifiques à une plateforme publicitaire"
+collection_moves:
+  - id: 209
+    new_parent: ad_platforms
+    new_name: "Google Ads"
+card_filing:
+  46255: 217      # card_id -> id de la collection de destination
+delete_empty:
+  - 211           # "04. Microsoft"
+```
+
+- [ ] **Step 1: Écrire le test de `load_plan`**
+
+Ajouter dans `tests/test_reorg_lib.py` :
+
+```python
+import textwrap
+from reorg_lib import load_plan, FamilySpec, CollectionMove
+
+
+def test_load_plan(tmp_path):
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(textwrap.dedent("""
+        families:
+          - key: ad_platforms
+            name: "Ad platforms"
+            description: "Plateformes publicitaires"
+        collection_moves:
+          - id: 209
+            new_parent: ad_platforms
+            new_name: "Google Ads"
+        card_filing:
+          46255: 217
+        delete_empty:
+          - 211
+    """))
+    plan = load_plan(plan_file)
+    assert plan.families == [FamilySpec(key="ad_platforms", name="Ad platforms",
+                                        description="Plateformes publicitaires")]
+    assert plan.collection_moves == [CollectionMove(id=209, new_parent="ad_platforms",
+                                                    new_name="Google Ads")]
+    assert plan.card_filing == {46255: 217}
+    assert plan.delete_empty == [211]
+```
+
+- [ ] **Step 2: Lancer le test, vérifier qu'il échoue**
+
+Run: `pytest tests/test_reorg_lib.py::test_load_plan -v`
+Expected: FAIL — `ImportError: cannot import name 'load_plan'`.
+
+- [ ] **Step 3: Implémenter `load_plan` dans `scripts/reorg_lib.py`**
+
+Ajouter en tête : `import yaml` et `from pathlib import Path`. Puis :
+
+```python
+@dataclass(frozen=True)
+class FamilySpec:
+    key: str
+    name: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class CollectionMove:
+    id: int
+    new_parent: str   # clé de famille, ou "root"
+    new_name: str
+
+
+@dataclass
+class Phase1Plan:
+    families: list[FamilySpec]
+    collection_moves: list[CollectionMove]
+    card_filing: dict[int, int]   # card_id -> id collection destination
+    delete_empty: list[int]
+
+
+def load_plan(path) -> Phase1Plan:
+    data = yaml.safe_load(Path(path).read_text()) or {}
+    families = [FamilySpec(key=f["key"], name=f["name"],
+                           description=f.get("description", ""))
+                for f in data.get("families", [])]
+    moves = [CollectionMove(id=m["id"], new_parent=m["new_parent"],
+                            new_name=m["new_name"])
+             for m in data.get("collection_moves", [])]
+    card_filing = {int(k): int(v) for k, v in (data.get("card_filing") or {}).items()}
+    delete_empty = [int(x) for x in data.get("delete_empty", [])]
+    return Phase1Plan(families=families, collection_moves=moves,
+                      card_filing=card_filing, delete_empty=delete_empty)
+```
+
+- [ ] **Step 4: Lancer le test, vérifier qu'il passe**
+
+Run: `pytest tests/test_reorg_lib.py::test_load_plan -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/reorg_lib.py tests/test_reorg_lib.py
+git commit -m "reorg: chargement du plan déclaratif phase1-plan.yaml"
+```
+
+---
+
+## Task 3: Vérification d'invariant (cœur de sécurité)
+
+**Files:**
+- Modify: `scripts/reorg_lib.py`
+- Test: `tests/test_reorg_lib.py`
+
+`verify_invariant` compare un état baseline (snapshot) à un état courant et retourne
+la liste des divergences interdites. Un **déplacement** de carte (changement de
+`collection_id`) n'est PAS une divergence — c'est l'opération attendue. Les
+divergences sont : carte perdue, carte archivée, `dashboard_count` modifié.
+
+- [ ] **Step 1: Écrire les tests de `verify_invariant`**
+
+Ajouter dans `tests/test_reorg_lib.py` :
+
+```python
+from reorg_lib import verify_invariant, Divergence
+
+
+def _state(cards):
+    return MetabaseState(collections={}, cards={c.id: c for c in cards})
+
+
+def test_verify_invariant_clean_when_only_moved():
+    base = _state([CardRef(29, "CAC", 214, 1211, False)])
+    # même carte, collection différente -> déplacement légitime, pas de divergence
+    current = _state([CardRef(29, "CAC", 999, 1211, False)])
+    assert verify_invariant(base, current) == []
+
+
+def test_verify_invariant_detects_lost_card():
+    base = _state([CardRef(29, "CAC", 214, 1211, False)])
+    current = _state([])
+    divs = verify_invariant(base, current)
+    assert [d.kind for d in divs] == ["lost_card"]
+    assert divs[0].card_id == 29
+
+
+def test_verify_invariant_detects_archived_card():
+    base = _state([CardRef(29, "CAC", 214, 1211, False)])
+    current = _state([CardRef(29, "CAC", 214, 1211, True)])
+    divs = verify_invariant(base, current)
+    assert [d.kind for d in divs] == ["archived_card"]
+
+
+def test_verify_invariant_detects_dashboard_count_change():
+    base = _state([CardRef(29, "CAC", 214, 1211, False)])
+    current = _state([CardRef(29, "CAC", 214, 1210, False)])
+    divs = verify_invariant(base, current)
+    assert [d.kind for d in divs] == ["dashboard_count_changed"]
+```
+
+- [ ] **Step 2: Lancer les tests, vérifier qu'ils échouent**
+
+Run: `pytest tests/test_reorg_lib.py -k verify_invariant -v`
+Expected: FAIL — `ImportError: cannot import name 'verify_invariant'`.
+
+- [ ] **Step 3: Implémenter `verify_invariant` dans `scripts/reorg_lib.py`**
+
+```python
+@dataclass(frozen=True)
+class Divergence:
+    kind: str        # "lost_card" | "archived_card" | "dashboard_count_changed"
+    card_id: int
+    detail: str
+
+
+def verify_invariant(baseline: MetabaseState,
+                     current: MetabaseState) -> list[Divergence]:
+    """Retourne les divergences interdites entre l'état baseline et l'état courant.
+
+    Un changement de `collection_id` (déplacement) n'est PAS une divergence.
+    """
+    out: list[Divergence] = []
+    for cid, base in baseline.cards.items():
+        cur = current.cards.get(cid)
+        if cur is None:
+            out.append(Divergence("lost_card", cid,
+                                   f"{base.name!r} absente de l'état courant"))
+            continue
+        if cur.archived and not base.archived:
+            out.append(Divergence("archived_card", cid,
+                                   f"{base.name!r} a été archivée"))
+        if cur.dashboard_count != base.dashboard_count:
+            out.append(Divergence(
+                "dashboard_count_changed", cid,
+                f"{base.name!r}: dashboard_count "
+                f"{base.dashboard_count} -> {cur.dashboard_count}"))
+    return out
+```
+
+- [ ] **Step 4: Lancer les tests, vérifier qu'ils passent**
+
+Run: `pytest tests/test_reorg_lib.py -k verify_invariant -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/reorg_lib.py tests/test_reorg_lib.py
+git commit -m "reorg: vérification d'invariant de non-régression"
+```
+
+---
+
+## Task 4: Calcul des lots d'opérations
+
+**Files:**
+- Modify: `scripts/reorg_lib.py`
+- Test: `tests/test_reorg_lib.py`
+
+`compute_lots` transforme `(state, plan)` en un dict ordonné `nom de lot -> liste
+d'opérations`. Les lots :
+
+- `lot-1` : créer les familles (`create_collection`).
+- `lot-2` : déplacer/renommer les collections (`move_collection`).
+- `lot-3` : déplacer les cartes dont la collection courante n'est PAS `To sort`.
+- `lot-4` : déplacer les cartes dont la collection courante EST `To sort`.
+- `lot-5` : supprimer les collections vides (`delete_collection`).
+
+Le `new_parent` d'un `move_collection` est une **clé de famille** ; elle n'est
+résolue en id réel que pendant `apply` (les familles n'existent pas avant `lot-1`).
+`compute_lots` laisse donc la clé telle quelle dans `Op.payload["new_parent_key"]`.
+
+- [ ] **Step 1: Écrire le test de `compute_lots`**
+
+Ajouter dans `tests/test_reorg_lib.py` :
+
+```python
+from reorg_lib import (compute_lots, FamilySpec, CollectionMove, Phase1Plan,
+                       TO_SORT_COLLECTION_ID)
+
+
+def test_compute_lots_groups_operations():
+    state = MetabaseState(
+        collections={
+            209: CollectionNode(209, "02. Google", 215),
+            211: CollectionNode(211, "04. Microsoft", 215),
+        },
+        cards={
+            46255: CardRef(46255, "Loose card", 214, 0, False),
+            777: CardRef(777, "To-sort card", TO_SORT_COLLECTION_ID, 3, False),
+        },
+    )
+    plan = Phase1Plan(
+        families=[FamilySpec("ad_platforms", "Ad platforms")],
+        collection_moves=[CollectionMove(209, "ad_platforms", "Google Ads")],
+        card_filing={46255: 217, 777: 218},
+        delete_empty=[211],
+    )
+    lots = compute_lots(state, plan)
+    assert [op.kind for op in lots["lot-1"]] == ["create_collection"]
+    assert [op.kind for op in lots["lot-2"]] == ["move_collection"]
+    assert lots["lot-2"][0].payload["new_parent_key"] == "ad_platforms"
+    assert [op.payload["card_id"] for op in lots["lot-3"]] == [46255]
+    assert [op.payload["card_id"] for op in lots["lot-4"]] == [777]
+    assert [op.payload["collection_id"] for op in lots["lot-5"]] == [211]
+```
+
+- [ ] **Step 2: Lancer le test, vérifier qu'il échoue**
+
+Run: `pytest tests/test_reorg_lib.py::test_compute_lots_groups_operations -v`
+Expected: FAIL — `ImportError: cannot import name 'compute_lots'`.
+
+- [ ] **Step 3: Implémenter `compute_lots` et `Op` dans `scripts/reorg_lib.py`**
+
+```python
+@dataclass(frozen=True)
+class Op:
+    lot: str
+    kind: str        # create_collection|move_collection|move_card|delete_collection
+    summary: str
+    payload: dict
+
+
+def compute_lots(state: MetabaseState, plan: Phase1Plan) -> dict[str, list[Op]]:
+    lots: dict[str, list[Op]] = {f"lot-{i}": [] for i in range(1, 6)}
+
+    for fam in plan.families:
+        lots["lot-1"].append(Op(
+            "lot-1", "create_collection",
+            f"Créer la famille « {fam.name} »",
+            {"key": fam.key, "name": fam.name, "description": fam.description}))
+
+    for mv in plan.collection_moves:
+        old = state.collections.get(mv.id)
+        old_name = old.name if old else f"#{mv.id}"
+        lots["lot-2"].append(Op(
+            "lot-2", "move_collection",
+            f"Déplacer « {old_name} » -> famille « {mv.new_parent} », "
+            f"renommer en « {mv.new_name} »",
+            {"collection_id": mv.id, "new_parent_key": mv.new_parent,
+             "new_name": mv.new_name}))
+
+    for card_id, dest in plan.card_filing.items():
+        card = state.cards.get(card_id)
+        if card is None:
+            raise ValueError(f"card_filing référence une carte inconnue: {card_id}")
+        lot = "lot-4" if card.collection_id == TO_SORT_COLLECTION_ID else "lot-3"
+        lots[lot].append(Op(
+            lot, "move_card",
+            f"Déplacer la carte « {card.name} » (#{card_id}) "
+            f"de la collection {card.collection_id} vers {dest}",
+            {"card_id": card_id, "collection_id": dest}))
+
+    for coll_id in plan.delete_empty:
+        old = state.collections.get(coll_id)
+        old_name = old.name if old else f"#{coll_id}"
+        lots["lot-5"].append(Op(
+            "lot-5", "delete_collection",
+            f"Supprimer la collection vide « {old_name} »",
+            {"collection_id": coll_id}))
+
+    return lots
+```
+
+- [ ] **Step 4: Lancer le test, vérifier qu'il passe**
+
+Run: `pytest tests/test_reorg_lib.py::test_compute_lots_groups_operations -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lancer toute la suite**
+
+Run: `pytest tests/test_reorg_lib.py -v`
+Expected: PASS (tous les tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/reorg_lib.py tests/test_reorg_lib.py
+git commit -m "reorg: calcul des lots d'opérations à partir du plan"
+```
+
+---
+
+## Task 5: Squelette du CLI et connexion Metabase
+
+**Files:**
+- Create: `scripts/reorg_phase1.py`
+
+- [ ] **Step 1: Créer `scripts/reorg_phase1.py` avec le CLI et la connexion**
+
+```python
+#!/usr/bin/env python3
+"""CLI de migration Phase 1 de la collection Metabase « 2. Generic Questions ».
+
+Sous-commandes : snapshot | plan | apply | verify | rollback.
+Voir docs/superpowers/specs/2026-05-20-generic-questions-reorg-phase1-design.md
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+
+
+def _load_env() -> dict:
+    """Lit les paires KEY=VALUE de .env (sans dépendance externe)."""
+    env = {}
+    env_file = REPO_ROOT / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            env[key.strip()] = value.strip()
+    return env
+
+
+def connect() -> Metabase_API:
+    """Connexion Metabase depuis .env (session_id prioritaire)."""
+    env = _load_env()
+    domain = env.get("METABASE_DOMAIN") or os.environ.get("METABASE_DOMAIN")
+    session_id = env.get("METABASE_SESSION_ID") or os.environ.get("METABASE_SESSION_ID")
+    email = env.get("METABASE_EMAIL") or os.environ.get("METABASE_EMAIL")
+    password = env.get("METABASE_PASSWORD") or os.environ.get("METABASE_PASSWORD")
+    if not domain:
+        sys.exit("METABASE_DOMAIN manquant (.env ou environnement).")
+    if session_id:
+        mb = Metabase_API(domain=domain, session_id=session_id)
+        if mb.is_session_valid():
+            return mb
+        print("session_id expiré — bascule sur email/password.")
+    if not (email and password):
+        sys.exit("Aucune session valide et METABASE_EMAIL/PASSWORD manquants.")
+    return Metabase_API(domain=domain, email=email, password=password)
+
+
+def cmd_snapshot(args):
+    raise NotImplementedError
+
+
+def cmd_plan(args):
+    raise NotImplementedError
+
+
+def cmd_apply(args):
+    raise NotImplementedError
+
+
+def cmd_verify(args):
+    raise NotImplementedError
+
+
+def cmd_rollback(args):
+    raise NotImplementedError
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Migration Phase 1 collection 215")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("snapshot", help="Capturer l'état du sous-arbre 215")
+
+    p_plan = sub.add_parser("plan", help="Dry-run : afficher tous les déplacements")
+    p_plan.add_argument("--snapshot", required=True)
+    p_plan.add_argument("--plan", default=str(MIGRATION_DIR / "phase1-plan.yaml"))
+
+    p_apply = sub.add_parser("apply", help="Exécuter un lot du plan")
+    p_apply.add_argument("lot", choices=[f"lot-{i}" for i in range(1, 6)])
+    p_apply.add_argument("--snapshot", required=True)
+    p_apply.add_argument("--plan", default=str(MIGRATION_DIR / "phase1-plan.yaml"))
+    p_apply.add_argument("--yes", action="store_true", help="Sans confirmation")
+
+    p_verify = sub.add_parser("verify", help="Comparer l'état live au snapshot")
+    p_verify.add_argument("--snapshot", required=True)
+
+    p_rollback = sub.add_parser("rollback", help="Restaurer les positions du snapshot")
+    p_rollback.add_argument("--snapshot", required=True)
+    p_rollback.add_argument("--yes", action="store_true")
+
+    args = parser.parse_args(argv)
+    {"snapshot": cmd_snapshot, "plan": cmd_plan, "apply": cmd_apply,
+     "verify": cmd_verify, "rollback": cmd_rollback}[args.command](args)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Vérifier que le CLI se charge et affiche l'aide**
+
+Run: `python scripts/reorg_phase1.py --help`
+Expected: l'aide liste les sous-commandes `snapshot, plan, apply, verify, rollback`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/reorg_phase1.py
+git commit -m "reorg: squelette CLI + connexion Metabase depuis .env"
+```
+
+---
+
+## Task 6: Capture d'état et commande `snapshot`
+
+**Files:**
+- Modify: `scripts/reorg_lib.py` (ajouter `capture_state`)
+- Modify: `scripts/reorg_phase1.py` (implémenter `cmd_snapshot`)
+- Test: `tests/test_reorg_lib.py`
+
+`capture_state` parcourt récursivement le sous-arbre d'une collection racine. Elle
+prend une fonction `get(endpoint)` en argument (pas l'objet Metabase) pour être
+testable avec un faux client. Elle exclut le sous-arbre `EXCLUDE_COLLECTION_ID` du
+parcours des cartes mais enregistre la collection elle-même.
+
+- [ ] **Step 1: Écrire le test de `capture_state` avec un faux client**
+
+Ajouter dans `tests/test_reorg_lib.py` :
+
+```python
+from reorg_lib import capture_state
+
+
+def test_capture_state_walks_tree_and_excludes_conversions():
+    # Faux backend : réponses canned indexées par endpoint.
+    items = {
+        "/api/collection/215/items?limit=2000": {"data": [
+            {"model": "collection", "id": 214, "name": "01. Global"},
+            {"model": "collection", "id": 11673, "name": "18. Nouvelles Conversions"},
+            {"model": "card", "id": 29, "name": "CAC"},
+        ]},
+        "/api/collection/214/items?limit=2000": {"data": [
+            {"model": "card", "id": 46255, "name": "Loose card"},
+        ]},
+        # le sous-arbre de 11673 ne doit jamais être demandé
+    }
+    cards = {
+        29: {"id": 29, "name": "CAC", "collection_id": 215,
+             "dashboard_count": 1211, "archived": False},
+        46255: {"id": 46255, "name": "Loose card", "collection_id": 214,
+                "dashboard_count": 0, "archived": False},
+    }
+
+    def fake_get(endpoint):
+        if "/items" in endpoint:
+            return items[endpoint]
+        card_id = int(endpoint.split("/")[-1])
+        return cards[card_id]
+
+    state = capture_state(fake_get, root_id=215)
+    assert set(state.collections) == {215, 214, 11673}
+    assert set(state.cards) == {29, 46255}
+    assert state.collections[214].parent_id == 215
+```
+
+- [ ] **Step 2: Lancer le test, vérifier qu'il échoue**
+
+Run: `pytest tests/test_reorg_lib.py::test_capture_state_walks_tree_and_excludes_conversions -v`
+Expected: FAIL — `ImportError: cannot import name 'capture_state'`.
+
+- [ ] **Step 3: Implémenter `capture_state` dans `scripts/reorg_lib.py`**
+
+```python
+def capture_state(get, root_id: int = ROOT_COLLECTION_ID) -> MetabaseState:
+    """Parcourt le sous-arbre `root_id` et capture collections + cartes.
+
+    `get` est une fonction `endpoint -> json`. Le sous-arbre
+    EXCLUDE_COLLECTION_ID est enregistré comme collection mais son contenu
+    n'est pas parcouru.
+    """
+    collections: dict[int, CollectionNode] = {
+        root_id: CollectionNode(id=root_id, name="(root)", parent_id=None)
+    }
+    cards: dict[int, CardRef] = {}
+
+    def walk(coll_id: int):
+        items = get(f"/api/collection/{coll_id}/items?limit=2000").get("data", [])
+        for it in items:
+            if it["model"] == "collection":
+                collections[it["id"]] = CollectionNode(
+                    id=it["id"], name=it["name"], parent_id=coll_id)
+                if it["id"] != EXCLUDE_COLLECTION_ID:
+                    walk(it["id"])
+            elif it["model"] in ("card", "dataset"):
+                detail = get(f"/api/card/{it['id']}")
+                cards[it["id"]] = CardRef(
+                    id=detail["id"], name=detail["name"],
+                    collection_id=detail.get("collection_id"),
+                    dashboard_count=detail.get("dashboard_count", 0),
+                    archived=bool(detail.get("archived", False)))
+
+    walk(root_id)
+    return MetabaseState(collections=collections, cards=cards)
+```
+
+- [ ] **Step 4: Lancer le test, vérifier qu'il passe**
+
+Run: `pytest tests/test_reorg_lib.py::test_capture_state_walks_tree_and_excludes_conversions -v`
+Expected: PASS.
+
+- [ ] **Step 5: Implémenter `cmd_snapshot` dans `scripts/reorg_phase1.py`**
+
+Ajouter les imports en tête : `import json`, `from datetime import datetime`,
+`from reorg_lib import capture_state, ROOT_COLLECTION_ID`. Remplacer `cmd_snapshot` :
+
+```python
+def cmd_snapshot(args):
+    mb = connect()
+    print(f"Capture du sous-arbre de la collection {ROOT_COLLECTION_ID}...")
+    state = capture_state(mb.get, root_id=ROOT_COLLECTION_ID)
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = MIGRATION_DIR / f"snapshot-{ts}.json"
+    out.write_text(json.dumps(state.to_dict(), indent=2, ensure_ascii=False))
+    print(f"  {len(state.collections)} collections, {len(state.cards)} cartes")
+    print(f"Snapshot écrit : {out}")
+```
+
+- [ ] **Step 6: Exécuter `snapshot` en réel (lecture seule)**
+
+Run: `python scripts/reorg_phase1.py snapshot`
+Expected: affiche ~222 collections et ~3181 cartes ; crée `migration/snapshot-<ts>.json`.
+Note : si « session_id expiré », rafraîchir `METABASE_SESSION_ID` dans `.env`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/reorg_lib.py scripts/reorg_phase1.py tests/test_reorg_lib.py
+git commit -m "reorg: capture d'état et commande snapshot"
+```
+
+---
+
+## Task 7: Commande `plan` (dry-run)
+
+**Files:**
+- Modify: `scripts/reorg_phase1.py` (implémenter `cmd_plan`)
+
+- [ ] **Step 1: Implémenter `cmd_plan` dans `scripts/reorg_phase1.py`**
+
+Ajouter à l'import `reorg_lib` : `load_plan, compute_lots, MetabaseState`.
+Remplacer `cmd_plan` :
+
+```python
+def cmd_plan(args):
+    state = MetabaseState.from_dict(json.loads(Path(args.snapshot).read_text()))
+    plan = load_plan(args.plan)
+    lots = compute_lots(state, plan)
+    total = 0
+    for lot_name in (f"lot-{i}" for i in range(1, 6)):
+        ops = lots[lot_name]
+        print(f"\n=== {lot_name} ({len(ops)} opérations) ===")
+        for op in ops:
+            print(f"  - {op.summary}")
+        total += len(ops)
+    print(f"\nTotal : {total} opérations. (DRY-RUN — rien n'a été modifié.)")
+```
+
+- [ ] **Step 2: Vérifier le dry-run sur un plan minimal**
+
+Créer un fichier de test temporaire `migration/phase1-plan.yaml` minimal (une
+famille, un `delete_empty`), puis :
+
+Run: `python scripts/reorg_phase1.py plan --snapshot migration/snapshot-<ts>.json`
+Expected: affiche les 5 lots et se termine par « DRY-RUN — rien n'a été modifié ».
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/reorg_phase1.py
+git commit -m "reorg: commande plan (dry-run du diff)"
+```
+
+---
+
+## Task 8: Commande `apply` avec vérification post-lot
+
+**Files:**
+- Modify: `scripts/reorg_phase1.py` (implémenter `cmd_apply`)
+
+`apply` exécute un lot, puis re-capture l'état et lance `verify_invariant` contre le
+snapshot baseline. Toute divergence → arrêt avec code de sortie non nul. `lot-1`
+écrit `migration/families.json` (clé -> id créé) ; `lot-2` le relit pour résoudre
+`new_parent_key`.
+
+- [ ] **Step 1: Implémenter `cmd_apply` et ses helpers dans `scripts/reorg_phase1.py`**
+
+Ajouter à l'import `reorg_lib` : `verify_invariant, TO_SORT_COLLECTION_ID`.
+Remplacer `cmd_apply` et ajouter les helpers :
+
+```python
+FAMILIES_FILE_NAME = "families.json"
+
+
+def _families_path():
+    return MIGRATION_DIR / FAMILIES_FILE_NAME
+
+
+def _check(status, what):
+    """`mb.put` renvoie un code HTTP — on échoue fort si non-2xx."""
+    if not (200 <= int(status) < 300):
+        raise RuntimeError(f"{what} a échoué — HTTP {status}")
+
+
+def _exec_op(mb, op, family_ids):
+    if op.kind == "create_collection":
+        coll = mb.create_collection(
+            collection_name=op.payload["name"],
+            parent_collection_id=ROOT_COLLECTION_ID,
+            return_results=True)
+        if not coll:
+            raise RuntimeError(f"Échec création collection {op.payload['name']!r}")
+        desc = op.payload.get("description", "")
+        if desc:
+            _check(mb.put(f"/api/collection/{coll['id']}",
+                          json={"description": desc}), "MAJ description")
+        family_ids[op.payload["key"]] = coll["id"]
+        print(f"  créée : {op.payload['name']} (id {coll['id']})")
+    elif op.kind == "move_collection":
+        key = op.payload["new_parent_key"]
+        parent = ROOT_COLLECTION_ID if key == "root" else family_ids[key]
+        _check(mb.put(f"/api/collection/{op.payload['collection_id']}",
+                      json={"parent_id": parent, "name": op.payload["new_name"]}),
+               f"déplacement collection {op.payload['collection_id']}")
+        print(f"  déplacée : collection {op.payload['collection_id']} "
+              f"-> parent {parent}")
+    elif op.kind == "move_card":
+        _check(mb.put(f"/api/card/{op.payload['card_id']}",
+                      json={"collection_id": op.payload["collection_id"]}),
+               f"déplacement carte {op.payload['card_id']}")
+        print(f"  carte {op.payload['card_id']} -> "
+              f"collection {op.payload['collection_id']}")
+    elif op.kind == "delete_collection":
+        cid = op.payload["collection_id"]
+        resp = mb.get(f"/api/collection/{cid}/items?limit=10")
+        if resp is False:
+            raise RuntimeError(f"impossible de lister la collection {cid}")
+        items = resp.get("data", [])
+        if items:
+            print(f"  IGNORÉE : collection {cid} non vide "
+                  f"({len(items)} éléments) — suppression annulée")
+            return
+        _check(mb.put(f"/api/collection/{cid}", json={"archived": True}),
+               f"archivage collection {cid}")
+        print(f"  collection {cid} archivée (vide)")
+    else:
+        raise ValueError(f"opération inconnue : {op.kind}")
+
+
+def cmd_apply(args):
+    baseline = MetabaseState.from_dict(json.loads(Path(args.snapshot).read_text()))
+    plan = load_plan(args.plan)
+    lots = compute_lots(baseline, plan)
+    ops = lots[args.lot]
+    if not ops:
+        print(f"{args.lot} : aucune opération.")
+        return
+
+    print(f"\n=== {args.lot} : {len(ops)} opérations ===")
+    for op in ops:
+        print(f"  - {op.summary}")
+    if not args.yes:
+        if input(f"\nAppliquer {args.lot} ? [tape 'oui'] ").strip() != "oui":
+            sys.exit("Annulé.")
+
+    mb = connect()
+    family_ids = {}
+    if _families_path().exists():
+        family_ids = json.loads(_families_path().read_text())
+
+    for op in ops:
+        _exec_op(mb, op, family_ids)
+
+    if args.lot == "lot-1":
+        _families_path().write_text(json.dumps(family_ids, indent=2))
+        print(f"Familles enregistrées : {_families_path()}")
+
+    print("\nVérification d'invariant post-lot...")
+    current = capture_state(mb.get, root_id=ROOT_COLLECTION_ID)
+    divergences = verify_invariant(baseline, current)
+    if divergences:
+        print("DIVERGENCES DÉTECTÉES — ARRÊT :")
+        for d in divergences:
+            print(f"  [{d.kind}] carte {d.card_id} : {d.detail}")
+        sys.exit(1)
+    print(f"OK — {len(current.cards)} cartes intactes, 0 divergence.")
+```
+
+- [ ] **Step 2: Vérifier que `apply` refuse sans confirmation**
+
+Run: `echo "non" | python scripts/reorg_phase1.py apply lot-1 --snapshot migration/snapshot-<ts>.json`
+Expected: se termine par « Annulé. » sans aucun appel d'écriture.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/reorg_phase1.py
+git commit -m "reorg: commande apply avec vérification d'invariant post-lot"
+```
+
+---
+
+## Task 9: Commandes `verify` et `rollback`
+
+**Files:**
+- Modify: `scripts/reorg_phase1.py` (implémenter `cmd_verify`, `cmd_rollback`)
+
+- [ ] **Step 1: Implémenter `cmd_verify` et `cmd_rollback`**
+
+Remplacer les deux fonctions :
+
+```python
+def cmd_verify(args):
+    baseline = MetabaseState.from_dict(json.loads(Path(args.snapshot).read_text()))
+    mb = connect()
+    current = capture_state(mb.get, root_id=ROOT_COLLECTION_ID)
+    divergences = verify_invariant(baseline, current)
+    if divergences:
+        print(f"{len(divergences)} divergence(s) :")
+        for d in divergences:
+            print(f"  [{d.kind}] carte {d.card_id} : {d.detail}")
+        sys.exit(1)
+    print(f"OK — {len(current.cards)} cartes, 0 divergence vs snapshot.")
+
+
+def cmd_rollback(args):
+    baseline = MetabaseState.from_dict(json.loads(Path(args.snapshot).read_text()))
+    if not args.yes:
+        if input("Restaurer toutes les positions du snapshot ? [tape 'oui'] "
+                 ).strip() != "oui":
+            sys.exit("Annulé.")
+    mb = connect()
+    current = capture_state(mb.get, root_id=ROOT_COLLECTION_ID)
+
+    # Restaurer collection_id de chaque carte déplacée.
+    for cid, base in baseline.cards.items():
+        cur = current.cards.get(cid)
+        if cur and cur.collection_id != base.collection_id:
+            mb.put(f"/api/card/{cid}", json={"collection_id": base.collection_id})
+            print(f"  carte {cid} restaurée -> collection {base.collection_id}")
+
+    # Restaurer parent_id de chaque collection déplacée (présente dans le snapshot).
+    for coll_id, base in baseline.collections.items():
+        if coll_id == ROOT_COLLECTION_ID:
+            continue
+        cur = current.collections.get(coll_id)
+        if cur and cur.parent_id != base.parent_id:
+            mb.put(f"/api/collection/{coll_id}",
+                   json={"parent_id": base.parent_id, "name": base.name})
+            print(f"  collection {coll_id} restaurée -> parent {base.parent_id}")
+
+    print("Rollback terminé. Les familles créées (absentes du snapshot) "
+          "sont à archiver manuellement si besoin.")
+```
+
+- [ ] **Step 2: Vérifier `verify` contre le snapshot (état non encore modifié)**
+
+Run: `python scripts/reorg_phase1.py verify --snapshot migration/snapshot-<ts>.json`
+Expected: « OK — N cartes, 0 divergence vs snapshot. »
+
+- [ ] **Step 3: Lancer toute la suite de tests**
+
+Run: `pytest tests/test_reorg_lib.py -v`
+Expected: PASS (tous les tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/reorg_phase1.py
+git commit -m "reorg: commandes verify et rollback"
+```
+
+---
+
+## Task 10: Validation end-to-end en lecture seule
+
+**Files:** aucun fichier modifié — tâche de validation.
+
+- [ ] **Step 1: Snapshot frais**
+
+Run: `python scripts/reorg_phase1.py snapshot`
+Expected: ~222 collections, ~3181 cartes ; nouveau fichier snapshot.
+
+- [ ] **Step 2: Vérifier que la collection Conversions est bien capturée mais exclue du parcours**
+
+Run: `python -c "import json,glob; s=json.load(open(sorted(glob.glob('migration/snapshot-*.json'))[-1])); ids={c['id'] for c in s['collections']}; print('11673 présent:', 11673 in ids); print('cartes:', len(s['cards']))"`
+Expected: `11673 présent: True` ; le nombre de cartes est ~1212 (sous-arbre Conversions non parcouru) — confirme que `EXCLUDE_COLLECTION_ID` fonctionne.
+
+- [ ] **Step 3: Vérifier l'idempotence de `verify`**
+
+Run: `python scripts/reorg_phase1.py verify --snapshot migration/snapshot-<ts>.json`
+Expected: « 0 divergence » (l'état n'a pas changé).
+
+- [ ] **Step 4: Ignorer les artefacts runtime de migration + commit**
+
+Les snapshots et `families.json` sont volumineux et régénérables — on ne les
+versionne pas. Ajouter à `.gitignore` :
+
+```
+# Migration Phase 1 — artefacts runtime (régénérables)
+migration/snapshot-*.json
+migration/families.json
+```
+
+```bash
+git add .gitignore
+git commit -m "reorg: ignorer les artefacts runtime de migration"
+```
+
+---
+
+## Runbook d'exécution (NON auto-exécutable — gates humains)
+
+Ces étapes effectuent la migration live et comportent des validations humaines.
+Elles sont menées **interactivement avec l'utilisateur**, pas par un worker autonome.
+
+1. **Snapshot baseline** — `python scripts/reorg_phase1.py snapshot`, commité.
+2. **Générer `migration/phase1-plan.yaml`** — depuis le snapshot et le mapping §4 de
+   `docs/generic-questions-reorg.md` : les 4 familles, les ~14 `collection_moves`,
+   les `delete_empty` (collections vides), et le `card_filing` des 425 cartes en vrac
+   de `01. Global` + 9 cartes de `To sort`. Le `card_filing` est produit en analysant
+   le nom et la requête de chaque carte. → **GATE : l'utilisateur relit et valide le
+   `card_filing` avant tout `apply`.**
+3. **Dry-run** — `python scripts/reorg_phase1.py plan --snapshot <snap>` → relecture
+   du diff complet par l'utilisateur.
+4. **`apply lot-1`** — créer les 4 familles.
+5. **`apply lot-2`** — déplacer/renommer les collections (vérif. post-lot auto).
+6. **`apply lot-3`** — ranger les cartes en vrac de Global (vérif. post-lot auto).
+7. **`apply lot-4`** — dispatcher les 9 cartes « To sort » (vérif. post-lot auto).
+8. **`apply lot-5`** — supprimer les collections vides (vérif. post-lot auto).
+9. **`verify` final** — `python scripts/reorg_phase1.py verify --snapshot <snap>` :
+   0 carte perdue, 0 archivée, tous les `dashboard_count` identiques.
+10. **Figer** — `spark-metabase export "2. Generic Questions"
+    specs/generic-questions.yaml`, commité. Évolutions futures via `plan`/`apply` IaC.
+
+En cas de divergence à n'importe quel lot : `apply` s'arrête seul ;
+`python scripts/reorg_phase1.py rollback --snapshot <snap>` restaure l'état.
+
+---
+
+## Notes de mise en œuvre
+
+- **`create_collection`** : signature
+  `create_collection(collection_name, parent_collection_id=None, ...,
+  return_results=False)` — pas de paramètre `description`. La description est
+  posée par un `PUT /api/collection/{id}` séparé. La librairie gère déjà le repli
+  sur la version Metabase (champ `color`).
+- **`mb.put` / `mb.delete`** renvoient un **code HTTP** (pas du JSON) ; `mb.get` /
+  `mb.post` renvoient le JSON ou `False`. `_exec_op` contrôle chaque code via
+  `_check` pour qu'un PUT échoué ne passe pas silencieusement.
+- **Suppression de collection** : Metabase archive (il n'existe pas de hard-delete
+  d'API simple) — `PUT {archived: true}` sur une collection vide. C'est réversible.
+- **`dashboard_count` modifié** : peut provenir d'une édition concurrente par un
+  tiers pendant la migration, pas forcément du script. Si `verify` le signale,
+  investiguer la carte concernée avant de conclure à une régression.
+- **Renommage des cartes interdit** : aucune opération de ce plan ne modifie le
+  champ `name` d'une carte — uniquement celui des collections.

--- a/docs/superpowers/plans/2026-05-21-card-naming-normalization-phase1.5.md
+++ b/docs/superpowers/plans/2026-05-21-card-naming-normalization-phase1.5.md
@@ -1,0 +1,1044 @@
+# Card Naming Normalization — Phase 1.5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construire un outil CLI qui normalise en live les noms des ~1 212 cartes de la collection Metabase 215 (hors `Nouvelles Conversions`) — règles déterministes pour les corrections mécaniques, gate de relecture humaine sur les décisions, snapshot/verify/rollback comme filet.
+
+**Architecture:** Deux fichiers Python sous `scripts/`, indépendants de l'outil Phase 1. `rename_lib.py` contient toute la logique pure (`normalize_name`, modèle d'état, génération de la proposition, vérification d'invariant) — testée unitairement. `rename_phase15.py` est le CLI : il lit `.env`, appelle l'API Metabase via la librairie `spark_metabase_api`, orchestre `snapshot · propose · apply · verify · rollback`. L'artefact de relecture est un CSV éditable (`migration/rename-proposal.csv`).
+
+**Tech Stack:** Python 3, `spark_metabase_api`, modules stdlib (`csv`, `re`, `dataclasses`, `pathlib`).
+
+**Spec de référence :** `docs/superpowers/specs/2026-05-21-card-naming-normalization-phase1.5-design.md`.
+
+---
+
+## Convention de test
+
+Comme pour la Phase 1, on ne dépend d'aucun framework (`pip` PEP 668 + convention du repo).
+`tests/test_rename_lib.py` est un script autonome lancé par
+**`python3 tests/test_rename_lib.py`**, qui exécute toutes ses fonctions `test_*` et sort
+en code ≠ 0 si l'une échoue. Pattern identique à `tests/test_reorg_lib.py`.
+
+## File Structure
+
+| Fichier | Responsabilité |
+|---|---|
+| `scripts/rename_lib.py` | Logique pure : constantes (acronymes, libellés viz, patterns cryptiques), `CardRecord`, `Snapshot`, `normalize_name`, `propose_renames`, `verify_invariant`. Aucun effet de bord. |
+| `scripts/rename_phase15.py` | CLI : argparse, `.env`, connexion Metabase, `snapshot/propose/apply/verify/rollback`. Importe `rename_lib`. |
+| `tests/test_rename_lib.py` | Tests unitaires de toute la logique pure. |
+| `migration/rename-snapshot-<ts>.json` | Snapshot pré-vol (généré au runtime). Gitignoré comme les snapshots Phase 1. |
+| `migration/rename-proposal.csv` | Proposition de renommage (générée, éditée par l'utilisateur, relue par `apply`). |
+
+## Constantes partagées
+
+Définies en tête de `scripts/rename_lib.py` :
+
+```python
+ROOT_COLLECTION_ID = 215
+EXCLUDE_COLLECTION_ID = 11673   # Nouvelles Conversions — non traitée en 1.5
+
+ACRONYMS = {
+    "CAC", "CPC", "CPM", "CPL", "CPA", "CPI",
+    "CTR", "CR", "ROAS", "COS", "KPI", "KPIs",
+    "SEO", "GA4", "PMax", "DPA", "ATC", "ROI",
+}
+
+DISPLAY_LABEL = {
+    "line": "Line", "bar": "Bar", "area": "Area", "combo": "Combo",
+    "pie": "Pie", "table": "Table", "scalar": "Scalar",
+    "smartscalar": "Smart scalar", "funnel": "Funnel",
+    "map": "Map", "waterfall": "Waterfall", "row": "Row",
+    "progress": "Progress", "gauge": "Gauge", "pivot": "Pivot",
+}
+
+CRYPTIC_PATTERNS = (r"^Cac\d+$", r"^Conv\d+$")
+```
+
+---
+
+## Task 1: Harnais de test + `normalize_name`
+
+**Files:**
+- Create: `scripts/rename_lib.py`
+- Create: `tests/test_rename_lib.py`
+
+`normalize_name` applique : trim, `_`→espace, doubles espaces collapsés, true
+Sentence case (lowercase puis acronymes en majuscule par allowlist, première
+lettre du nom en majuscule).
+
+- [ ] **Step 1: Créer `tests/test_rename_lib.py` avec le harnais et le premier test**
+
+```python
+#!/usr/bin/env python3
+"""Tests unitaires de rename_lib — script autonome (convention du repo).
+
+Usage : python3 tests/test_rename_lib.py
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from rename_lib import normalize_name
+
+
+def test_normalize_name_basic():
+    # Trim + doubles espaces + snake_case
+    assert normalize_name("  Add_to_cart_rate ") == "Add to cart rate"
+    assert normalize_name("Cac_7,  conversions_7 by date") == "CAC 7, conversions 7 by date"
+    # Acronymes préservés
+    assert normalize_name("cac") == "CAC"
+    assert normalize_name("Cpc by date") == "CPC by date"
+    assert normalize_name("CAC") == "CAC"
+    # Sentence case + première lettre capitalisée
+    assert normalize_name("average basket - purchase") == "Average basket - purchase"
+    # Idempotence
+    assert normalize_name(normalize_name("App_installs_rate")) == normalize_name("App_installs_rate")
+    # Vide / blanc
+    assert normalize_name("   ") == ""
+
+
+TESTS = [test_normalize_name_basic]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()
+```
+
+Chaque tâche suivante **ajoute** sa fonction `test_*` et l'inscrit dans `TESTS`.
+
+- [ ] **Step 2: Lancer, voir échouer**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: `ModuleNotFoundError: No module named 'rename_lib'`.
+
+- [ ] **Step 3: Implémenter `normalize_name` dans `scripts/rename_lib.py`**
+
+```python
+"""Logique pure de la Phase 1.5 — normalisation du nommage des cartes."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+ROOT_COLLECTION_ID = 215
+EXCLUDE_COLLECTION_ID = 11673
+
+ACRONYMS = {
+    "CAC", "CPC", "CPM", "CPL", "CPA", "CPI",
+    "CTR", "CR", "ROAS", "COS", "KPI", "KPIs",
+    "SEO", "GA4", "PMax", "DPA", "ATC", "ROI",
+}
+
+_ACRONYM_BY_UPPER = {a.upper(): a for a in ACRONYMS}
+_TOKEN_RE = re.compile(r"^(\W*)([A-Za-z0-9]+)(\W*)$")
+
+
+def _fix_acronym(tok: str) -> str:
+    m = _TOKEN_RE.match(tok)
+    if not m:
+        return tok
+    pre, core, post = m.groups()
+    canonical = _ACRONYM_BY_UPPER.get(core.upper())
+    return f"{pre}{canonical}{post}" if canonical else tok
+
+
+def normalize_name(name: str) -> str:
+    """Trim, snake_case→spaces, Sentence case, acronymes préservés."""
+    s = name.replace("_", " ").strip()
+    s = re.sub(r"\s+", " ", s)
+    if not s:
+        return s
+    s = s.lower()
+    s = " ".join(_fix_acronym(t) for t in s.split(" "))
+    # Capitaliser le premier caractère alphabétique
+    for i, ch in enumerate(s):
+        if ch.isalpha():
+            return s[:i] + ch.upper() + s[i + 1 :]
+    return s
+```
+
+- [ ] **Step 4: Lancer, vérifier que le test passe**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: `PASS  test_normalize_name_basic` ; `1/1 tests passés`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/rename_lib.py tests/test_rename_lib.py
+git commit -m "rename: normalize_name + harnais de test"
+```
+
+---
+
+## Task 2: Modèle `CardRecord` + capture d'état
+
+**Files:**
+- Modify: `scripts/rename_lib.py`
+- Modify: `tests/test_rename_lib.py`
+
+Capture les cartes du sous-arbre 215 hors `Nouvelles Conversions`, en incluant
+le champ **`display`** (nécessaire pour la disambiguïsation viz par collision).
+
+- [ ] **Step 1: Ajouter le test de `capture_snapshot` avec un faux client**
+
+Dans `tests/test_rename_lib.py`, mettre à jour l'import et ajouter le test :
+
+```python
+from rename_lib import normalize_name, CardRecord, capture_snapshot
+
+
+def test_capture_snapshot_excludes_conversions():
+    items = {
+        "/api/collection/215/items?limit=2000": {"data": [
+            {"model": "collection", "id": 214, "name": "Cross-platform"},
+            {"model": "collection", "id": 11673, "name": "18. Nouvelles Conversions"},
+            {"model": "card", "id": 29, "name": "CAC"},
+        ]},
+        "/api/collection/214/items?limit=2000": {"data": [
+            {"model": "card", "id": 46255, "name": "Loose card"},
+        ]},
+    }
+    cards = {
+        29: {"id": 29, "name": "CAC", "collection_id": 215,
+             "dashboard_count": 1211, "archived": False, "display": "scalar"},
+        46255: {"id": 46255, "name": "Loose card", "collection_id": 214,
+                "dashboard_count": 0, "archived": False, "display": "line"},
+    }
+
+    def fake_get(endpoint):
+        if "/items" in endpoint:
+            return items[endpoint]
+        card_id = int(endpoint.split("/")[-1])
+        return cards[card_id]
+
+    snap = capture_snapshot(fake_get, root_id=215)
+    assert set(snap) == {29, 46255}
+    assert snap[29] == CardRecord(id=29, name="CAC", collection_id=215,
+                                  dashboard_count=1211, archived=False,
+                                  display="scalar")
+```
+
+Et ajouter `test_capture_snapshot_excludes_conversions` à `TESTS`.
+
+- [ ] **Step 2: Lancer, voir échouer**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: `ImportError: cannot import name 'CardRecord'`.
+
+- [ ] **Step 3: Implémenter `CardRecord` et `capture_snapshot`**
+
+À ajouter à `scripts/rename_lib.py` :
+
+```python
+@dataclass(frozen=True)
+class CardRecord:
+    id: int
+    name: str
+    collection_id: int
+    dashboard_count: int
+    archived: bool
+    display: str
+
+
+def capture_snapshot(get, root_id: int = ROOT_COLLECTION_ID) -> dict[int, CardRecord]:
+    """Parcourt le sous-arbre `root_id` et capture les cartes (hors EXCLUDE).
+
+    `get` est une fonction `endpoint -> json`. Le sous-arbre
+    EXCLUDE_COLLECTION_ID n'est pas parcouru.
+    """
+    cards: dict[int, CardRecord] = {}
+
+    def walk(coll_id: int):
+        items = get(f"/api/collection/{coll_id}/items?limit=2000").get("data", [])
+        for it in items:
+            if it["model"] == "collection":
+                if it["id"] != EXCLUDE_COLLECTION_ID:
+                    walk(it["id"])
+            elif it["model"] in ("card", "dataset"):
+                detail = get(f"/api/card/{it['id']}")
+                cards[it["id"]] = CardRecord(
+                    id=detail["id"],
+                    name=detail["name"],
+                    collection_id=detail.get("collection_id"),
+                    dashboard_count=detail.get("dashboard_count", 0),
+                    archived=bool(detail.get("archived", False)),
+                    display=detail.get("display") or "",
+                )
+
+    walk(root_id)
+    return cards
+```
+
+- [ ] **Step 4: Lancer, vérifier le pass**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: 2/2 tests passés.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/rename_lib.py tests/test_rename_lib.py
+git commit -m "rename: CardRecord + capture_snapshot avec champ display"
+```
+
+---
+
+## Task 3: Génération de la proposition (`propose_renames`)
+
+**Files:**
+- Modify: `scripts/rename_lib.py`
+- Modify: `tests/test_rename_lib.py`
+
+Algorithme :
+
+1. Pour chaque carte : `normalized = normalize_name(name)`.
+2. Grouper par `normalized`.
+3. Pour chaque groupe :
+   - **Singleton** : si `normalized != current` → `ProposalRow(status='auto', rule='normalize')`.
+   - **Multi avec displays tous distincts** : suffixer chaque carte ` — <DisplayLabel>` → `status='auto', rule='viz_collision'`.
+   - **Multi avec ≥ 2 cartes du même `display`** : tout le groupe en `status='décision'`, `rule='duplicate'`, `proposed_name=current_name` (le humain tranche).
+4. Marquer en `status='décision'` les cartes dont le `current_name` (ou normalized) matche `CRYPTIC_PATTERNS`, avec `rule='cryptic'`.
+5. Ne retenir que les lignes où `(proposed_name != current_name) or (status == 'décision')`.
+
+- [ ] **Step 1: Ajouter les tests de `propose_renames`**
+
+Ajouter à `tests/test_rename_lib.py` (et à `TESTS`) :
+
+```python
+from rename_lib import propose_renames, ProposalRow
+
+
+def _rec(id, name, display="line", collection_id=214, dashboard_count=0):
+    return CardRecord(id=id, name=name, collection_id=collection_id,
+                      dashboard_count=dashboard_count, archived=False,
+                      display=display)
+
+
+def test_propose_skips_unchanged_cards():
+    snap = {1: _rec(1, "Add to cart rate")}     # déjà propre
+    rows = propose_renames(snap)
+    assert rows == []
+
+
+def test_propose_auto_normalize_change():
+    snap = {1: _rec(1, "Add_to_cart_rate")}
+    rows = propose_renames(snap)
+    assert len(rows) == 1
+    assert rows[0].card_id == 1
+    assert rows[0].proposed_name == "Add to cart rate"
+    assert rows[0].status == "auto"
+    assert rows[0].rule == "normalize"
+
+
+def test_propose_viz_collision_adds_suffix():
+    snap = {
+        1: _rec(1, "Cac by date", display="line"),
+        2: _rec(2, "Cac by date", display="bar"),
+    }
+    rows = sorted(propose_renames(snap), key=lambda r: r.card_id)
+    assert [r.proposed_name for r in rows] == ["CAC by date — Line", "CAC by date — Bar"]
+    assert [r.status for r in rows] == ["auto", "auto"]
+    assert [r.rule for r in rows] == ["viz_collision", "viz_collision"]
+
+
+def test_propose_true_duplicate_is_decision():
+    snap = {
+        1: _rec(1, "Cac_2 by date, channel", display="line"),
+        2: _rec(2, "Cac_2 by date, channel", display="line"),
+    }
+    rows = sorted(propose_renames(snap), key=lambda r: r.card_id)
+    assert [r.status for r in rows] == ["décision", "décision"]
+    assert [r.rule for r in rows] == ["duplicate", "duplicate"]
+    # En statut décision, on laisse proposed = current
+    assert rows[0].proposed_name == rows[0].current_name
+
+
+def test_propose_cryptic_is_decision():
+    snap = {1: _rec(1, "Cac3")}
+    rows = propose_renames(snap)
+    assert len(rows) == 1
+    assert rows[0].status == "décision"
+    assert rows[0].rule == "cryptic"
+    assert rows[0].proposed_name == "Cac3"
+```
+
+- [ ] **Step 2: Lancer, voir échouer**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: `ImportError: cannot import name 'propose_renames'`.
+
+- [ ] **Step 3: Implémenter `ProposalRow` et `propose_renames`**
+
+À ajouter à `scripts/rename_lib.py` :
+
+```python
+from collections import defaultdict
+
+
+DISPLAY_LABEL = {
+    "line": "Line", "bar": "Bar", "area": "Area", "combo": "Combo",
+    "pie": "Pie", "table": "Table", "scalar": "Scalar",
+    "smartscalar": "Smart scalar", "funnel": "Funnel",
+    "map": "Map", "waterfall": "Waterfall", "row": "Row",
+    "progress": "Progress", "gauge": "Gauge", "pivot": "Pivot",
+}
+
+_CRYPTIC = [re.compile(p) for p in (r"^Cac\d+$", r"^Conv\d+$")]
+
+
+@dataclass(frozen=True)
+class ProposalRow:
+    card_id: int
+    current_name: str
+    proposed_name: str
+    rule: str        # normalize | viz_collision | duplicate | cryptic
+    status: str      # auto | décision
+    notes: str = ""
+
+
+def _is_cryptic(name: str) -> bool:
+    return any(p.match(name) for p in _CRYPTIC)
+
+
+def _viz_label(display: str) -> str:
+    return DISPLAY_LABEL.get(display, display.title() if display else "?")
+
+
+def propose_renames(snapshot: dict[int, CardRecord]) -> list[ProposalRow]:
+    # Group by normalized name
+    groups: dict[str, list[CardRecord]] = defaultdict(list)
+    for rec in snapshot.values():
+        groups[normalize_name(rec.name)].append(rec)
+
+    rows: list[ProposalRow] = []
+    for normalized, members in groups.items():
+        if len(members) == 1:
+            rec = members[0]
+            if _is_cryptic(rec.name):
+                rows.append(ProposalRow(
+                    card_id=rec.id, current_name=rec.name,
+                    proposed_name=rec.name, rule="cryptic", status="décision",
+                    notes="nom court non descriptif — humain décide"))
+            elif normalized != rec.name:
+                rows.append(ProposalRow(
+                    card_id=rec.id, current_name=rec.name,
+                    proposed_name=normalized, rule="normalize", status="auto"))
+            continue
+
+        # Groupe de 2+ cartes au même nom normalisé
+        displays = [m.display for m in members]
+        has_dup_display = len(set(displays)) < len(displays)
+        if has_dup_display:
+            # Au moins 2 cartes partagent le même display -> vrai doublon, humain tranche
+            ids = ", ".join(f"#{m.id}" for m in members)
+            for rec in members:
+                rows.append(ProposalRow(
+                    card_id=rec.id, current_name=rec.name,
+                    proposed_name=rec.name, rule="duplicate", status="décision",
+                    notes=f"doublon dans le groupe ({ids})"))
+        else:
+            # Tous les displays distincts -> suffixer
+            for rec in members:
+                proposed = f"{normalized} — {_viz_label(rec.display)}"
+                rows.append(ProposalRow(
+                    card_id=rec.id, current_name=rec.name,
+                    proposed_name=proposed, rule="viz_collision", status="auto"))
+
+    return rows
+```
+
+- [ ] **Step 4: Lancer, vérifier les passages**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: 7/7 tests passés.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/rename_lib.py tests/test_rename_lib.py
+git commit -m "rename: propose_renames avec collisions viz et cryptiques"
+```
+
+---
+
+## Task 4: Vérification d'invariant
+
+**Files:**
+- Modify: `scripts/rename_lib.py`
+- Modify: `tests/test_rename_lib.py`
+
+L'invariant Phase 1.5 : même ensemble de cartes, aucune archivée, `dashboard_count`
+**ET** `collection_id` strictement identiques au snapshot. Le `name` peut changer
+(c'est le but).
+
+- [ ] **Step 1: Ajouter les tests de `verify_invariant`**
+
+```python
+from rename_lib import verify_invariant
+
+
+def test_verify_clean_when_only_name_changed():
+    base = {1: _rec(1, "Cac_2", display="line")}
+    current = {1: _rec(1, "CAC 2", display="line")}
+    assert verify_invariant(base, current) == []
+
+
+def test_verify_detects_lost_card():
+    base = {1: _rec(1, "X")}
+    assert [d.kind for d in verify_invariant(base, {})] == ["lost_card"]
+
+
+def test_verify_detects_archived_card():
+    base = {1: _rec(1, "X")}
+    archived = CardRecord(1, "X", 214, 0, True, "line")
+    assert [d.kind for d in verify_invariant(base, {1: archived})] == ["archived_card"]
+
+
+def test_verify_detects_dashboard_count_change():
+    base = {1: _rec(1, "X", dashboard_count=10)}
+    cur = {1: _rec(1, "X", dashboard_count=9)}
+    assert [d.kind for d in verify_invariant(base, cur)] == ["dashboard_count_changed"]
+
+
+def test_verify_detects_moved_card():
+    base = {1: _rec(1, "X", collection_id=214)}
+    cur = {1: _rec(1, "X", collection_id=999)}
+    assert [d.kind for d in verify_invariant(base, cur)] == ["moved_card"]
+```
+
+Ajouter les 5 tests à `TESTS`.
+
+- [ ] **Step 2: Lancer, voir échouer**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: `ImportError: cannot import name 'verify_invariant'`.
+
+- [ ] **Step 3: Implémenter `verify_invariant` et `Divergence`**
+
+```python
+@dataclass(frozen=True)
+class Divergence:
+    kind: str        # lost_card | archived_card | dashboard_count_changed | moved_card
+    card_id: int
+    detail: str
+
+
+def verify_invariant(baseline: dict[int, CardRecord],
+                     current: dict[int, CardRecord]) -> list[Divergence]:
+    out: list[Divergence] = []
+    for cid, base in baseline.items():
+        cur = current.get(cid)
+        if cur is None:
+            out.append(Divergence("lost_card", cid,
+                                   f"{base.name!r} absente de l'état courant"))
+            continue
+        if cur.archived and not base.archived:
+            out.append(Divergence("archived_card", cid,
+                                   f"{base.name!r} a été archivée"))
+        if cur.dashboard_count != base.dashboard_count:
+            out.append(Divergence(
+                "dashboard_count_changed", cid,
+                f"{base.name!r}: dashboard_count "
+                f"{base.dashboard_count} -> {cur.dashboard_count}"))
+        if cur.collection_id != base.collection_id:
+            out.append(Divergence(
+                "moved_card", cid,
+                f"{base.name!r}: collection {base.collection_id} -> "
+                f"{cur.collection_id}"))
+    return out
+```
+
+- [ ] **Step 4: Lancer, vérifier les passages**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: 12/12 tests passés.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/rename_lib.py tests/test_rename_lib.py
+git commit -m "rename: invariant (lost/archived/moved/dashboard_count) pour le renommage"
+```
+
+---
+
+## Task 5: Squelette du CLI et commande `snapshot`
+
+**Files:**
+- Create: `scripts/rename_phase15.py`
+
+- [ ] **Step 1: Créer le squelette + `cmd_snapshot`**
+
+```python
+#!/usr/bin/env python3
+"""CLI de normalisation des noms de cartes — collection Metabase 215.
+
+Sous-commandes : snapshot | propose | apply | verify | rollback.
+Voir docs/superpowers/specs/2026-05-21-card-naming-normalization-phase1.5-design.md
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from rename_lib import (  # noqa: E402
+    capture_snapshot, propose_renames, verify_invariant,
+    CardRecord, ROOT_COLLECTION_ID,
+)
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+
+
+def _load_env() -> dict:
+    env = {}
+    env_file = REPO_ROOT / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            env[k.strip()] = v.strip()
+    return env
+
+
+def connect() -> Metabase_API:
+    env = _load_env()
+    domain = env.get("METABASE_DOMAIN") or os.environ.get("METABASE_DOMAIN")
+    session_id = env.get("METABASE_SESSION_ID") or os.environ.get("METABASE_SESSION_ID")
+    email = env.get("METABASE_EMAIL") or os.environ.get("METABASE_EMAIL")
+    password = env.get("METABASE_PASSWORD") or os.environ.get("METABASE_PASSWORD")
+    if not domain:
+        sys.exit("METABASE_DOMAIN manquant.")
+    if session_id:
+        mb = Metabase_API(domain=domain, session_id=session_id)
+        if mb.is_session_valid():
+            return mb
+        print("session_id expiré — bascule sur email/password.")
+    if not (email and password):
+        sys.exit("Aucune session valide et METABASE_EMAIL/PASSWORD manquants.")
+    return Metabase_API(domain=domain, email=email, password=password)
+
+
+def _snapshot_to_dict(snap: dict[int, CardRecord]) -> dict:
+    return {"cards": [asdict(r) for r in snap.values()]}
+
+
+def _snapshot_from_dict(data: dict) -> dict[int, CardRecord]:
+    return {c["id"]: CardRecord(**c) for c in data["cards"]}
+
+
+def cmd_snapshot(args):
+    mb = connect()
+    print(f"Capture du sous-arbre de la collection {ROOT_COLLECTION_ID} "
+          f"(hors Nouvelles Conversions)...")
+    snap = capture_snapshot(mb.get, root_id=ROOT_COLLECTION_ID)
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = MIGRATION_DIR / f"rename-snapshot-{ts}.json"
+    out.write_text(json.dumps(_snapshot_to_dict(snap), indent=2, ensure_ascii=False))
+    print(f"  {len(snap)} cartes capturées")
+    print(f"Snapshot écrit : {out}")
+
+
+def cmd_propose(args):
+    raise NotImplementedError
+
+
+def cmd_apply(args):
+    raise NotImplementedError
+
+
+def cmd_verify(args):
+    raise NotImplementedError
+
+
+def cmd_rollback(args):
+    raise NotImplementedError
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Normalisation des noms — Phase 1.5")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("snapshot", help="Capturer l'état des cartes du sous-arbre 215")
+
+    p_prop = sub.add_parser("propose", help="Générer rename-proposal.csv")
+    p_prop.add_argument("--snapshot", required=True)
+    p_prop.add_argument("--out", default=str(MIGRATION_DIR / "rename-proposal.csv"))
+
+    p_apply = sub.add_parser("apply", help="Appliquer le CSV de renommage")
+    p_apply.add_argument("--snapshot", required=True)
+    p_apply.add_argument("--proposal", default=str(MIGRATION_DIR / "rename-proposal.csv"))
+    p_apply.add_argument("--yes", action="store_true")
+
+    p_verify = sub.add_parser("verify", help="Comparer l'état live au snapshot")
+    p_verify.add_argument("--snapshot", required=True)
+
+    p_rb = sub.add_parser("rollback", help="Restaurer les noms d'origine")
+    p_rb.add_argument("--snapshot", required=True)
+    p_rb.add_argument("--yes", action="store_true")
+
+    args = parser.parse_args(argv)
+    {"snapshot": cmd_snapshot, "propose": cmd_propose, "apply": cmd_apply,
+     "verify": cmd_verify, "rollback": cmd_rollback}[args.command](args)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Vérifier l'aide du CLI**
+
+Run: `python3 scripts/rename_phase15.py --help`
+Expected: liste les 5 sous-commandes.
+
+- [ ] **Step 3: Lancer le snapshot live (lecture seule)**
+
+Run: `python3 scripts/rename_phase15.py snapshot`
+Expected: ~1 212 cartes capturées ; nouveau fichier `migration/rename-snapshot-<ts>.json`.
+Durée : quelques minutes (1 GET par carte).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/rename_phase15.py
+git commit -m "rename: squelette CLI + commande snapshot"
+```
+
+---
+
+## Task 6: Commande `propose` (génération du CSV)
+
+**Files:**
+- Modify: `scripts/rename_phase15.py`
+
+Le CSV contient toutes les lignes où il y a quelque chose à faire (changement
+mécanique OU statut `décision`). Trié par statut (décisions d'abord) puis
+par nom courant, pour faciliter la relecture.
+
+- [ ] **Step 1: Implémenter `cmd_propose`**
+
+Remplacer `cmd_propose` dans `scripts/rename_phase15.py` :
+
+```python
+def cmd_propose(args):
+    snap = _snapshot_from_dict(json.loads(Path(args.snapshot).read_text()))
+    rows = propose_renames(snap)
+    # Tri : décisions d'abord, puis par nom courant
+    rows.sort(key=lambda r: (0 if r.status == "décision" else 1, r.current_name))
+    out = Path(args.out)
+    out.parent.mkdir(exist_ok=True)
+    with out.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["card_id", "current_name", "proposed_name",
+                    "rule", "status", "notes"])
+        for r in rows:
+            w.writerow([r.card_id, r.current_name, r.proposed_name,
+                        r.rule, r.status, r.notes])
+    by_status = {"auto": 0, "décision": 0}
+    by_rule: dict[str, int] = {}
+    for r in rows:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+        by_rule[r.rule] = by_rule.get(r.rule, 0) + 1
+    print(f"Proposition écrite : {out}")
+    print(f"  {len(rows)} lignes — auto: {by_status['auto']}, "
+          f"décision: {by_status['décision']}")
+    print(f"  par règle : " + ", ".join(f"{k}={v}" for k, v in sorted(by_rule.items())))
+    print("\n→ Relis et édite le CSV avant `apply`.")
+```
+
+- [ ] **Step 2: Lancer la proposition contre le snapshot live**
+
+Run: `SNAP=$(ls migration/rename-snapshot-*.json | tail -1); python3 scripts/rename_phase15.py propose --snapshot "$SNAP"`
+Expected: création de `migration/rename-proposal.csv` ; résumé imprimé (compte
+auto vs décision, ventilation par règle).
+
+- [ ] **Step 3: Inspecter le CSV (qualitatif)**
+
+Run: `head -20 migration/rename-proposal.csv && echo "---" && wc -l migration/rename-proposal.csv`
+Expected: en-tête + lignes lisibles, lignes `décision` en haut.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/rename_phase15.py
+git commit -m "rename: commande propose (CSV de relecture)"
+```
+
+---
+
+## Task 7: Commande `apply` avec vérification post-batch
+
+**Files:**
+- Modify: `scripts/rename_phase15.py`
+
+`apply` lit le CSV, applique uniquement les lignes où `proposed_name != current_name`
+et `proposed_name` est non vide. Chaque PUT contrôlé par code HTTP. Vérification
+post-batch contre le snapshot baseline.
+
+- [ ] **Step 1: Implémenter `_check` et `cmd_apply`**
+
+Ajouter à `scripts/rename_phase15.py` :
+
+```python
+def _check(status, what):
+    """`mb.put` renvoie un code HTTP — on échoue fort si non-2xx."""
+    if not (200 <= int(status) < 300):
+        raise RuntimeError(f"{what} a échoué — HTTP {status}")
+
+
+def _load_proposal(path: Path) -> list[dict]:
+    with path.open(encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def cmd_apply(args):
+    baseline = _snapshot_from_dict(json.loads(Path(args.snapshot).read_text()))
+    proposal = _load_proposal(Path(args.proposal))
+    # Filtrer : ne renommer que les lignes où proposed != current ET proposed non vide
+    to_apply = [r for r in proposal
+                if r["proposed_name"] and r["proposed_name"] != r["current_name"]]
+    if not to_apply:
+        print("Aucun renommage à appliquer.")
+        return
+
+    print(f"\n=== Renommages à appliquer : {len(to_apply)} ===")
+    for r in to_apply[:20]:
+        print(f"  #{r['card_id']:>6} : {r['current_name']!r} -> {r['proposed_name']!r}  "
+              f"[{r['rule']}/{r['status']}]")
+    if len(to_apply) > 20:
+        print(f"  ... ({len(to_apply) - 20} de plus)")
+    if not args.yes:
+        if input(f"\nAppliquer ces {len(to_apply)} renommages ? [tape 'oui'] "
+                 ).strip() != "oui":
+            sys.exit("Annulé.")
+
+    mb = connect()
+    for r in to_apply:
+        cid = int(r["card_id"])
+        new_name = r["proposed_name"]
+        _check(mb.put(f"/api/card/{cid}", json={"name": new_name}),
+               f"renommage carte {cid}")
+        print(f"  #{cid} -> {new_name!r}")
+
+    print("\nVérification d'invariant post-batch...")
+    current = capture_snapshot(mb.get, root_id=ROOT_COLLECTION_ID)
+    divergences = verify_invariant(baseline, current)
+    if divergences:
+        print("DIVERGENCES DÉTECTÉES — ARRÊT :")
+        for d in divergences:
+            print(f"  [{d.kind}] carte {d.card_id} : {d.detail}")
+        sys.exit(1)
+    print(f"OK — {len(current)} cartes intactes (hors changement de nom), "
+          f"0 divergence.")
+```
+
+- [ ] **Step 2: Vérifier que `apply` refuse sans confirmation (dry-run de garde-fou)**
+
+Run: `SNAP=$(ls migration/rename-snapshot-*.json | tail -1); echo "non" | python3 scripts/rename_phase15.py apply --snapshot "$SNAP"`
+Expected: « Annulé. » sans appel d'écriture (sortie code 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/rename_phase15.py
+git commit -m "rename: commande apply avec vérification d'invariant post-batch"
+```
+
+---
+
+## Task 8: Commandes `verify` et `rollback`
+
+**Files:**
+- Modify: `scripts/rename_phase15.py`
+
+- [ ] **Step 1: Implémenter `cmd_verify` et `cmd_rollback`**
+
+Remplacer les deux fonctions :
+
+```python
+def cmd_verify(args):
+    baseline = _snapshot_from_dict(json.loads(Path(args.snapshot).read_text()))
+    mb = connect()
+    current = capture_snapshot(mb.get, root_id=ROOT_COLLECTION_ID)
+    divergences = verify_invariant(baseline, current)
+    if divergences:
+        print(f"{len(divergences)} divergence(s) :")
+        for d in divergences:
+            print(f"  [{d.kind}] carte {d.card_id} : {d.detail}")
+        sys.exit(1)
+    print(f"OK — {len(current)} cartes, 0 divergence vs snapshot.")
+
+
+def cmd_rollback(args):
+    baseline = _snapshot_from_dict(json.loads(Path(args.snapshot).read_text()))
+    if not args.yes:
+        if input("Restaurer tous les noms du snapshot ? [tape 'oui'] "
+                 ).strip() != "oui":
+            sys.exit("Annulé.")
+    mb = connect()
+    current = capture_snapshot(mb.get, root_id=ROOT_COLLECTION_ID)
+    restored = 0
+    for cid, base in baseline.items():
+        cur = current.get(cid)
+        if cur and cur.name != base.name:
+            _check(mb.put(f"/api/card/{cid}", json={"name": base.name}),
+                   f"restauration carte {cid}")
+            print(f"  carte {cid} -> nom d'origine {base.name!r}")
+            restored += 1
+    print(f"Rollback terminé. {restored} carte(s) restaurée(s).")
+```
+
+- [ ] **Step 2: Vérifier `verify` contre le snapshot (état non modifié)**
+
+Run: `SNAP=$(ls migration/rename-snapshot-*.json | tail -1); python3 scripts/rename_phase15.py verify --snapshot "$SNAP"`
+Expected: « OK — ~1212 cartes, 0 divergence vs snapshot. »
+
+- [ ] **Step 3: Lancer toute la suite de tests**
+
+Run: `python3 tests/test_rename_lib.py`
+Expected: 12/12 tests passés.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/rename_phase15.py
+git commit -m "rename: commandes verify et rollback"
+```
+
+---
+
+## Task 9: Gitignore des artefacts runtime + validation end-to-end
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Ajouter le snapshot Phase 1.5 au .gitignore**
+
+Éditer `.gitignore` pour ajouter la ligne sous le bloc « Migration Phase 1 » :
+
+```
+# Migration Phase 1 — artefacts runtime (régénérables)
+migration/snapshot-*.json
+migration/families.json
+migration/rename-snapshot-*.json
+```
+
+Note : `migration/rename-proposal.csv` reste trackable — c'est le registre de
+ce qui a été (ou sera) renommé, on peut le commiter une fois la passe terminée.
+
+- [ ] **Step 2: Snapshot frais (si pas déjà fait)**
+
+Run: `python3 scripts/rename_phase15.py snapshot`
+Expected: ~1 212 cartes.
+
+- [ ] **Step 3: Proposer**
+
+Run: `SNAP=$(ls migration/rename-snapshot-*.json | tail -1); python3 scripts/rename_phase15.py propose --snapshot "$SNAP"`
+Expected: CSV créé, résumé imprimé. Inspecter la ventilation (auto vs décision).
+
+- [ ] **Step 4: Vérifier l'idempotence par auto-relecture du CSV**
+
+Toute ligne d'`auto` doit produire un `proposed_name` qui, repassé dans
+`normalize_name`, donne le même résultat :
+
+```bash
+python3 - <<'EOF'
+import csv, sys
+sys.path.insert(0, 'scripts')
+from rename_lib import normalize_name
+rows = list(csv.DictReader(open('migration/rename-proposal.csv', encoding='utf-8')))
+bad = []
+for r in rows:
+    if r['status'] != 'auto' or r['rule'] != 'normalize':
+        continue
+    if normalize_name(r['proposed_name']) != r['proposed_name']:
+        bad.append((r['card_id'], r['proposed_name'], normalize_name(r['proposed_name'])))
+print(f"{len(rows)} lignes total ; idempotence : {len(bad)} violations")
+for b in bad[:5]:
+    print(" ", b)
+EOF
+```
+Expected: `0 violations`.
+
+- [ ] **Step 5: Verify idempotent**
+
+Run: `SNAP=$(ls migration/rename-snapshot-*.json | tail -1); python3 scripts/rename_phase15.py verify --snapshot "$SNAP"`
+Expected: 0 divergence.
+
+- [ ] **Step 6: Commit du .gitignore**
+
+```bash
+git add .gitignore
+git commit -m "rename: ignorer les snapshots Phase 1.5"
+```
+
+---
+
+## Runbook d'exécution (NON auto-exécutable — gates humains)
+
+Comme pour la Phase 1, ces étapes effectuent les renommages live avec des
+validations humaines. Menées **interactivement** avec l'utilisateur.
+
+1. **Snapshot baseline** — `python3 scripts/rename_phase15.py snapshot`.
+2. **Génération de la proposition** — `python3 scripts/rename_phase15.py propose --snapshot <snap>`.
+3. **GATE — relecture humaine du CSV** : édition de `migration/rename-proposal.csv` :
+   - Vérifier la ventilation `auto` / `décision`.
+   - Pour chaque ligne `décision` (cryptiques, doublons réels) : remplir
+     `proposed_name` (ou laisser = `current_name` pour ne rien changer).
+   - Possibilité d'auditer la casse obtenue après acronymes : enrichir la liste
+     blanche `ACRONYMS` dans `rename_lib.py` si une lacune apparaît et regénérer.
+4. **Échantillon de vérification côté client** : tirer 5-10 cartes parmi celles
+   qui vont être renommées (notamment celles à fort `dashboard_count`), vérifier
+   sur 2-3 dashboards échantillons que le titre affiché ne casse rien (souvent
+   override, voir la découverte du design §Découverte clé).
+5. **`apply`** — `python3 scripts/rename_phase15.py apply --snapshot <snap>` (confirmation puis verify automatique).
+6. **`verify` final** — re-vérification à froid.
+7. En cas de divergence : `apply` s'arrête seul ; `rollback --snapshot <snap>`
+   restaure les noms d'origine.
+
+---
+
+## Notes de mise en œuvre
+
+- **Stripping de fragments viz existants** (`- Bar Chart`, `(Bar Stack - 100%)`)
+  **n'est pas fait** par les règles : risque d'over-stripping de mots à sens
+  métier. Ces fragments restent dans le nom ; si la relecture montre un cas
+  gênant, le humain édite la ligne `proposed_name` dans le CSV.
+- **Casse sentence case stricte** : `Average basket - Purchase` devient
+  `Average basket - purchase` (le P de Purchase passe en minuscule). C'est
+  délibéré pour avoir une casse uniforme dans toute la bibliothèque. Si une
+  ligne est jugée gênante, le humain la corrige dans le CSV.
+- **Liste d'acronymes** : à enrichir au besoin lors de la relecture du CSV.
+  Modifier `ACRONYMS` dans `rename_lib.py` et regénérer la proposition.
+- **`dashboard_count` modifié pendant l'apply** : peut venir d'une édition
+  concurrente, pas du script. Si `verify` le signale, investiguer la carte
+  concernée.

--- a/docs/superpowers/plans/2026-05-28-metabase-instance-audit.md
+++ b/docs/superpowers/plans/2026-05-28-metabase-instance-audit.md
@@ -1,0 +1,1343 @@
+# Audit instance-wide Metabase — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construire `scripts/audit.py` (scan → deep → report) qui scanne toute l'instance Metabase (868 collections, ~5654 cartes), détecte 11 patterns d'optimisation et produit un rapport markdown court + un JSON exhaustif servant de backlog de campagnes.
+
+**Architecture:** Trois fichiers à responsabilité unique — `audit_lib.py` (analyse pure : empreintes v2, détecteurs, scoring), `audit_report.py` (rendu markdown digest), `audit.py` (orchestration + I/O réseau + cache disque reprenable). Logique pure testée en TDD sur fixtures (aucun réseau) ; commandes CLI vérifiées par run live. Lecture seule.
+
+**Tech Stack:** Python 3 (stdlib uniquement : `hashlib`, `json`, `re`, `argparse`, `collections`), le wrapper `spark_metabase_api`, réutilise `reorg_phase1._load_env` / `rename_lib.normalize_name`. Tests = scripts standalone (convention du repo, pas de pytest).
+
+---
+
+## Spec de référence
+
+`docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md`
+
+## File Structure
+
+| Fichier | Responsabilité |
+|---------|----------------|
+| `scripts/audit_lib.py` | Analyse pure : `query_fingerprint`, `output_fingerprint`, `classify_query_groups`, détecteurs (#1-#10), `build_source_ids`, `PATTERNS` (scoring), `summarize_findings`. Aucune I/O. |
+| `scripts/audit_report.py` | `render_report(findings)` → markdown **court** (digest). |
+| `scripts/audit.py` | CLI `scan`/`deep`/`report` : connexion, fetch, cache disque reprenable, écriture du JSON et du `.md`. |
+| `tests/test_audit_lib.py` | Tests standalone des fonctions pures (dont la régression faux-positifs). |
+| `tests/test_audit_report.py` | Tests standalone du rendu (digest court). |
+
+Conventions du repo (à respecter) :
+- Scripts en tête : `REPO_ROOT = Path(__file__).resolve().parent.parent` puis `sys.path.insert(0, str(REPO_ROOT / "scripts"))`.
+- Connexion run long : email/password (`connect_resilient`), comme `prune_unused.py`.
+- Tests : liste `TESTS = [...]`, fonction `run()`, `sys.exit(1 if failures else 0)`, lancés par `python3 tests/test_x.py`.
+
+---
+
+## Task 1: Scaffold `audit_lib.py` + registre `PATTERNS`
+
+**Files:**
+- Create: `scripts/audit_lib.py`
+- Test: `tests/test_audit_lib.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_audit_lib.py`:
+
+```python
+#!/usr/bin/env python3
+"""Tests unitaires d'audit_lib — script autonome (convention du repo).
+
+Usage : python3 tests/test_audit_lib.py
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import audit_lib
+
+
+def test_patterns_registry_complete():
+    assert len(audit_lib.PATTERNS) == 11
+    for key, meta in audit_lib.PATTERNS.items():
+        assert set(meta) >= {"num", "family", "impact", "risk", "effort", "wave"}
+        assert meta["impact"] in ("H", "M", "L")
+        assert meta["risk"] in ("H", "M", "L")
+        assert meta["effort"] in ("H", "M", "L")
+        assert meta["wave"] in (0, 1, 2, 3)
+    nums = sorted(m["num"] for m in audit_lib.PATTERNS.values())
+    assert nums == list(range(1, 12))
+
+
+TESTS = [
+    test_patterns_registry_complete,
+]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `ModuleNotFoundError: No module named 'audit_lib'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/audit_lib.py`:
+
+```python
+#!/usr/bin/env python3
+"""Logique d'analyse de l'audit instance-wide (pur, testable, aucune I/O réseau).
+
+Empreintes de requête v2, détecteurs de patterns, scoring. Les fonctions opèrent
+sur des listes de dicts déjà récupérés par audit.py.
+
+Voir docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from rename_lib import normalize_name  # noqa: E402  (réutilise la normalisation Phase 1.5)
+
+TEMPLATE_ROOT_ID = 215
+
+# Registre des patterns : scoring Impact/Risque/Effort + vague (cf. spec §6).
+PATTERNS = {
+    "empty_collections":    {"num": 1,  "family": "structurel", "impact": "H", "risk": "L", "effort": "L", "wave": 0},
+    "personal_sprawl":      {"num": 2,  "family": "structurel", "impact": "H", "risk": "H", "effort": "M", "wave": 2},
+    "dup_collection_names": {"num": 3,  "family": "structurel", "impact": "M", "risk": "M", "effort": "M", "wave": 2},
+    "junk_collections":     {"num": 4,  "family": "structurel", "impact": "M", "risk": "L", "effort": "L", "wave": 0},
+    "unused_cards":         {"num": 5,  "family": "gaspillage", "impact": "H", "risk": "L", "effort": "L", "wave": 1},
+    "pure_dups":            {"num": 6,  "family": "gaspillage", "impact": "H", "risk": "M", "effort": "M", "wave": 1},
+    "archived_backlog":     {"num": 7,  "family": "gaspillage", "impact": "M", "risk": "L", "effort": "L", "wave": 0},
+    "template_drift":       {"num": 8,  "family": "dry",        "impact": "H", "risk": "H", "effort": "H", "wave": 3},
+    "variant_families":     {"num": 9,  "family": "dry",        "impact": "M", "risk": "M", "effort": "H", "wave": 3},
+    "naming_issues":        {"num": 10, "family": "nommage",    "impact": "M", "risk": "L", "effort": "M", "wave": 1},
+    "expensive_cards":      {"num": 11, "family": "perf",       "impact": "M", "risk": "L", "effort": "M", "wave": 3},
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: `PASS  test_patterns_registry_complete` then `1/1 tests passés`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: squelette audit_lib + registre PATTERNS (scoring)"
+```
+
+---
+
+## Task 2: Empreinte v2 — `query_fingerprint` + `output_fingerprint` (régression faux-positifs)
+
+C'est le cœur. Les 3 cartes GSC (#28943 clics, #28945 CTR, #28946 position) ont
+**même SQL, mêmes paramètres, même display** ; elles ne diffèrent que par
+`visualization_settings["graph.metrics"]`. L'empreinte v2 doit séparer
+l'**identité de requête** (commune) de l'**identité fonctionnelle** (distincte).
+
+**Files:**
+- Modify: `scripts/audit_lib.py` (ajouter fonctions)
+- Test: `tests/test_audit_lib.py` (ajouter tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_audit_lib.py` (above the `TESTS = [...]` list):
+
+```python
+# Fixture reproduisant les vrais faux positifs GSC : même SQL, même display,
+# graph.metrics différents (CLICKS / CTR / WEIGHTED_POSITION).
+_GSC_SQL = json.dumps({
+    "type": "native",
+    "database": 2,
+    "native": {"query": "WITH get_data AS (SELECT date, clicks, ctr, weighted_position FROM gsc) SELECT * FROM get_data"},
+})
+
+
+def _gsc_card(cid, name, metric):
+    return {
+        "id": cid, "name": name, "display": "line",
+        "legacy_query": _GSC_SQL,
+        "visualization_settings": {"graph.metrics": [metric], "graph.dimensions": ["DATE", "URL_GROUP"]},
+    }
+
+
+def test_query_fingerprint_identical_for_gsc_trio():
+    a = _gsc_card(28943, "Clicks by date", "CLICKS")
+    b = _gsc_card(28945, "CTR by date", "CTR")
+    c = _gsc_card(28946, "Weighted position by date", "WEIGHTED_POSITION")
+    assert audit_lib.query_fingerprint(a) == audit_lib.query_fingerprint(b) == audit_lib.query_fingerprint(c)
+
+
+def test_output_fingerprint_distinct_for_gsc_trio():
+    a = _gsc_card(28943, "Clicks by date", "CLICKS")
+    b = _gsc_card(28945, "CTR by date", "CTR")
+    c = _gsc_card(28946, "Weighted position by date", "WEIGHTED_POSITION")
+    fps = {audit_lib.output_fingerprint(a), audit_lib.output_fingerprint(b), audit_lib.output_fingerprint(c)}
+    assert len(fps) == 3  # PAS des doublons
+
+
+def test_output_fingerprint_identical_for_true_duplicate():
+    a = _gsc_card(1, "Clicks by date", "CLICKS")
+    b = _gsc_card(2, "Clicks by date (copie)", "CLICKS")  # rendu identique
+    assert audit_lib.output_fingerprint(a) == audit_lib.output_fingerprint(b)
+```
+
+Then add the three test names to the `TESTS` list:
+
+```python
+TESTS = [
+    test_patterns_registry_complete,
+    test_query_fingerprint_identical_for_gsc_trio,
+    test_output_fingerprint_distinct_for_gsc_trio,
+    test_output_fingerprint_identical_for_true_duplicate,
+]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `AttributeError: module 'audit_lib' has no attribute 'query_fingerprint'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/audit_lib.py`:
+
+```python
+def _legacy_query(card):
+    """Retourne le legacy_query (dict) ou None.
+
+    Via l'API, `dataset_query` (nouveau format) ressort souvent vide ;
+    `legacy_query` (string JSON) porte la requête classique fiable.
+    """
+    lq = card.get("legacy_query")
+    if isinstance(lq, str):
+        try:
+            lq = json.loads(lq)
+        except Exception:
+            lq = None
+    return lq if isinstance(lq, dict) and lq else None
+
+
+def query_fingerprint(card):
+    """Empreinte de la REQUÊTE seule (SQL/MBQL normalisé + base). Identité logique."""
+    lq = _legacy_query(card)
+    if lq is None:
+        dq = card.get("dataset_query", {}) or {}
+        return "ds|" + hashlib.md5(json.dumps(dq, sort_keys=True).encode()).hexdigest()
+    db = lq.get("database")
+    if lq.get("type") == "native":
+        sql = (lq.get("native", {}) or {}).get("query", "") or ""
+        norm = re.sub(r"\s+", " ", sql.strip().lower())
+        payload = f"native|{db}|{norm}"
+    else:
+        payload = f"mbql|{db}|" + json.dumps(lq.get("query", {}), sort_keys=True)
+    return hashlib.md5(payload.encode()).hexdigest()
+
+
+def _output_selection(card):
+    """Ce que la carte AFFICHE réellement — la clé des faux positifs.
+
+    Graphes : graph.metrics + graph.dimensions. Tables/pivots : colonnes activées.
+    """
+    vs = card.get("visualization_settings", {}) or {}
+    metrics = vs.get("graph.metrics")
+    dims = vs.get("graph.dimensions")
+    if metrics or dims:
+        return json.dumps({"m": sorted(metrics or []), "d": sorted(dims or [])}, sort_keys=True)
+    cols = vs.get("table.columns")
+    if cols:
+        enabled = [c.get("name") for c in cols if isinstance(c, dict) and c.get("enabled", True)]
+        return json.dumps({"cols": enabled}, sort_keys=True)
+    return ""
+
+
+def output_fingerprint(card):
+    """Empreinte FONCTIONNELLE : requête + display + sélection affichée.
+
+    Même output_fingerprint ⇒ rendu identique ⇒ vrai doublon (#6). Même
+    query_fingerprint mais output ≠ (ex. GSC clics/CTR/position) ⇒ variante (#9).
+    """
+    payload = f"{query_fingerprint(card)}|{card.get('display') or ''}|{_output_selection(card)}"
+    return hashlib.md5(payload.encode()).hexdigest()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: 4/4 tests passés (les 3 nouveaux PASS)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: empreinte v2 (query_fp + output_fp) — corrige les faux positifs GSC"
+```
+
+---
+
+## Task 3: `classify_query_groups` — doublons (#6) vs variantes (#9) vs viz≠
+
+**Files:**
+- Modify: `scripts/audit_lib.py`
+- Test: `tests/test_audit_lib.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_audit_lib.py`:
+
+```python
+def test_classify_separates_dups_variants_and_viz():
+    # variant_families ⟂ diff_viz pour un même groupe de requête (un groupe a soit
+    # un seul display soit plusieurs) — donc deux requêtes distinctes pour tester les deux.
+    a1 = _gsc_card(1, "Clicks", "CLICKS")
+    a2 = _gsc_card(2, "Clicks copie", "CLICKS")          # doublon de #1 (output identique)
+    a3 = _gsc_card(3, "CTR", "CTR")                       # variante
+    a4 = _gsc_card(4, "Position", "WEIGHTED_POSITION")    # variante
+    sql_b = json.dumps({"type": "native", "database": 2, "native": {"query": "SELECT a, b FROM t"}})
+    b1 = {"id": 5, "name": "B line", "display": "line", "legacy_query": sql_b,
+          "visualization_settings": {"graph.metrics": ["A"]}}
+    b2 = {"id": 6, "name": "B bar", "display": "bar", "legacy_query": sql_b,
+          "visualization_settings": {"graph.metrics": ["A"]}}
+    res = audit_lib.classify_query_groups([a1, a2, a3, a4, b1, b2])
+    assert any(sorted(c["id"] for c in g) == [1, 2] for g in res["pure_dups"])          # #6
+    assert any({c["id"] for c in g} == {1, 2, 3, 4} for g in res["variant_families"])   # #9
+    assert any({c["id"] for c in g} == {5, 6} for g in res["diff_viz"])
+```
+
+Add `test_classify_separates_dups_variants_and_viz` to the `TESTS` list.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `AttributeError: module 'audit_lib' has no attribute 'classify_query_groups'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/audit_lib.py`:
+
+```python
+def classify_query_groups(cards):
+    """Classe les cartes partageant une même requête. Enrichit chaque carte de
+    'query_fp' et 'output_fp'. Retourne {pure_dups, variant_families, diff_viz}.
+    """
+    for c in cards:
+        c["query_fp"] = query_fingerprint(c)
+        c["output_fp"] = output_fingerprint(c)
+
+    by_q = defaultdict(list)
+    for c in cards:
+        by_q[c["query_fp"]].append(c)
+
+    pure_dups, variant_families, diff_viz = [], [], []
+    for _q, group in by_q.items():
+        if len(group) < 2:
+            continue
+        by_out = defaultdict(list)
+        for c in group:
+            by_out[c["output_fp"]].append(c)
+        for _out, sub in by_out.items():
+            if len(sub) >= 2:
+                pure_dups.append(sub)                 # #6 : rendu identique
+        displays = {c.get("display") or "" for c in group}
+        if len(by_out) >= 2 and len(displays) == 1:
+            variant_families.append(group)            # #9 : même viz, sélection ≠
+        if len(displays) >= 2:
+            diff_viz.append(group)                    # même logique, viz ≠
+    pure_dups.sort(key=len, reverse=True)
+    variant_families.sort(key=len, reverse=True)
+    return {"pure_dups": pure_dups, "variant_families": variant_families, "diff_viz": diff_viz}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: 5/5 tests passés
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: classify_query_groups — doublons #6 / variantes #9 / viz≠"
+```
+
+---
+
+## Task 4: Graphe de sources + cartes inutilisées (#5)
+
+**Files:**
+- Modify: `scripts/audit_lib.py`
+- Test: `tests/test_audit_lib.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_audit_lib.py`:
+
+```python
+def test_build_source_ids_finds_card_references():
+    details = [
+        {"id": 100, "dataset_query": {"query": {"source-table": "card__42"}}},
+        {"id": 101, "legacy_query": json.dumps({"query": {"source-table": "card__7"}})},
+    ]
+    assert audit_lib.build_source_ids(details) == {42, 7}
+
+
+def test_find_unused_cards_excludes_sources_and_used():
+    cards = [
+        {"id": 1, "name": "orpheline", "dashboard_count": 0, "archived": False},
+        {"id": 2, "name": "utilisée", "dashboard_count": 3, "archived": False},
+        {"id": 3, "name": "source", "dashboard_count": 0, "archived": False},
+        {"id": 4, "name": "archivée", "dashboard_count": 0, "archived": True},
+    ]
+    unused = audit_lib.find_unused_cards(cards, source_ids={3})
+    assert [c["id"] for c in unused] == [1]
+```
+
+Add both names to the `TESTS` list.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `AttributeError: module 'audit_lib' has no attribute 'build_source_ids'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/audit_lib.py`:
+
+```python
+_CARD_SRC_RE = re.compile(r"card__(\d+)")
+
+
+def build_source_ids(card_details):
+    """Ids des cartes référencées comme SOURCE par une autre (`card__<id>`)."""
+    source_ids = set()
+    for d in card_details:
+        lq = d.get("legacy_query")
+        lq_blob = lq if isinstance(lq, str) else json.dumps(lq or {})
+        blob = json.dumps(d.get("dataset_query", {})) + lq_blob
+        for m in _CARD_SRC_RE.findall(blob):
+            source_ids.add(int(m))
+    return source_ids
+
+
+def find_unused_cards(cards, source_ids):
+    """Cartes 0 dashboard, non archivées, non utilisées comme source (règle 'hors sources')."""
+    return [c for c in cards
+            if c.get("dashboard_count", 0) == 0
+            and not c.get("archived")
+            and c["id"] not in source_ids]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: 7/7 tests passés
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: graphe de sources + cartes inutilisées (#5, hors sources)"
+```
+
+---
+
+## Task 5: Détecteurs de collections — vides (#1), fourre-tout (#4), noms dupliqués (#3)
+
+**Files:**
+- Modify: `scripts/audit_lib.py`
+- Test: `tests/test_audit_lib.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_audit_lib.py`:
+
+```python
+def test_find_empty_collections_respects_descendants_and_personal():
+    collections = [
+        {"id": 1, "name": "Parent", "location": "/"},
+        {"id": 2, "name": "Enfant occupé", "location": "/1/"},
+        {"id": 3, "name": "Vraiment vide", "location": "/"},
+        {"id": 4, "name": "Perso vide", "location": "/", "personal_owner_id": 9},
+    ]
+    cards = [{"id": 50, "collection_id": 2, "archived": False}]
+    dashboards = []
+    empty = audit_lib.find_empty_collections(collections, cards, dashboards)
+    ids = {e["id"] for e in empty}
+    assert ids == {3}        # 1 a un descendant occupé ; 2 est occupée ; 4 est perso
+
+
+def test_find_junk_collections_matches_names():
+    collections = [
+        {"id": 1, "name": "To sort", "location": "/"},
+        {"id": 2, "name": "TMP backup", "location": "/"},
+        {"id": 3, "name": "05. Google Analytics 4", "location": "/"},
+    ]
+    junk_ids = {c["id"] for c in audit_lib.find_junk_collections(collections)}
+    assert junk_ids == {1, 2}
+
+
+def test_find_duplicate_collection_names():
+    collections = [
+        {"id": 1, "name": "Bar", "location": "/a/"},
+        {"id": 2, "name": "Bar", "location": "/b/"},
+        {"id": 3, "name": "Unique", "location": "/"},
+    ]
+    dups = audit_lib.find_duplicate_collection_names(collections)
+    assert len(dups) == 1 and dups[0]["name"] == "Bar" and dups[0]["count"] == 2
+```
+
+Add the three names to the `TESTS` list.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `AttributeError: module 'audit_lib' has no attribute 'find_empty_collections'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/audit_lib.py`:
+
+```python
+def _is_personal(col):
+    return bool(col.get("personal_owner_id"))
+
+
+def find_empty_collections(collections, cards, dashboards):
+    """Collections non-perso sans carte/dashboard actif ET sans descendant occupé."""
+    occupied = {c.get("collection_id") for c in cards if not c.get("archived")}
+    occupied |= {d.get("collection_id") for d in dashboards if not d.get("archived")}
+    occupied.discard(None)
+
+    # ids de toutes les collections-ancêtres d'une collection occupée (via location)
+    occupied_ancestors = set()
+    for col in collections:
+        if col.get("id") in occupied:
+            for part in (col.get("location") or "/").strip("/").split("/"):
+                if part.isdigit():
+                    occupied_ancestors.add(int(part))
+
+    empty = []
+    for col in collections:
+        cid = col.get("id")
+        if _is_personal(col) or cid in occupied or cid in occupied_ancestors:
+            continue
+        empty.append({"id": cid, "name": col.get("name"), "location": col.get("location") or "/"})
+    return empty
+
+
+_JUNK_RE = re.compile(
+    r"\b(to ?sort|[àa] trier|test|tmp|temp|old|draft|brouillon|wip|backup|"
+    r"sauvegarde|copy|copie|untitled|sans titre|delete|supprimer)\b", re.I)
+
+
+def find_junk_collections(collections):
+    """Collections non-perso dont le nom évoque du fourre-tout / staging."""
+    out = []
+    for col in collections:
+        if _is_personal(col):
+            continue
+        name = col.get("name") or ""
+        if _JUNK_RE.search(name):
+            out.append({"id": col.get("id"), "name": name, "location": col.get("location") or "/"})
+    return out
+
+
+def find_duplicate_collection_names(collections):
+    """Noms de collections apparaissant plus d'une fois."""
+    names = defaultdict(list)
+    for col in collections:
+        nm = (col.get("name") or "").strip()
+        if nm:
+            names[nm].append({"id": col.get("id"),
+                              "location": col.get("location") or "/",
+                              "personal": _is_personal(col)})
+    return [{"name": nm, "count": len(entries), "entries": entries}
+            for nm, entries in names.items() if len(entries) > 1]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: 10/10 tests passés
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: détecteurs collections — vides #1, fourre-tout #4, noms dupliqués #3"
+```
+
+---
+
+## Task 6: Sprawl perso (#2) + incohérences de nommage (#10)
+
+**Files:**
+- Modify: `scripts/audit_lib.py`
+- Test: `tests/test_audit_lib.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_audit_lib.py`:
+
+```python
+def test_find_personal_sprawl_groups_by_client():
+    collections = [
+        {"id": 1, "name": "Accor | Nanga's Personal Collection", "personal_owner_id": 5},
+        {"id": 2, "name": "Accor | Nanga's Personal Collection", "personal_owner_id": 5},
+        {"id": 3, "name": "Apple | Nanga's Personal Collection", "personal_owner_id": 5},
+        {"id": 4, "name": "Louis Monier's Personal Collection", "personal_owner_id": 7},  # pas de client
+        {"id": 5, "name": "06. Industry benchmarks"},  # partagée
+    ]
+    sprawl = {s["client"]: s["count"] for s in audit_lib.find_personal_sprawl(collections, [])}
+    assert sprawl == {"Accor": 2, "Apple": 1}
+
+
+def test_find_naming_issues_flags_non_normalized_outside_template():
+    cards = [
+        {"id": 1, "name": "Add_to_cart_rate", "archived": False, "collection_id": 99},
+        {"id": 2, "name": "Clean name", "archived": False, "collection_id": 99},
+        {"id": 3, "name": "Ignored_in_template", "archived": False, "collection_id": 99},
+    ]
+    issues = audit_lib.find_naming_issues(cards, template_card_ids={3})
+    assert [i["id"] for i in issues] == [1]  # #2 déjà propre, #3 dans le template
+```
+
+Add both names to the `TESTS` list.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `AttributeError: module 'audit_lib' has no attribute 'find_personal_sprawl'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/audit_lib.py`:
+
+```python
+_CLIENT_PREFIX_RE = re.compile(r"^\s*(.+?)\s*\|\s*.+personal collection\s*$", re.I)
+
+
+def find_personal_sprawl(collections, cards):
+    """Collections personnelles préfixées d'un nom de client (travail client mal logé).
+
+    Retourne des groupes : [{client, count, collections:[...]}].
+    """
+    by_client = defaultdict(list)
+    for col in collections:
+        if not _is_personal(col):
+            continue
+        m = _CLIENT_PREFIX_RE.match(col.get("name") or "")
+        if m:
+            by_client[m.group(1).strip()].append({"id": col.get("id"), "name": col.get("name")})
+    return [{"client": k, "count": len(v), "collections": v} for k, v in sorted(by_client.items())]
+
+
+def find_naming_issues(cards, template_card_ids):
+    """Cartes hors template dont le nom n'est pas normalisé (cf. Phase 1.5)."""
+    out = []
+    for c in cards:
+        if c.get("archived") or c["id"] in template_card_ids:
+            continue
+        name = c.get("name") or ""
+        norm = normalize_name(name)
+        if norm and norm != name:
+            out.append({"id": c["id"], "name": name, "normalized": norm})
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: 12/12 tests passés
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: sprawl perso #2 + incohérences de nommage #10"
+```
+
+---
+
+## Task 7: Dérive template (#8)
+
+**Files:**
+- Modify: `scripts/audit_lib.py`
+- Test: `tests/test_audit_lib.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_audit_lib.py`:
+
+```python
+def test_find_template_drift_by_name_and_query():
+    def card(cid, name, sql):
+        return {"id": cid, "name": name, "collection_id": 1,
+                "legacy_query": json.dumps({"type": "native", "database": 2, "native": {"query": sql}})}
+    template = [card(10, "Daily revenue", "SELECT day, sum(amount) FROM sales GROUP BY 1")]
+    others = [
+        card(20, "Daily revenue", "SELECT day, sum(amount) FROM sales GROUP BY 1"),   # conforme
+        card(21, "Daily revenue", "SELECT day, sum(amount) FROM sales WHERE x GROUP BY 1"),  # dérivée
+        card(22, "Autre carte", "SELECT 1"),  # pas d'équivalent template
+    ]
+    drift = audit_lib.find_template_drift(template, others)
+    assert [d["id"] for d in drift] == [21]
+    assert drift[0]["template_id"] == 10
+```
+
+Add the name to the `TESTS` list.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: FAIL with `AttributeError: module 'audit_lib' has no attribute 'find_template_drift'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/audit_lib.py`:
+
+```python
+def find_template_drift(template_cards, other_cards):
+    """Copies clientes divergentes : même nom normalisé qu'une carte template,
+    mais empreinte de requête différente.
+
+    Limite connue : appariement par NOM (rate les copies renommées) — l'audit
+    le signale dans le rapport.
+    """
+    tpl_by_name = {}
+    for c in template_cards:
+        tpl_by_name.setdefault(normalize_name(c.get("name") or ""), []).append(c)
+    drift = []
+    for c in other_cards:
+        matches = tpl_by_name.get(normalize_name(c.get("name") or ""))
+        if not matches:
+            continue
+        if query_fingerprint(c) != query_fingerprint(matches[0]):
+            drift.append({"id": c["id"], "name": c.get("name"),
+                          "collection_id": c.get("collection_id"),
+                          "template_id": matches[0]["id"]})
+    return drift
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 tests/test_audit_lib.py`
+Expected: 13/13 tests passés
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py tests/test_audit_lib.py
+git commit -m "audit: dérive template #8 (appariement nom + empreinte requête)"
+```
+
+---
+
+## Task 8: `summarize_findings` + rendu du rapport court (`audit_report.py`)
+
+**Files:**
+- Modify: `scripts/audit_lib.py` (ajouter `summarize_findings`)
+- Create: `scripts/audit_report.py`
+- Test: `tests/test_audit_lib.py` (summarize) + Create `tests/test_audit_report.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_audit_lib.py`:
+
+```python
+def test_summarize_findings_sorts_by_wave_then_count():
+    findings = {
+        "template_drift": {"count": 5, "items": []},      # wave 3
+        "empty_collections": {"count": 200, "items": []},  # wave 0
+        "naming_issues": {"count": 9, "items": []},        # wave 1
+    }
+    rows = audit_lib.summarize_findings(findings)
+    assert [r["key"] for r in rows][:3] == ["empty_collections", "naming_issues", "template_drift"]
+    assert rows[0]["wave"] == 0 and rows[0]["impact"] == "H"
+```
+
+Add the name to the `TESTS` list. Then append to `scripts/audit_lib.py`:
+
+```python
+def summarize_findings(findings):
+    """Joint le scoring (PATTERNS) à chaque finding et trie par vague puis compte décroissant.
+
+    findings : {pattern_key: {count, items}}. Retourne une liste de dicts plats.
+    """
+    out = []
+    for key, data in findings.items():
+        meta = PATTERNS.get(key, {})
+        out.append({"key": key, **meta, "count": data.get("count", 0), "items": data.get("items", [])})
+    out.sort(key=lambda f: (f.get("wave", 9), -f.get("count", 0)))
+    return out
+```
+
+Create `tests/test_audit_report.py`:
+
+```python
+#!/usr/bin/env python3
+"""Tests du rendu d'audit — script autonome. Usage : python3 tests/test_audit_report.py"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import audit_report
+
+
+def _findings():
+    return {
+        "empty_collections": {"count": 200, "items": [{"id": i, "name": f"col{i}"} for i in range(200)]},
+        "pure_dups": {"count": 2, "items": [[{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]]},
+        "template_drift": {"count": 0, "items": []},
+    }
+
+
+def test_report_is_short_and_caps_examples():
+    md = audit_report.render_report(_findings(), scanned_cards=5654, scanned_collections=868, date="2026-05-28")
+    # exec summary + backlog présents
+    assert "## Résumé" in md and "## Backlog" in md
+    # exemples plafonnés : au plus MAX_EXAMPLES lignes d'exemple + une ligne "+N"
+    assert md.count("  - `") <= audit_report.MAX_EXAMPLES
+    assert "+195" in md  # 200 - 5 exemples
+    # un pattern à 0 n'apparaît pas dans le backlog
+    assert "template_drift" not in md.split("## Backlog")[1]
+
+
+def test_report_short_overall():
+    md = audit_report.render_report(_findings(), scanned_cards=5654, scanned_collections=868, date="2026-05-28")
+    assert len(md.splitlines()) < 60  # digest, pas un pavé
+
+
+TESTS = [test_report_is_short_and_caps_examples, test_report_short_overall]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t(); print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1; print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 tests/test_audit_lib.py` → FAIL (`summarize_findings` manquant)
+Run: `python3 tests/test_audit_report.py` → FAIL (`ModuleNotFoundError: No module named 'audit_report'`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+(After adding `summarize_findings` to `audit_lib.py` per Step 1.) Create `scripts/audit_report.py`:
+
+```python
+#!/usr/bin/env python3
+"""Rendu du rapport d'audit en markdown — digest COURT (détail exhaustif dans le JSON)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from audit_lib import summarize_findings  # noqa: E402
+
+MAX_EXAMPLES = 5
+WAVE_TITLES = {
+    0: "Vague 0 — Quick wins",
+    1: "Vague 1 — Automatisable",
+    2: "Vague 2 — Structurel",
+    3: "Vague 3 — DRY / dérive",
+}
+
+
+def _example_line(key, item):
+    if key in ("empty_collections", "junk_collections"):
+        return f"`{item.get('id')}` {item.get('name')}"
+    if key == "dup_collection_names":
+        return f"« {item.get('name')} » ×{item.get('count')}"
+    if key == "personal_sprawl":
+        return f"{item.get('client')} ×{item.get('count')}"
+    if key in ("unused_cards", "naming_issues", "template_drift"):
+        return f"#{item.get('id')} {item.get('name')}"
+    if key in ("pure_dups", "variant_families"):
+        return f"groupe de {len(item)} : " + ", ".join(f"#{c['id']}" for c in item[:4])
+    return str(item)[:80]
+
+
+def render_report(findings, *, scanned_cards=0, scanned_collections=0, date=""):
+    rows = summarize_findings(findings)
+    lines = [f"# Audit Metabase — {date}", "",
+             f"_{scanned_collections} collections · {scanned_cards} cartes scannées._", ""]
+    lines += ["## Résumé", "", "| # | Pattern | Compte | I/R/E | Vague |",
+              "|---|---------|--------|-------|-------|"]
+    for f in rows:
+        ire = f"{f.get('impact','?')}/{f.get('risk','?')}/{f.get('effort','?')}"
+        lines.append(f"| {f.get('num','?')} | {f['key']} | {f.get('count',0)} | {ire} | {f.get('wave','?')} |")
+    lines += ["", "## Backlog (quick-wins d'abord)", ""]
+    for wave in (0, 1, 2, 3):
+        wf = [f for f in rows if f.get("wave") == wave and f.get("count", 0) > 0]
+        if not wf:
+            continue
+        lines.append(f"### {WAVE_TITLES[wave]}")
+        for f in wf:
+            lines.append(f"- **{f['key']}** ({f.get('count',0)}) — {f.get('impact')}/{f.get('risk')}/{f.get('effort')}")
+            for item in f.get("items", [])[:MAX_EXAMPLES]:
+                lines.append(f"  - {_example_line(f['key'], item)}")
+            if f.get("count", 0) > MAX_EXAMPLES:
+                lines.append(f"  - … +{f['count'] - MAX_EXAMPLES} (détail dans le JSON)")
+        lines.append("")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 tests/test_audit_lib.py` → 14/14 tests passés
+Run: `python3 tests/test_audit_report.py` → 2/2 tests passés
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/audit_lib.py scripts/audit_report.py tests/test_audit_lib.py tests/test_audit_report.py
+git commit -m "audit: summarize_findings + rendu rapport court (digest)"
+```
+
+---
+
+## Task 9: Scaffold `audit.py` — connexion, argparse, helpers cache & template
+
+**Files:**
+- Create: `scripts/audit.py`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `scripts/audit.py`:
+
+```python
+#!/usr/bin/env python3
+"""Audit instance-wide Metabase : scan (large) → deep (profond) → report.
+
+Lecture seule. Voir :
+  docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md
+  docs/superpowers/plans/2026-05-28-metabase-instance-audit.md
+
+Usage :
+  python3 scripts/audit.py scan
+  python3 scripts/audit.py deep [--limit N]
+  python3 scripts/audit.py report
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+import audit_lib  # noqa: E402
+from audit_report import render_report  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+CACHE_DIR = MIGRATION_DIR / "audit-cache"
+DOCS_DIR = REPO_ROOT / "docs" / "audits"
+
+
+def connect_resilient():
+    """Connexion email/password (résiste à l'expiration de session sur run long)."""
+    env = _load_env()
+    domain, email, password = (env.get("METABASE_DOMAIN"),
+                               env.get("METABASE_EMAIL"),
+                               env.get("METABASE_PASSWORD"))
+    if not (domain and email and password):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env (run long).")
+    return Metabase_API(domain=domain, email=email, password=password)
+
+
+def _safe_get(mb, endpoint):
+    """GET tolérant : retourne [] sur erreur réseau/HTTP au lieu de tuer le run.
+
+    L'endpoint des archivées est volumineux et l'instance renvoie parfois un
+    ConnectionError transitoire (constaté lors de la conception).
+    """
+    try:
+        r = mb.get(endpoint)
+    except Exception as e:  # ConnectionError, Timeout, ...
+        print(f"  ⚠️  {endpoint} a échoué ({type(e).__name__}) — ignoré.")
+        return []
+    return r or []
+
+
+def _latest(prefix):
+    files = sorted(MIGRATION_DIR.glob(f"{prefix}-*.json"))
+    return files[-1] if files else None
+
+
+def _template_card_ids(collections, cards):
+    """Ids des cartes sous l'arbre du template (215), via location."""
+    root = audit_lib.TEMPLATE_ROOT_ID
+    tpl_cols = {c.get("id") for c in collections
+                if c.get("id") == root or f"/{root}/" in (c.get("location") or "")}
+    tpl_cols.add(root)
+    return {c["id"] for c in cards if c.get("collection_id") in tpl_cols}
+
+
+def cmd_scan(args):
+    raise NotImplementedError  # Task 10
+
+
+def cmd_deep(args):
+    raise NotImplementedError  # Task 11
+
+
+def cmd_report(args):
+    raise NotImplementedError  # Task 12
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("scan")
+    d = sub.add_parser("deep")
+    d.add_argument("--limit", type=int, default=0, help="ne traiter que les N premières cartes (test)")
+    sub.add_parser("report")
+    args = p.parse_args()
+    {"scan": cmd_scan, "deep": cmd_deep, "report": cmd_report}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Verify it parses (smoke)**
+
+Run: `python3 scripts/audit.py --help`
+Expected: l'aide liste les sous-commandes `{scan,deep,report}` sans erreur.
+
+Run: `python3 scripts/audit.py report` (sans findings)
+Expected: `NotImplementedError` (les commandes sont câblées ; corps en Tasks 10-12).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/audit.py
+git commit -m "audit: squelette CLI audit.py (scan/deep/report) + helpers cache/template"
+```
+
+---
+
+## Task 10: `cmd_scan` — passe large (métadonnées + archivées)
+
+**Files:**
+- Modify: `scripts/audit.py:cmd_scan`
+
+- [ ] **Step 1: Write the implementation**
+
+Replace the `cmd_scan` stub in `scripts/audit.py`:
+
+```python
+def cmd_scan(args):
+    mb = connect_resilient()
+    print("Passe large : collections, cartes, dashboards (+ archivés)...")
+    collections = _safe_get(mb, "/api/collection/")
+    arch_cols = _safe_get(mb, "/api/collection/?archived=true")
+    cards = _safe_get(mb, "/api/card/")
+    arch_cards = _safe_get(mb, "/api/card/?f=archived")
+    dashboards = _safe_get(mb, "/api/dashboard/")
+
+    template_ids = _template_card_ids(collections, cards)
+
+    findings = {}
+    empty = audit_lib.find_empty_collections(collections, cards, dashboards)
+    findings["empty_collections"] = {"count": len(empty), "items": empty}
+    junk = audit_lib.find_junk_collections(collections)
+    findings["junk_collections"] = {"count": len(junk), "items": junk}
+    dn = audit_lib.find_duplicate_collection_names(collections)
+    findings["dup_collection_names"] = {"count": len(dn), "items": dn}
+    sprawl = audit_lib.find_personal_sprawl(collections, cards)
+    findings["personal_sprawl"] = {"count": len(sprawl), "items": sprawl}
+    naming = audit_lib.find_naming_issues(cards, template_ids)
+    findings["naming_issues"] = {"count": len(naming), "items": naming}
+    findings["archived_backlog"] = {
+        "count": len(arch_cards) + len(arch_cols),
+        "items": [{"archived_cards": len(arch_cards), "archived_collections": len(arch_cols)}],
+    }
+    # #5 inutilisées : compte provisoire (sans graphe de sources), affiné en `deep`
+    prelim = [c for c in cards if c.get("dashboard_count", 0) == 0 and not c.get("archived")]
+    findings["unused_cards"] = {"count": len(prelim),
+                                "items": [{"id": c["id"], "name": c.get("name")} for c in prelim],
+                                "preliminary": True}
+    # patterns enrichis par la passe profonde
+    for k in ("pure_dups", "variant_families", "template_drift", "expensive_cards"):
+        findings.setdefault(k, {"count": 0, "items": []})
+
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = MIGRATION_DIR / f"audit-findings-{ts}.json"
+    out.write_text(json.dumps({
+        "meta": {"scanned_collections": len(collections), "scanned_cards": len(cards),
+                 "archived_cards": len(arch_cards), "archived_collections": len(arch_cols),
+                 "template_card_ids": sorted(template_ids), "deep_done": False},
+        "findings": findings,
+    }, indent=2, ensure_ascii=False))
+    print(f"  {len(collections)} collections, {len(cards)} cartes, {len(dashboards)} dashboards")
+    print(f"  vides:{len(empty)} fourre-tout:{len(junk)} noms-dupes:{len(dn)} "
+          f"sprawl:{len(sprawl)} nommage:{len(naming)} archivées:{len(arch_cards)}")
+    print(f"Findings écrits : {out}")
+```
+
+- [ ] **Step 2: Run live to verify**
+
+Run: `python3 scripts/audit.py scan`
+Expected (ordres de grandeur connus au 2026-05-28) :
+- `~868 collections, ~5654 cartes, ~735 dashboards`
+- `vides:~241` (collections non-perso vides), `sprawl:` plusieurs dizaines de clients
+- archivées : `~1803` collections archivées (gros backlog, pattern #7) ; le compte
+  des cartes archivées peut être 0 si `/api/card/?f=archived` a renvoyé un
+  `ConnectionError` transitoire (le `⚠️` s'affiche alors) — relancer `scan` pour
+  retenter ; le reste du scan reste valide.
+- un fichier `migration/audit-findings-<ts>.json` est créé.
+
+- [ ] **Step 3: Sanity-check the JSON**
+
+Run:
+```bash
+python3 -c "import json,glob; f=sorted(glob.glob('migration/audit-findings-*.json'))[-1]; b=json.load(open(f)); print('keys:', list(b['findings'])); print('empty:', b['findings']['empty_collections']['count']); print('meta:', b['meta']['scanned_cards'], b['meta']['archived_cards'])"
+```
+Expected: 11 clés de findings ; `empty` ≈ 241 ; `scanned_cards` ≈ 5654.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/audit.py
+git commit -m "audit: cmd_scan — passe large (métadonnées + archivées) -> findings JSON"
+```
+
+---
+
+## Task 11: `cmd_deep` — passe profonde (corpus complet, cache reprenable)
+
+**Files:**
+- Modify: `scripts/audit.py:cmd_deep` (+ helper `_card_detail`)
+
+- [ ] **Step 1: Write the implementation**
+
+Add the helper above `cmd_deep`, then replace the `cmd_deep` stub in `scripts/audit.py`:
+
+```python
+def _card_detail(mb, cid):
+    """Fetch /api/card/{id} avec cache disque (reprenable). 3 essais espacés."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    f = CACHE_DIR / f"card-{cid}.json"
+    if f.exists():
+        return json.loads(f.read_text())
+    for attempt in range(3):
+        d = mb.get(f"/api/card/{cid}")
+        if d:
+            f.write_text(json.dumps(d, ensure_ascii=False))
+            return d
+        time.sleep(1.5 * (attempt + 1))
+    return None
+
+
+def cmd_deep(args):
+    mb = connect_resilient()
+    findings_file = _latest("audit-findings")
+    if not findings_file:
+        sys.exit("Aucun audit-findings : lancer `scan` d'abord.")
+    blob = json.loads(findings_file.read_text())
+
+    cards = mb.get("/api/card/") or []
+    if args.limit:
+        cards = cards[:args.limit]
+    print(f"Passe profonde : fetch de {len(cards)} requêtes (cache {CACHE_DIR})...")
+    details = []
+    for i, c in enumerate(cards, 1):
+        d = _card_detail(mb, c["id"])
+        if d:
+            details.append(d)
+        if i % 200 == 0:
+            print(f"  {i}/{len(cards)}")
+
+    groups = audit_lib.classify_query_groups(details)
+    source_ids = audit_lib.build_source_ids(details)
+    unused = audit_lib.find_unused_cards(details, source_ids)
+
+    tpl_ids = set(blob["meta"].get("template_card_ids", []))
+    tpl_cards = [d for d in details if d["id"] in tpl_ids]
+    other_cards = [d for d in details if d["id"] not in tpl_ids]
+    drift = audit_lib.find_template_drift(tpl_cards, other_cards)
+
+    f = blob["findings"]
+    f["pure_dups"] = {"count": len(groups["pure_dups"]),
+                      "items": [[{"id": c["id"], "name": c.get("name"), "display": c.get("display")}
+                                 for c in g] for g in groups["pure_dups"]]}
+    f["variant_families"] = {"count": len(groups["variant_families"]),
+                             "items": [[{"id": c["id"], "name": c.get("name")} for c in g]
+                                       for g in groups["variant_families"]]}
+    f["unused_cards"] = {"count": len(unused),
+                         "items": [{"id": c["id"], "name": c.get("name")} for c in unused]}
+    f["template_drift"] = {"count": len(drift), "items": drift}
+    blob["meta"]["deep_done"] = True
+    findings_file.write_text(json.dumps(blob, indent=2, ensure_ascii=False))
+    print(f"  doublons:{len(groups['pure_dups'])} variantes:{len(groups['variant_families'])} "
+          f"inutilisées:{len(unused)} dérive:{len(drift)}")
+    print(f"Findings enrichis : {findings_file}")
+```
+
+- [ ] **Step 2: Run a small sample first**
+
+Run: `python3 scripts/audit.py deep --limit 50`
+Expected: `Passe profonde : fetch de 50 requêtes...`, un résumé `doublons:.. variantes:.. inutilisées:.. dérive:..`, et 50 fichiers `migration/audit-cache/card-*.json`.
+
+- [ ] **Step 3: Verify resumability**
+
+Run the same command again: `python3 scripts/audit.py deep --limit 50`
+Expected: termine quasi instantanément (cache touché, aucun re-fetch réseau).
+
+- [ ] **Step 4: Run the full corpus**
+
+Run: `python3 scripts/audit.py deep`
+Expected: progresse par paliers de 200 jusqu'à ~5654 ; résumé final avec les comptes réels. Tolérant aux coupures : relancer reprend depuis le cache.
+
+- [ ] **Step 5: Spot-check the GSC false-positives are NOT pure dups**
+
+Run:
+```bash
+python3 -c "import json,glob; f=sorted(glob.glob('migration/audit-findings-*.json'))[-1]; b=json.load(open(f)); pure=[i for g in b['findings']['pure_dups']['items'] for i in g]; ids={c['id'] for c in pure}; print('28943/28945/28946 dans pure_dups ?', {28943,28945,28946} & ids)"
+```
+Expected: `set()` — les cartes GSC clics/CTR/position ne sont PAS classées en doublons (elles doivent apparaître en `variant_families`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit.py
+git commit -m "audit: cmd_deep — passe profonde corpus complet (cache reprenable), enrichit findings"
+```
+
+---
+
+## Task 12: `cmd_report` + bout-en-bout + .gitignore
+
+**Files:**
+- Modify: `scripts/audit.py:cmd_report`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Write the implementation**
+
+Replace the `cmd_report` stub in `scripts/audit.py`:
+
+```python
+def cmd_report(args):
+    findings_file = _latest("audit-findings")
+    if not findings_file:
+        sys.exit("Aucun audit-findings : lancer `scan` d'abord.")
+    blob = json.loads(findings_file.read_text())
+    if not blob["meta"].get("deep_done"):
+        print("⚠️  passe profonde non exécutée — doublons/variantes/dérive seront à 0. "
+              "Lancer `deep` pour un rapport complet.")
+    md = render_report(blob["findings"],
+                       scanned_cards=blob["meta"].get("scanned_cards", 0),
+                       scanned_collections=blob["meta"].get("scanned_collections", 0),
+                       date=datetime.now().strftime("%Y-%m-%d"))
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    out = DOCS_DIR / f"audit-{datetime.now().strftime('%Y%m%d')}.md"
+    out.write_text(md)
+    print(f"Rapport écrit : {out}")
+```
+
+- [ ] **Step 2: Add ignore rules**
+
+Add to the end of `.gitignore`:
+
+```
+migration/audit-findings-*.json
+migration/audit-cache/
+# Rapport d'audit : données live (noms de clients) — régénérable, non versionné par défaut
+docs/audits/
+```
+
+- [ ] **Step 3: Run report + eyeball**
+
+Run: `python3 scripts/audit.py report`
+Expected: `Rapport écrit : docs/audits/audit-<date>.md`.
+
+Run: `python3 -c "p=open('docs/audits/audit-$(date +%Y%m%d).md').read(); print(p[:1500]); print('--- lignes:', len(p.splitlines()))"`
+Expected: un digest court — `## Résumé` (tableau 11 lignes), `## Backlog` par vague, exemples plafonnés à 5/section. Lignes totales raisonnables (dizaines, pas centaines).
+
+- [ ] **Step 4: Run the whole test suite**
+
+Run: `python3 tests/test_audit_lib.py && python3 tests/test_audit_report.py`
+Expected: `14/14 tests passés` puis `2/2 tests passés`.
+
+- [ ] **Step 5: Verify the report is untracked**
+
+Run: `git status --porcelain docs/audits migration/audit-findings-*.json migration/audit-cache`
+Expected: aucune sortie (tout ignoré).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit.py .gitignore
+git commit -m "audit: cmd_report (digest court) + ignore artefacts d'audit"
+```
+
+---
+
+## Self-Review (rempli pendant l'écriture du plan)
+
+**Spec coverage** — chaque pattern de la spec §5 a une tâche :
+#1 empty (T5) · #2 sprawl (T6) · #3 dup names (T5) · #4 junk (T5) · #5 unused (T4) · #6 pure_dups (T2/T3) · #7 archived (T10) · #8 drift (T7) · #9 variants (T3) · #10 naming (T6) · #11 perf — *partiellement* : `expensive_cards` est câblé dans le registre/findings à 0 (best-effort, cf. décision « #11 best-effort »). Collecte des stats `query_executions` non implémentée ici ; à ajouter dans une itération si l'API les expose (note ci-dessous).
+
+Scan/deep/report (architecture §4) → T9/T10/T11/T12. Scoring & vagues (§6) → T1 + T8. Format sortie (§7) → T10 (JSON) + T8/T12 (md court). Sûreté (§9) : quirk `dataset_query` (T2), graphe de sources (T4), cache reprenable (T11), archivées (T10).
+
+**Placeholder scan** — pas de TBD ; les stubs `NotImplementedError` (T9) sont remplis en T10-12 (référence explicite). `expensive_cards` reste à 0 par décision produit, pas par oubli.
+
+**Type consistency** — `findings` = `{key: {count, items}}` partout (scan, deep, summarize, render). `query_fingerprint`/`output_fingerprint`/`classify_query_groups`/`build_source_ids`/`find_*`/`summarize_findings`/`render_report` : signatures identiques entre définition (audit_lib) et appels (audit.py, audit_report). `_template_card_ids` produit le set consommé par `find_naming_issues` et par le partitionnement drift en T11.
+
+**Note #11 (perf)** — pour activer plus tard : en `deep`, tenter `GET /api/card/:id` → champ `last_query_start` / endpoint `/api/card/:id/query_metadata`, ou la table d'audit si dispo ; remplir `findings["expensive_cards"]`. Laisser à 0 sinon (le rapport l'affiche simplement à 0).
+
+---
+
+## Execution Handoff
+
+Voir la fin de la conversation pour le choix du mode d'exécution.

--- a/docs/superpowers/plans/2026-06-03-conversion-migration.md
+++ b/docs/superpowers/plans/2026-06-03-conversion-migration.md
@@ -1,0 +1,1061 @@
+# Conversion Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate every old-system conversion tile on the ~110 client custom dashboards (under Metabase collection 317) to its new named-conversion equivalent, preserving layout and filter wiring, mapping-driven and per-client, with snapshot rollback and per-tile validation.
+
+**Architecture:** A pure logic library (`conv_lib.py`, unit-tested) + a per-dashboard CLI migrator (`migrate_conversions_on_dashboard.py`, reusing `swap_lib.rewrite_dashcards`) + input builders (Airtable mapping export, new-tree index, target discovery) + a wave orchestrator with a living tracker. The old→new mapping comes from Airtable (`type` slot → `new_type` named, per client); card shape is matched structurally against the generated new tree (collection 11673).
+
+**Tech stack:** Python 3 (`.venv`), the in-repo `spark_metabase_api` wrapper (Metabase REST), standalone-script pytest-style tests (run via `python3 tests/test_x.py`), Airtable via MCP (export to JSON), Snowflake via Metabase `/api/dataset`.
+
+**Validated facts (spike, 2026-06-03):** `266 "Conversions 1" → 42635 "Custom Conversion 1"` swap on a copy of dashboard 14118 preserved layout+filters; value reconciled exactly vs Snowflake. New cards lack `legacy_query` (tags live in `dataset_query.stages[].template-tags`). Pro Nutrition mapping: `Main→Purchases`, `1st→Custom 1`, `3rd→Custom 2` (slot ≠ Custom number). Spec: `docs/superpowers/specs/2026-06-03-conversion-migration-design.md`. Sandbox to clean up: collection 13851, dashboard 25302.
+
+**Conventions:** pure logic in `scripts/conv_lib.py` (no network I/O), tested in `tests/test_conv_lib.py`. CLIs default to dry-run; mutations require `--yes`; every mutation writes a JSON snapshot under `migration/`. Commit after each task.
+
+---
+
+## Phase 0 — Library scaffolding: columns + format-tolerant extractor
+
+### Task 1: Column inventory + native/tag extractor
+
+**Files:**
+- Create: `scripts/conv_lib.py`
+- Test: `tests/test_conv_lib.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_conv_lib.py
+#!/usr/bin/env python3
+"""Tests de conv_lib — script autonome. Usage : python3 tests/test_conv_lib.py"""
+import json, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import conv_lib
+
+def _native(sql, tags=()):  # old legacy-native card
+    return {"dataset_query": {"type": "native", "native": {"query": sql, "template-tags": {t: {} for t in tags}}}}
+
+def _staged(sql, tags=()):  # new pMBQL stages-native card (no legacy_query)
+    return {"dataset_query": {"lib/type": "mbql/query",
+            "stages": [{"lib/type": "mbql.stage/native", "native": sql,
+                        "template-tags": {t: {} for t in tags}}]}}
+
+def test_native_and_tags_legacy_format():
+    sql, tags = conv_lib.native_and_tags(_native("SELECT SUM(conversions_1)", ["clients", "date"]))
+    assert "conversions_1" in sql and tags.keys() == {"clients", "date"}
+
+def test_native_and_tags_stages_format():
+    sql, tags = conv_lib.native_and_tags(_staged("SELECT SUM(custom_conversions_1)", ["clients", "date"]))
+    assert "custom_conversions_1" in sql and set(tags) == {"clients", "date"}
+
+def test_native_and_tags_legacy_query_fallback():
+    card = {"legacy_query": json.dumps({"type": "native", "native": {"query": "SELECT 1", "template-tags": {"date": {}}}})}
+    sql, tags = conv_lib.native_and_tags(card)
+    assert sql == "SELECT 1" and set(tags) == {"date"}
+
+def test_old_columns_detects_positional_not_custom():
+    sql = "SELECT SUM(global.campaign_daily_metrics.conversions_1), SUM(custom_conversions_1) "
+    assert conv_lib.old_conversion_columns(sql) == {"CONVERSIONS_1"}
+
+def test_old_columns_base_not_matched_inside_positional():
+    assert conv_lib.old_conversion_columns("SELECT SUM(conversions_12)") == {"CONVERSIONS_12"}
+
+def test_old_columns_ignores_conversion_type_filter():
+    assert conv_lib.old_conversion_columns("WHERE conversion_type = 'x'") == set()
+
+def test_new_columns_named_and_custom():
+    sql = "SELECT SUM(purchases), SUM(custom_conversions_2_value)"
+    assert conv_lib.new_conversion_columns(sql) == {"PURCHASES", "CUSTOM_CONVERSIONS_2_VALUE"}
+
+TESTS = [test_native_and_tags_legacy_format, test_native_and_tags_stages_format,
+         test_native_and_tags_legacy_query_fallback, test_old_columns_detects_positional_not_custom,
+         test_old_columns_base_not_matched_inside_positional, test_old_columns_ignores_conversion_type_filter,
+         test_new_columns_named_and_custom]
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try: t(); print(f"PASS  {t.__name__}")
+        except Exception as e: failures += 1; print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés"); sys.exit(1 if failures else 0)
+
+if __name__ == "__main__":
+    run()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python tests/test_conv_lib.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'conv_lib'`.
+
+- [ ] **Step 3: Implement `conv_lib.py` (this part)**
+
+```python
+# scripts/conv_lib.py
+#!/usr/bin/env python3
+"""Logique pure de la migration de conversions (ancien positionnel -> nouveau nommé).
+Aucune I/O réseau. Voir docs/superpowers/specs/2026-06-03-conversion-migration-design.md."""
+from __future__ import annotations
+import json, re
+from collections import defaultdict
+
+# --- Column inventory (authoritative, Snowflake information_schema 2026-06-03) ---
+OLD_COUNT = ["CONVERSIONS"] + [f"CONVERSIONS_{n}" for n in range(1, 20)]
+OLD_VALUE = ["CONVERSION_VALUE"] + [f"CONVERSION_{n}_VALUE" for n in range(1, 20)]
+OLD_COLS = set(OLD_COUNT) | set(OLD_VALUE)
+
+CUSTOM_COUNT = {n: f"CUSTOM_CONVERSIONS_{n}" for n in range(1, 16)}
+CUSTOM_VALUE = {n: f"CUSTOM_CONVERSIONS_{n}_VALUE" for n in range(1, 16)}
+NAMED_COL = {  # new_type label -> (count_col, value_col | None)
+    "Purchases": ("PURCHASES", "PURCHASES_VALUE"),
+    "Add to cart": ("ADD_TO_CARTS_NEW", "ADD_TO_CARTS_VALUE_NEW"),
+    "Initiate checkouts": ("INITIATE_CHECKOUTS", "INITIATE_CHECKOUTS_VALUE"),
+    "Content views OR View Item": ("CONTENT_VIEWS", None),
+    "Sign ups": ("SIGN_UPS", None),
+    "Leads": ("LEADS", "LEADS_VALUE"),
+    "Marketing Qualified Leads": ("MARKETING_QUALIFIED_LEADS", "MARKETING_QUALIFIED_LEADS_VALUE"),
+    "Sales Qualified Leads": ("SALES_QUALIFIED_LEADS", "SALES_QUALIFIED_LEADS_VALUE"),
+    "Offline sales": ("OFFLINE_SALES", "OFFLINE_SALES_VALUE"),
+    "App installs": ("APP_INSTALLS_NEW", "APP_INSTALL_VALUE"),
+    "Search visits (combo organic + sea custom conv meta)": ("SEARCH_VISITS_COMBO", None),
+    "Organic search visits (custom conv meta)": ("ORGANIC_SEARCH_VISITS", None),
+    "Paid search visits (custom conv meta)": ("PAID_SEARCH_VISITS", None),
+}
+NEW_COLS = set()
+for n in range(1, 16):
+    NEW_COLS |= {CUSTOM_COUNT[n], CUSTOM_VALUE[n]}
+for _c, _v in NAMED_COL.values():
+    NEW_COLS.add(_c)
+    if _v:
+        NEW_COLS.add(_v)
+
+def _rx(cols):
+    return re.compile(r"(?<![A-Z0-9_])(" + "|".join(sorted(cols, key=len, reverse=True)) + r")(?![A-Z0-9_])")
+_OLD_RX, _NEW_RX = _rx(OLD_COLS), _rx(NEW_COLS)
+
+def native_and_tags(card):
+    """(sql, template-tags dict) — tolère natif legacy, stages pMBQL, et legacy_query."""
+    dq = card.get("dataset_query") or {}
+    if dq.get("type") == "native":
+        n = dq.get("native") or {}
+        return n.get("query") or "", (n.get("template-tags") or {})
+    for st in dq.get("stages") or []:
+        if st.get("lib/type") == "mbql.stage/native":
+            return st.get("native") or "", (st.get("template-tags") or {})
+    lq = card.get("legacy_query")
+    if isinstance(lq, str):
+        try:
+            lq = json.loads(lq)
+        except Exception:
+            lq = {}
+        if isinstance(lq, dict) and lq.get("type") == "native":
+            n = lq.get("native") or {}
+            return n.get("query") or "", (n.get("template-tags") or {})
+    return "", {}
+
+def old_conversion_columns(sql):
+    return set(_OLD_RX.findall((sql or "").upper()))
+
+def new_conversion_columns(sql):
+    return set(_NEW_RX.findall((sql or "").upper()))
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python tests/test_conv_lib.py`
+Expected: `7/7 tests passés`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/conv_lib.py tests/test_conv_lib.py
+git commit -m "conv/lib: column inventory + format-tolerant native/tag extractor (TDD)"
+```
+
+---
+
+## Phase 1 — Type-axis: slot↔column maps + Airtable mapping ingestion
+
+### Task 2: Slot/new_type column maps + `build_client_mappings`
+
+**Files:**
+- Modify: `scripts/conv_lib.py` (append)
+- Modify: `tests/test_conv_lib.py` (add tests + extend `TESTS`)
+
+- [ ] **Step 1: Add failing tests**
+
+```python
+# append to tests/test_conv_lib.py before TESTS list
+def test_slot_old_columns():
+    assert conv_lib.slot_old_columns(0) == ("CONVERSIONS", "CONVERSION_VALUE")
+    assert conv_lib.slot_old_columns(3) == ("CONVERSIONS_3", "CONVERSION_3_VALUE")
+
+def test_type_to_slot():
+    assert conv_lib.TYPE_TO_SLOT["Main conversion"] == 0
+    assert conv_lib.TYPE_TO_SLOT["1st conversion"] == 1
+    assert conv_lib.TYPE_TO_SLOT["3rd conversion"] == 3
+    assert conv_lib.TYPE_TO_SLOT["19th conversion"] == 19
+
+def test_new_type_columns_custom_and_named():
+    assert conv_lib.new_type_columns("Custom 1") == ("CUSTOM_CONVERSIONS_1", "CUSTOM_CONVERSIONS_1_VALUE")
+    assert conv_lib.new_type_columns("Custom 2") == ("CUSTOM_CONVERSIONS_2", "CUSTOM_CONVERSIONS_2_VALUE")
+    assert conv_lib.new_type_columns("Purchases") == ("PURCHASES", "PURCHASES_VALUE")
+    assert conv_lib.new_type_columns("Sign ups") == ("SIGN_UPS", None)
+
+def test_build_client_mappings_resolves_consistent_and_flags_unmapped_conflict():
+    records = [
+        {"client": "Pro Nutrition", "type": "Main conversion", "new_type": "Purchases"},
+        {"client": "Pro Nutrition", "type": "Main conversion", "new_type": "Purchases"},   # consistent dup
+        {"client": "Pro Nutrition", "type": "1st conversion", "new_type": "Custom 1"},
+        {"client": "Pro Nutrition", "type": "3rd conversion", "new_type": "Custom 2"},      # slot != custom#
+        {"client": "Pro Nutrition", "type": "1st conversion", "new_type": None},            # empty ignored
+        {"client": "Acme", "type": "Main conversion", "new_type": None},                    # only empty -> UNMAPPED
+        {"client": "Acme", "type": "2nd conversion", "new_type": "Leads"},
+        {"client": "Acme", "type": "2nd conversion", "new_type": "Purchases"},              # conflict
+    ]
+    m = conv_lib.build_client_mappings(records)
+    assert m["Pro Nutrition"][0] == "Purchases"
+    assert m["Pro Nutrition"][1] == "Custom 1"
+    assert m["Pro Nutrition"][3] == "Custom 2"
+    assert m["Acme"][0] == conv_lib.UNMAPPED
+    assert m["Acme"][2] == conv_lib.CONFLICT
+```
+
+```python
+# extend TESTS list with:
+    test_slot_old_columns, test_type_to_slot, test_new_type_columns_custom_and_named,
+    test_build_client_mappings_resolves_consistent_and_flags_unmapped_conflict,
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python tests/test_conv_lib.py`
+Expected: FAIL — `AttributeError: module 'conv_lib' has no attribute 'slot_old_columns'`.
+
+- [ ] **Step 3: Implement (append to `conv_lib.py`)**
+
+```python
+# --- Type-axis (Airtable slot -> new named) ---
+TYPE_TO_SLOT = {"Main conversion": 0}
+_ORD = ["1st", "2nd", "3rd"] + [f"{n}th" for n in range(4, 20)]
+for _i, _o in enumerate(_ORD, start=1):
+    TYPE_TO_SLOT[f"{_o} conversion"] = _i
+
+UNMAPPED = "__UNMAPPED__"
+CONFLICT = "__CONFLICT__"
+
+def slot_old_columns(slot):
+    if slot == 0:
+        return ("CONVERSIONS", "CONVERSION_VALUE")
+    return (f"CONVERSIONS_{slot}", f"CONVERSION_{slot}_VALUE")
+
+def new_type_columns(new_type):
+    m = re.match(r"Custom (\d+)$", new_type or "")
+    if m:
+        n = int(m.group(1))
+        return (CUSTOM_COUNT.get(n), CUSTOM_VALUE.get(n))
+    return NAMED_COL.get(new_type, (None, None))
+
+def build_client_mappings(records):
+    """records: [{client, type, new_type}] (flattened Airtable rows) ->
+    {client: {slot: new_type | UNMAPPED | CONFLICT}}. Slots seen with only empty
+    new_type -> UNMAPPED; multiple distinct new_type for one slot -> CONFLICT."""
+    seen = defaultdict(lambda: defaultdict(set))
+    for r in records:
+        client, typ = r.get("client"), r.get("type")
+        if not client or typ not in TYPE_TO_SLOT:
+            continue
+        slot = TYPE_TO_SLOT[typ]
+        nt = r.get("new_type")
+        seen[client][slot]  # ensure slot recorded even if empty
+        if nt:
+            seen[client][slot].add(nt)
+    out = {}
+    for client, slots in seen.items():
+        out[client] = {}
+        for slot, nts in slots.items():
+            out[client][slot] = (next(iter(nts)) if len(nts) == 1
+                                 else CONFLICT if len(nts) > 1 else UNMAPPED)
+    return out
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python tests/test_conv_lib.py`
+Expected: `11/11 tests passés`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/conv_lib.py tests/test_conv_lib.py
+git commit -m "conv/lib: slot/new_type column maps + per-client mapping ingestion (TDD)"
+```
+
+### Task 3: Export the Airtable mapping to JSON (input artifact)
+
+> The Python tool has no Airtable token; the mapping is exported once (and re-exported when it changes) via the Airtable MCP in the orchestrating Claude session, then transformed by `build_client_mappings`.
+
+**Files:**
+- Create: `scripts/export_conv_mapping.py`
+- Output: `migration/conv-airtable-rows-<ts>.json` (raw flattened rows) and `migration/conv-client-mapping.json` (resolved)
+
+- [ ] **Step 1: Produce raw rows via MCP (orchestrator session)**
+
+In the Claude session, page through Airtable base `apptzpE1FqCMGH0dw` table `tbliHOIPYGJCvLvas` with `list_records_for_table`, filter `type` isNotEmpty (field `fldKwKgjtULTSjX6g`), fields `[brand_name, type, new_type]`, paginating on `cursor`. Flatten each record to `{"client": <brand_name>, "type": <type name>, "new_type": <new_type name or null>}` and write the list to `migration/conv-airtable-rows-<ts>.json`. (`brand_name`/`type`/`new_type` come back as objects/arrays — take `.name` / first element name.)
+
+- [ ] **Step 2: Implement the transform CLI**
+
+```python
+# scripts/export_conv_mapping.py
+#!/usr/bin/env python3
+"""Transforme les lignes Airtable exportées en mapping client résolu.
+Usage: python3 scripts/export_conv_mapping.py migration/conv-airtable-rows-<ts>.json"""
+import json, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import conv_lib
+
+def main():
+    rows = json.loads(Path(sys.argv[1]).read_text())
+    mapping = conv_lib.build_client_mappings(rows)
+    n_un = sum(1 for c in mapping.values() for v in c.values() if v == conv_lib.UNMAPPED)
+    n_cf = sum(1 for c in mapping.values() for v in c.values() if v == conv_lib.CONFLICT)
+    out = Path("migration/conv-client-mapping.json")
+    out.write_text(json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True))
+    print(f"{len(mapping)} clients -> {out}  (UNMAPPED slots: {n_un}, CONFLICT slots: {n_cf})")
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: Run + sanity-check Pro Nutrition**
+
+Run: `.venv/bin/python scripts/export_conv_mapping.py migration/conv-airtable-rows-<ts>.json`
+Then: `.venv/bin/python -c "import json; m=json.load(open('migration/conv-client-mapping.json')); print(m['Pro Nutrition'])"`
+Expected: `{'0': 'Purchases', '1': 'Custom 1', '3': 'Custom 2'}` (JSON keys are strings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/export_conv_mapping.py migration/conv-client-mapping.json
+git commit -m "conv/mapping: export Airtable type->new_type to per-client JSON"
+```
+
+---
+
+## Phase 2 — Shape axis: new-tree index + card matcher
+
+### Task 4: Card shape signature + matcher (`conv_lib`)
+
+**Files:**
+- Modify: `scripts/conv_lib.py` (append)
+- Modify: `tests/test_conv_lib.py`
+
+- [ ] **Step 1: Add failing tests**
+
+```python
+def _card(name, display, dims=(), sql="SELECT 1"):
+    return {"name": name, "display": display,
+            "visualization_settings": {"graph.dimensions": list(dims)},
+            "dataset_query": {"type": "native", "native": {"query": sql}}}
+
+def test_metric_kind():
+    assert conv_lib.metric_kind("Conversions 1") == "COUNT"
+    assert conv_lib.metric_kind("CR (conversions 1)") == "RATE"
+    assert conv_lib.metric_kind("CAC (Custom Conversion 1)") == "CAC"
+    assert conv_lib.metric_kind("ROAS (Custom Conversion 1)") == "ROAS"
+    assert conv_lib.metric_kind("Custom Conversion 1 value") == "VALUE"
+
+def test_card_shape():
+    s = conv_lib.card_shape(_card("Conversions 1 by date, campaign channel", "bar", ["date"]))
+    assert s == ("bar", "COUNT", ("channel", "date"))
+
+def test_resolve_new_card_picks_single_shape_match():
+    old = _card("Conversions 1", "smartscalar", sql="SELECT SUM(conversions_1)")
+    new_index = {("CUSTOM_CONVERSIONS_1", ("smartscalar", "COUNT", ())): [42635],
+                 ("PURCHASES", ("smartscalar", "COUNT", ())): [99999]}
+    mapping = {0: "Purchases", 1: "Custom 1"}
+    res = conv_lib.resolve_new_card(old, mapping, new_index)
+    assert res["status"] == "ok" and res["new_card_id"] == 42635 and res["new_type"] == "Custom 1"
+
+def test_resolve_new_card_unmapped_slot():
+    old = _card("Conversions 2", "smartscalar", sql="SELECT SUM(conversions_2)")
+    res = conv_lib.resolve_new_card(old, {2: conv_lib.UNMAPPED}, {})
+    assert res["status"] == "unmapped"
+
+def test_resolve_new_card_no_shape_match_goes_to_review():
+    old = _card("Conversions 1 by URL", "table", ["url"], sql="SELECT SUM(conversions_1)")
+    mapping = {1: "Custom 1"}
+    res = conv_lib.resolve_new_card(old, mapping, {})  # empty index -> no candidate
+    assert res["status"] == "review" and res["reason"]
+```
+
+```python
+# extend TESTS with: test_metric_kind, test_card_shape,
+# test_resolve_new_card_picks_single_shape_match, test_resolve_new_card_unmapped_slot,
+# test_resolve_new_card_no_shape_match_goes_to_review
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python tests/test_conv_lib.py`
+Expected: FAIL — `AttributeError: ... 'metric_kind'`.
+
+- [ ] **Step 3: Implement (append to `conv_lib.py`)**
+
+```python
+# --- Shape axis (display x metric x breakdown) ---
+_BREAKDOWN = [("date", "date"), ("channel", "channel"), ("network", "network"),
+              ("categor", "category"), ("countr", "country"), ("location", "location"),
+              ("device", "device"), ("product", "product"), ("url", "url"), ("type", "type"),
+              ("adset", "adset"), ("adgroup", "adgroup"), ("placement", "placement"),
+              ("segment", "segment"), ("medium", "medium"), ("page", "page")]
+
+def metric_kind(name):
+    n = (name or "").upper()
+    for k in ("ROAS", "CAC", "COS", "CPA", "CPI", "CTR"):
+        if re.search(rf"\b{k}\b", n):
+            return k
+    if re.search(r"\bCR\b", n) or "RATE" in n:
+        return "RATE"
+    if "VALUE" in n:
+        return "VALUE"
+    if "AVG" in n or "AVERAGE" in n:
+        return "AVG"
+    return "COUNT"
+
+def _breakdown(name, viz):
+    found = set()
+    src = (name or "").lower()
+    m = re.search(r"\bby\b(.+)$", src)
+    seg = m.group(1) if m else ""
+    for needle, label in _BREAKDOWN:
+        if needle in seg:
+            found.add(label)
+    for d in (viz or {}).get("graph.dimensions") or []:
+        if isinstance(d, str):
+            dl = d.lower()
+            for needle, label in _BREAKDOWN:
+                if needle in dl:
+                    found.add(label)
+    return tuple(sorted(found))
+
+def card_shape(card):
+    return (card.get("display") or "?", metric_kind(card.get("name")),
+            _breakdown(card.get("name"), card.get("visualization_settings")))
+
+def _old_slot_and_value(card):
+    """(slot, is_value) inferred from the old columns the card sums, or (None, None)."""
+    sql, _ = native_and_tags(card)
+    cols = old_conversion_columns(sql)
+    if not cols:
+        return None, None
+    is_value = any(c.endswith("_VALUE") or c == "CONVERSION_VALUE" for c in cols)
+    slots = set()
+    for c in cols:
+        if c in ("CONVERSIONS", "CONVERSION_VALUE"):
+            slots.add(0)
+        else:
+            mm = re.search(r"(\d+)", c)
+            if mm:
+                slots.add(int(mm.group(1)))
+    return (min(slots) if slots else None, is_value)
+
+def resolve_new_card(old_card, client_mapping, new_index):
+    """Return {status: ok|unmapped|conflict|multi|review|skip, ...}.
+    client_mapping: {slot:int -> new_type|UNMAPPED|CONFLICT}. new_index:
+    {(NEW_COL, shape) -> [card_id]}."""
+    slot, is_value = _old_slot_and_value(old_card)
+    if slot is None:
+        return {"status": "skip", "reason": "no old conversion column"}
+    nt = client_mapping.get(slot)
+    if nt is None:
+        return {"status": "review", "reason": f"slot {slot} absent from client mapping"}
+    if nt in (UNMAPPED, CONFLICT):
+        return {"status": nt.strip("_").lower(), "slot": slot}
+    count_col, value_col = new_type_columns(nt)
+    new_col = value_col if is_value else count_col
+    if not new_col:
+        return {"status": "review", "reason": f"new_type {nt!r} has no {'value' if is_value else 'count'} column"}
+    cands = new_index.get((new_col, card_shape(old_card))) or []
+    if len(cands) == 1:
+        return {"status": "ok", "new_card_id": cands[0], "new_type": nt, "new_col": new_col, "slot": slot}
+    if len(cands) > 1:
+        return {"status": "multi", "candidates": cands, "new_type": nt, "new_col": new_col}
+    return {"status": "review", "reason": f"no new card for {new_col} shape {card_shape(old_card)}",
+            "new_type": nt, "new_col": new_col}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python tests/test_conv_lib.py`
+Expected: `16/16 tests passés`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/conv_lib.py tests/test_conv_lib.py
+git commit -m "conv/lib: card shape signature + new-card resolver (TDD)"
+```
+
+### Task 5: Build the new-tree index from the live instance
+
+**Files:**
+- Create: `scripts/build_new_conv_index.py`
+- Output: `migration/conv-new-index.json`
+
+- [ ] **Step 1: Implement the index builder**
+
+```python
+# scripts/build_new_conv_index.py
+#!/usr/bin/env python3
+"""Indexe l'arbre des nouvelles conversions (collection 11673) :
+{(NEW_COL, [display, metric_kind, breakdown]) -> [card_id]}.
+Usage: python3 scripts/build_new_conv_index.py [--root 11673]"""
+import argparse, json, sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import conv_lib
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def walk_cards(mb, cid, acc):
+    r = mb.get(f"/api/collection/{cid}/items?models=card&models=collection")
+    data = r.get("data") if isinstance(r, dict) else r
+    for it in data or []:
+        if it.get("model") == "collection":
+            walk_cards(mb, it["id"], acc)
+        elif it.get("model") == "card":
+            acc.append(it["id"])
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--root", type=int, default=11673)
+    args = ap.parse_args()
+    mb = connect()
+    ids = []
+    walk_cards(mb, args.root, ids)
+    index = defaultdict(list)
+    for cid in ids:
+        c = mb.get(f"/api/card/{cid}")
+        if not isinstance(c, dict) or c.get("archived"):
+            continue
+        sql, _ = conv_lib.native_and_tags(c)
+        for col in conv_lib.new_conversion_columns(sql):
+            key = json.dumps([col, list(conv_lib.card_shape(c))])
+            index[key].append(cid)
+    out = Path("migration") / "conv-new-index.json"
+    out.write_text(json.dumps(index, ensure_ascii=False, indent=2))
+    multi = sum(1 for v in index.values() if len(v) > 1)
+    print(f"{len(ids)} cards walked -> {len(index)} (col,shape) keys ({multi} ambiguous) -> {out}")
+
+if __name__ == "__main__":
+    main()
+```
+
+> Note: keys are JSON strings `[col, [display, kind, [breakdowns]]]`; the migrator rebuilds the tuple form when looking up. Ambiguous (>1) keys feed the review queue.
+
+- [ ] **Step 2: Run + sanity-check the Custom 1 smartscalar entry**
+
+Run: `.venv/bin/python scripts/build_new_conv_index.py`
+Then verify `["CUSTOM_CONVERSIONS_1", ["smartscalar", "COUNT", []]]` maps to `[42635]`:
+`.venv/bin/python -c "import json; i=json.load(open('migration/conv-new-index.json')); print(i.get('[\"CUSTOM_CONVERSIONS_1\", [\"smartscalar\", \"COUNT\", []]]'))"`
+Expected: `[42635]`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/build_new_conv_index.py migration/conv-new-index.json
+git commit -m "conv/index: build (col,shape)->card index of the new conversions tree"
+```
+
+---
+
+## Phase 3 — Per-dashboard migrator + validation
+
+### Task 6: The migrator CLI (`migrate_conversions_on_dashboard.py`)
+
+**Files:**
+- Create: `scripts/migrate_conversions_on_dashboard.py`
+- Reuse: `scripts/swap_lib.py` (`rewrite_dashcards`, `referenced_template_tags`), `scripts/conv_lib.py`
+
+- [ ] **Step 1: Implement the CLI**
+
+```python
+# scripts/migrate_conversions_on_dashboard.py
+#!/usr/bin/env python3
+"""Migre les tuiles de conversion d'UN dashboard vers le nouveau système.
+Par tuile : détecte la carte ancienne, résout new_type (mapping client) + carte cible
+(index de forme), garde-fous relâchés, snapshot, repointe (swap_lib), recâble les
+column_settings, valide (structurel + lecture de valeur + réconciliation Snowflake).
+NE archive JAMAIS la carte partagée. Réversible (snapshot).
+
+Usage:
+  python3 scripts/migrate_conversions_on_dashboard.py --dashboard 25302 --client "Pro Nutrition"          # dry-run
+  python3 scripts/migrate_conversions_on_dashboard.py --dashboard 25302 --client "Pro Nutrition" --copy   # migre une COPIE
+  python3 scripts/migrate_conversions_on_dashboard.py --dashboard 14118 --client "Pro Nutrition" --yes     # applique in-place + snapshot
+"""
+import argparse, json, sys
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import swap_lib, conv_lib
+
+MIG = REPO / "migration"
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def _dashcards(d):
+    return d.get("dashcards") or d.get("ordered_cards") or []
+
+def load_inputs():
+    mapping = json.loads((MIG / "conv-client-mapping.json").read_text())
+    raw = json.loads((MIG / "conv-new-index.json").read_text())
+    index = {}
+    for k, v in raw.items():
+        col, shape = json.loads(k)
+        index[(col, tuple([shape[0], shape[1], tuple(shape[2])]))] = v
+    return mapping, index
+
+def remap_column_settings(viz, old_col, new_col):
+    """Re-key dashcard column_settings ["name","OLD_COL"] -> NEW_COL so number formatting applies."""
+    cs = (viz or {}).get("column_settings")
+    if not cs:
+        return viz
+    out = dict(viz)
+    new_cs = {}
+    for k, val in cs.items():
+        nk = k.replace(f'"{old_col}"', f'"{new_col}"').replace(f'"{old_col.lower()}"', f'"{new_col.lower()}"')
+        new_cs[nk] = val
+    out["column_settings"] = new_cs
+    return out
+
+def reconcile(mb, client, old_col, new_col, start, end):
+    """Independent SUM of old/new columns over the same join chain (Snowflake via /api/dataset)."""
+    sql = f"""
+WITH base AS (
+  SELECT global.campaign_daily_metrics.{old_col} AS old_c,
+         global.campaign_daily_metrics.{new_col} AS new_c
+  FROM utils.clients
+    JOIN utils.client_ad_platforms ON client_id = utils.clients.id
+    JOIN reports.campaign_details ON reports.campaign_details.account_id = utils.client_ad_platforms.account_id
+    JOIN global.campaign_daily_metrics ON global.campaign_daily_metrics.campaign_id = reports.campaign_details.campaign_id
+  WHERE utils.clients.name = '{client}'
+    AND global.campaign_daily_metrics.date BETWEEN '{start}' AND '{end}')
+SELECT COALESCE(SUM(old_c),0), COALESCE(SUM(new_c),0) FROM base""".strip()
+    ds = mb.post("/api/dataset", json={"database": 144, "type": "native", "native": {"query": sql}}, timeout=180)
+    rows = ds.get("data", {}).get("rows") if isinstance(ds, dict) else None
+    return (rows[0][0], rows[0][1]) if rows else (None, None)
+
+def tile_value(mb, dash_id, dc_id, card_id, client, date_range):
+    d = mb.get(f"/api/dashboard/{dash_id}")
+    dc = next((x for x in _dashcards(d) if x.get("id") == dc_id), {})
+    params = []
+    for pm in dc.get("parameter_mappings") or []:
+        p = next((q for q in d.get("parameters") or [] if q.get("id") == pm.get("parameter_id")), {})
+        val = [client] if p.get("slug") == "client" else (date_range if p.get("slug") == "date" else None)
+        if val is not None:
+            params.append({"id": p["id"], "type": p.get("type"), "value": val, "target": pm.get("target")})
+    r = mb.post(f"/api/dashboard/{dash_id}/dashcard/{dc_id}/card/{card_id}/query", json={"parameters": params}, timeout=120)
+    try:
+        return r["data"]["rows"][-1][-1]
+    except Exception:
+        return None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--copy", action="store_true", help="migrer une copie (test) au lieu de l'original")
+    ap.add_argument("--yes", action="store_true", help="appliquer (sinon dry-run)")
+    ap.add_argument("--window", default="2026-05-01~2026-05-31", help="fenêtre de validation date/all-options")
+    args = ap.parse_args()
+    mb = connect()
+    mapping_all, index = load_inputs()
+    cmap = {int(k): v for k, v in mapping_all.get(args.client, {}).items()}
+    if not cmap:
+        sys.exit(f"Aucun mapping pour client {args.client!r} (conv-client-mapping.json).")
+
+    src = args.dashboard
+    if args.copy and args.yes:
+        cp = mb.post(f"/api/dashboard/{src}/copy", json={"collection_id": None, "name": f"MIGRATION TEST {src}", "is_deep_copy": False})
+        src = cp["id"]
+        print(f"copie -> dashboard {src}")
+    dash = mb.get(f"/api/dashboard/{src}")
+    dcs = _dashcards(dash)
+
+    plan, report = [], {"dashboard": src, "client": args.client, "tiles": []}
+    for dc in dcs:
+        cid = dc.get("card_id")
+        if not cid:
+            continue
+        card = mb.get(f"/api/card/{cid}")
+        sql, _ = conv_lib.native_and_tags(card)
+        if not conv_lib.old_conversion_columns(sql):
+            continue
+        res = conv_lib.resolve_new_card(card, cmap, index)
+        entry = {"dashcard_id": dc["id"], "old_card": cid, "old_name": card.get("name"), **res}
+        if res["status"] == "ok":
+            new = mb.get(f"/api/card/{res['new_card_id']}")
+            ref = swap_lib.referenced_template_tags(dcs, cid)
+            _, ntags = conv_lib.native_and_tags(new)
+            problems = []
+            if new.get("archived"): problems.append("new archived")
+            if card.get("database_id") != new.get("database_id"): problems.append("different DB")
+            miss = ref - set(ntags)
+            if miss: problems.append(f"new misses tags {sorted(miss)}")
+            entry["safety"] = problems
+            if problems:
+                entry["status"] = "blocked"
+            else:
+                oc = res["old_col"]  # resolver supplies old+new cols for reconciliation
+                entry["old_col"] = oc
+                plan.append((dc, card, new, res, oc))
+        report["tiles"].append(entry)
+
+    print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+    if not args.yes or not plan:
+        print("\n(DRY-RUN ou rien à faire — aucune modification.)")
+        return
+
+    MIG.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    snap = MIG / f"conv-migrate-snapshot-{src}-{ts}.json"
+    snap.write_text(json.dumps({"dashboard": src, "dashcards": dcs}, ensure_ascii=False, indent=2))
+    print(f"snapshot: {snap}")
+
+    new_dcs = dcs
+    for dc, card, new, res, oc in plan:
+        new_dcs, _ = swap_lib.rewrite_dashcards(new_dcs, card["id"], res["new_card_id"])
+        for ndc in new_dcs:
+            if ndc.get("id") == dc["id"]:
+                ndc["visualization_settings"] = remap_column_settings(ndc.get("visualization_settings") or {}, oc, res["new_col"])
+    rc = mb.put(f"/api/dashboard/{src}", json={"dashcards": new_dcs})
+    print(f"PUT dashboard {src}: {rc}")
+
+    start, end = args.window.split("~")
+    for dc, card, new, res, oc in plan:
+        nv = tile_value(mb, src, dc["id"], res["new_card_id"], args.client, args.window)
+        o_sum, n_sum = reconcile(mb, args.client, oc, res["new_col"], start, end)
+        ok = (nv is not None and n_sum is not None and abs(float(nv) - float(n_sum)) < 1e-6)
+        print(f"  tile {dc['id']} {card['name']!r} -> #{res['new_card_id']}: tile={nv} snowflake_new={n_sum} reconciled={ok} (old_sum={o_sum})")
+    print(f"\nRollback: restaurer dashcards depuis {snap}.")
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Dry-run against the existing sandbox copy (25302)**
+
+Run: `.venv/bin/python scripts/migrate_conversions_on_dashboard.py --dashboard 25302 --client "Pro Nutrition"`
+Expected: report lists the conversion tile resolving `status: ok` to `new_card_id: 42635`, `new_type: Custom 1`, empty `safety`. No mutation.
+
+- [ ] **Step 3: Apply on a FRESH copy (Custom 1 case, value unchanged)**
+
+Run: `.venv/bin/python scripts/migrate_conversions_on_dashboard.py --dashboard 14118 --client "Pro Nutrition" --copy --yes`
+Expected: PUT 200; tile reconciled `True` (`tile == snowflake_new`), matching the spike's `646.225741`.
+
+- [ ] **Step 4: Validate the value-CHANGING case (Main conversion → Purchases)**
+
+Find a Pro Nutrition dashboard tile backed by base `conversions` (slot 0). Dry-run the migrator on a copy and confirm it resolves to a `PURCHASES` card; apply on the copy; confirm `reconciled True` with `tile == snowflake_new` and `old_sum != new_sum` (the number genuinely changes). Record both values in the report.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/migrate_conversions_on_dashboard.py
+git commit -m "conv/migrate: per-dashboard migrator (mapping+shape resolve, relaxed safety, snapshot, Snowflake reconcile)"
+```
+
+---
+
+## Phase 4 — Target discovery
+
+### Task 7: Discover custom dashboards + conversion tiles under 317
+
+**Files:**
+- Create: `scripts/discover_conversion_targets.py`
+- Output: `migration/conv-targets-<ts>.json`
+
+- [ ] **Step 1: Implement the crawler**
+
+```python
+# scripts/discover_conversion_targets.py
+#!/usr/bin/env python3
+"""Liste les dashboards custom sous 317 et leurs tuiles de conversion (ancien système).
+Sortie: migration/conv-targets-<ts>.json = [{client, collection_id, dashboard_id, dashboard_name,
+is_template_like, tiles:[{dashcard_id, card_id, card_name, old_cols}]}].
+Usage: python3 scripts/discover_conversion_targets.py [--root 317]"""
+import argparse, json, re, sys
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import conv_lib
+
+TEMPLATE_RX = re.compile(r"template|\bspec\b|master", re.I)
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def items(mb, cid):
+    r = mb.get(f"/api/collection/{cid}/items")
+    return (r.get("data") if isinstance(r, dict) else r) or []
+
+def dashboards_under(mb, cid, acc):
+    for it in items(mb, cid):
+        if it.get("model") == "collection":
+            dashboards_under(mb, it["id"], acc)
+        elif it.get("model") == "dashboard":
+            acc.append((cid, it["id"], it.get("name")))
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--root", type=int, default=317)
+    args = ap.parse_args()
+    mb = connect()
+    clients = [(c["id"], c["name"]) for c in items(mb, args.root) if c.get("model") == "collection"]
+    card_cache, out = {}, []
+    for coll_id, client in clients:
+        dl = []
+        dashboards_under(mb, coll_id, dl)
+        for _src, did, dname in dl:
+            full = mb.get(f"/api/dashboard/{did}")
+            tiles = []
+            for dc in (full.get("dashcards") or full.get("ordered_cards") or []):
+                cid = dc.get("card_id")
+                if not cid:
+                    continue
+                if cid not in card_cache:
+                    card_cache[cid] = mb.get(f"/api/card/{cid}")
+                sql, _ = conv_lib.native_and_tags(card_cache[cid] or {})
+                oc = conv_lib.old_conversion_columns(sql)
+                if oc:
+                    tiles.append({"dashcard_id": dc["id"], "card_id": cid,
+                                  "card_name": (card_cache[cid] or {}).get("name"), "old_cols": sorted(oc)})
+            if tiles:
+                out.append({"client": client, "collection_id": coll_id, "dashboard_id": did,
+                            "dashboard_name": dname, "is_template_like": bool(TEMPLATE_RX.search(dname or "")),
+                            "tiles": tiles})
+    p = REPO / "migration" / f"conv-targets-{datetime.now():%Y%m%d-%H%M%S}.json"
+    p.write_text(json.dumps(out, ensure_ascii=False, indent=2))
+    print(f"{len(clients)} clients | {len(out)} dashboards w/ conversion tiles | "
+          f"{sum(len(d['tiles']) for d in out)} tiles | template-like: {sum(d['is_template_like'] for d in out)} -> {p}")
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run + sanity-check Pro Nutrition appears**
+
+Run: `.venv/bin/python scripts/discover_conversion_targets.py`
+Expected: prints totals; the output JSON contains a Pro Nutrition entry with dashboard 14118 listing the `Conversions 1` tile (`old_cols: ["CONVERSIONS_1"]`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/discover_conversion_targets.py
+git commit -m "conv/discover: crawl custom dashboards under 317 for old-conversion tiles"
+```
+
+---
+
+## Phase 5 — Wave orchestration, tracker, agent rollout
+
+### Task 8: Pre-flight resolver report (what auto-applies vs review)
+
+**Files:**
+- Create: `scripts/conv_preflight.py`
+- Output: `migration/conv-preflight-<ts>.{json,csv}`
+
+- [ ] **Step 1: Implement preflight (resolve every target tile, no mutation)**
+
+```python
+# scripts/conv_preflight.py
+#!/usr/bin/env python3
+"""Pour chaque tuile cible, résout new_type+carte sans rien modifier; classe en
+ok / unmapped / conflict / multi / review. Produit la file de revue.
+Usage: python3 scripts/conv_preflight.py migration/conv-targets-<ts>.json"""
+import csv, json, sys
+from collections import Counter
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import conv_lib
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def main():
+    mb = connect()
+    targets = json.loads(Path(sys.argv[1]).read_text())
+    mapping_all = json.loads((REPO / "migration" / "conv-client-mapping.json").read_text())
+    raw = json.loads((REPO / "migration" / "conv-new-index.json").read_text())
+    index = {}
+    for k, v in raw.items():
+        col, shape = json.loads(k)
+        index[(col, tuple([shape[0], shape[1], tuple(shape[2])]))] = v
+    rows, counts = [], Counter()
+    for d in targets:
+        cmap = {int(k): v for k, v in mapping_all.get(d["client"], {}).items()}
+        for t in d["tiles"]:
+            card = mb.get(f"/api/card/{t['card_id']}")
+            res = conv_lib.resolve_new_card(card, cmap, index) if cmap else {"status": "review", "reason": "client not in mapping"}
+            counts[res["status"]] += 1
+            rows.append({"client": d["client"], "dashboard_id": d["dashboard_id"], "dashcard_id": t["dashcard_id"],
+                         "old_card": t["card_id"], "old_name": t["card_name"], "status": res["status"],
+                         "new_card": res.get("new_card_id"), "new_type": res.get("new_type"), "reason": res.get("reason")})
+    base = REPO / "migration"
+    (base / "conv-preflight.json").write_text(json.dumps(rows, ensure_ascii=False, indent=2))
+    with open(base / "conv-preflight.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys())); w.writeheader(); w.writerows(rows)
+    print("status counts:", dict(counts))
+    print("-> migration/conv-preflight.json / .csv")
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run and read the status distribution**
+
+Run: `.venv/bin/python scripts/conv_preflight.py migration/conv-targets-<ts>.json`
+Expected: a `status counts` dict; `ok` should dominate (~the 77% measured), the rest split across `review/multi/unmapped/conflict`. The CSV is the human review queue.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/conv_preflight.py migration/conv-preflight.json migration/conv-preflight.csv
+git commit -m "conv/preflight: resolve every target tile, emit auto vs review queue"
+```
+
+### Task 9: Wave runner + living tracker
+
+**Files:**
+- Create: `scripts/migrate_conversions_wave.py`
+- Create: `docs/conversion-migration-roadmap.md` (tracker, mirrors `cleaning-roadmap.md`)
+- Output: `migration/conv-wave-report-<ts>.json`
+
+- [ ] **Step 1: Implement the wave runner (one dashboard at a time, copy or in-place)**
+
+```python
+# scripts/migrate_conversions_wave.py
+#!/usr/bin/env python3
+"""Exécute le migrateur sur une liste de dashboards (une vague). Par défaut --copy
+(sandbox) ; --in-place --yes pour appliquer pour de vrai. Agrège un rapport + met à
+jour le tracker. Réversible (chaque dashboard a son snapshot).
+Usage:
+  python3 scripts/migrate_conversions_wave.py --targets migration/conv-targets-<ts>.json --clients "Pro Nutrition" --copy --yes
+  python3 scripts/migrate_conversions_wave.py --targets ... --clients "Pro Nutrition" --in-place --yes
+"""
+import argparse, json, subprocess, sys
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--targets", required=True)
+    ap.add_argument("--clients", nargs="*", help="restreindre à ces clients (défaut: tous)")
+    ap.add_argument("--copy", action="store_true")
+    ap.add_argument("--in-place", action="store_true")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    targets = json.loads(Path(args.targets).read_text())
+    sel = [d for d in targets if (not args.clients or d["client"] in args.clients) and not d["is_template_like"]]
+    report = []
+    for d in sel:
+        cmd = [str(REPO / ".venv/bin/python"), str(REPO / "scripts/migrate_conversions_on_dashboard.py"),
+               "--dashboard", str(d["dashboard_id"]), "--client", d["client"]]
+        if args.copy: cmd.append("--copy")
+        if args.yes: cmd.append("--yes")
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        report.append({"client": d["client"], "dashboard_id": d["dashboard_id"],
+                       "rc": r.returncode, "stdout_tail": r.stdout[-2000:], "stderr_tail": r.stderr[-500:]})
+        print(f"[{ 'OK' if r.returncode==0 else 'ERR' }] {d['client']} / {d['dashboard_id']}")
+    p = REPO / "migration" / f"conv-wave-report-{datetime.now():%Y%m%d-%H%M%S}.json"
+    p.write_text(json.dumps(report, ensure_ascii=False, indent=2))
+    print(f"-> {p}")
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Create the tracker doc**
+
+```markdown
+# Conversion Migration — Roadmap (tracker vivant)
+
+> Migration ancien positionnel -> nouveau nommé sur les dashboards custom (collection 317).
+> Design: docs/superpowers/specs/2026-06-03-conversion-migration-design.md. Réversible (snapshots).
+> Légende : ✅ fait · 🚧 en cours · ⬜ à faire
+
+## Outillage (testé)
+- `conv_lib.py` (+ `tests/test_conv_lib.py`) — colonnes, extracteur tolérant, mapping client, résolveur.
+- `export_conv_mapping.py` · `build_new_conv_index.py` · `discover_conversion_targets.py` · `conv_preflight.py`.
+- `migrate_conversions_on_dashboard.py` (snapshot, garde-fous, recâblage, réconciliation Snowflake).
+- `migrate_conversions_wave.py` — runner par vague.
+
+## Inputs (régénérables)
+- `migration/conv-client-mapping.json` — mapping Airtable (date d'export : __).
+- `migration/conv-new-index.json` — index arbre 11673 (date : __).
+- `migration/conv-targets-<ts>.json` — dashboards cibles.
+- `migration/conv-preflight.csv` — file de revue (statuts non-`ok`).
+
+## Vagues
+| # | Périmètre | Statut | Auto | Revue | Note |
+|---|-----------|--------|------|-------|------|
+| 0 | Pro Nutrition (pilote, copies) | ⬜ | | | valider ok + Main→Purchases |
+| 1 | Pro Nutrition (in-place) | ⬜ | | | après revue vague 0 |
+| 2 | 5 clients échantillon | ⬜ | | | |
+| 3 | Reste (~104 clients) | ⬜ | | | par lots |
+
+## Garde-fous
+Snapshot → réconciliation Snowflake par tuile → échantillon → batch. Jamais d'archivage de
+template partagé. Tuiles non-`ok` (review/conflict/unmapped/multi) : NON appliquées, file de revue.
+```
+
+- [ ] **Step 3: Pilot wave 0 on Pro Nutrition copies**
+
+Run: `.venv/bin/python scripts/migrate_conversions_wave.py --targets migration/conv-targets-<ts>.json --clients "Pro Nutrition" --copy --yes`
+Expected: each Pro Nutrition dashboard migrated on a copy, `rc 0`, reconciliations `True`. Inspect copies in Metabase, fill the tracker's wave-0 row.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/migrate_conversions_wave.py docs/conversion-migration-roadmap.md
+git commit -m "conv/wave: wave runner + living migration tracker; pilot wave 0 (Pro Nutrition copies)"
+```
+
+### Task 10: Agent-parallel rollout (optional scale-out)
+
+> For >100 dashboards, parallelize wave execution. Each unit is independent (distinct dashboard, own snapshot), so it fans out cleanly. Use the Workflow tool: one agent per dashboard runs `migrate_conversions_on_dashboard.py --in-place --yes`, returns its reconciliation verdict; a final stage aggregates failures into the review queue and updates the tracker. Gate each wave on the prior wave's reconciliations being green. Apply in-place only after the copy-based pilot for that client passed.
+
+- [ ] **Step 1:** After wave-0 (copies) is signed off, run wave-1 in-place for Pro Nutrition; verify each tile reconciles and the live dashboards render; update tracker.
+- [ ] **Step 2:** Run a 5-client sample wave (copies → review → in-place). Triage the preflight review queue; map exotic shapes by hand into `migration/conv-new-index.json` overrides or skip.
+- [ ] **Step 3:** Batch the remaining clients in waves of ~10, each gated on green reconciliation; keep the tracker current; never archive shared templates.
+- [ ] **Step 4: Cleanup** — delete the spike sandbox (collection 13851, dashboard 25302) and any `MIGRATION TEST` copies once their client is migrated in-place.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** tool design (§5)→Tasks 1–6; validation incl. Snowflake reconcile (§6)→Task 6 steps 2–4; sizing/coverage (§7)→Tasks 7–8; type-axis ingestion (§2,§9)→Tasks 2–3; scaling/agents/tracker (§8)→Tasks 9–10; custom-dashboard discovery (§9 open)→Task 7.
+- **Format-tolerant extractor** (mandatory per spike) is Task 1 and used everywhere downstream.
+- **Never-archive / per-dashcard / snapshot** invariants encoded in Task 6.
+- **Review queue** (unmapped/conflict/multi/review) never auto-applies (Tasks 6, 8, 10).

--- a/docs/superpowers/plans/2026-06-20-pre-apply-validation-layer.md
+++ b/docs/superpowers/plans/2026-06-20-pre-apply-validation-layer.md
@@ -1,0 +1,879 @@
+# Pre-apply Validation Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reusable, execution-based validation layer (`spark_metabase_api/validate.py`) that gates Metabase content changes — structure, refs, execution, and before/after differential — consumed by `iac.apply()`, campaign libs, and a `spark-metabase validate` CLI.
+
+**Architecture:** A single module exposes a `CardUnit` normalization, four pure-ish check functions ordered cheap→expensive, a `Report`/`Finding` model that renders like `iac.Plan`, and a `guarded_apply` orchestrator that captures a baseline, runs the pre-apply gate (aborting on error), mutates, then diffs. Execution runs the real query via `POST /api/dataset` (unsaved) or `get_card_data` (saved) — Metabase is the source of truth.
+
+**Tech Stack:** Python 3, the existing `Metabase_API` wrapper (`client.get/post/put`, `get_card_data`), `iac.CollectionSpec`, pytest.
+
+## Global Constraints
+
+- Implements Phase 1 of `docs/superpowers/specs/2026-06-20-metabase-pre-apply-validation-design.md`. Phase 0 (`2026-06-20-repo-menage-leger.md`) lands first.
+- **Execution is the source of truth** — no static-only mode is authoritative; `--no-execute` is only a smoke fallback.
+- Non-goals: no chatbot wiring, no Enterprise JAR, no metadata cache.
+- REST helper contract: `client.post(ep, "raw", json=body)` returns a `requests.Response`; `client.post(ep, json=body)` returns parsed JSON or `False`; `client.get(ep)` returns JSON or `False`. `client.get_card_data(card_id=ID, data_format="json")` returns a list of row dicts.
+- Differential metric = auto (row count + column set + per-numeric-column sums), tolerance default 0.0, with optional per-card override.
+- Findings are collected into a `Report`, never raised mid-batch.
+- Commit messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Report + Finding data model
+
+**Files:**
+- Create: `spark_metabase_api/validate.py`
+- Test: `tests/test_validate.py`
+
+**Interfaces:**
+- Produces:
+  - `Finding(target: str, check: str, level: str, message: str, before=None, after=None)` — `level` ∈ {"error","warn","ok"}.
+  - `Report` with `.add(f)`, `.findings: list`, `.errors() -> list`, `.ok() -> bool`, `.summary() -> str`, `.render() -> str`, `.exit_code() -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_validate.py
+from spark_metabase_api import validate as V
+
+def test_report_collects_and_renders():
+    r = V.Report()
+    r.add(V.Finding("c/A", "structure", "ok", "well-formed"))
+    r.add(V.Finding("c/B", "execution", "error", "query failed: boom"))
+    assert [f.level for f in r.findings] == ["ok", "error"]
+    assert r.ok() is False
+    assert len(r.errors()) == 1
+    assert r.exit_code() == 1
+    out = r.render()
+    assert "c/B" in out and "query failed" in out
+    assert "1 error" in r.summary()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py::test_report_collects_and_renders -v`
+Expected: FAIL (`ModuleNotFoundError` / `AttributeError`).
+
+- [ ] **Step 3: Implement the model**
+
+```python
+# spark_metabase_api/validate.py
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+@dataclass
+class Finding:
+    target: str
+    check: str
+    level: str  # "error" | "warn" | "ok"
+    message: str
+    before: Any = None
+    after: Any = None
+
+@dataclass
+class Report:
+    findings: List[Finding] = field(default_factory=list)
+
+    def add(self, f: Finding) -> None:
+        self.findings.append(f)
+
+    def errors(self) -> List[Finding]:
+        return [f for f in self.findings if f.level == "error"]
+
+    def ok(self) -> bool:
+        return not self.errors()
+
+    def summary(self) -> str:
+        counts: Dict[str, int] = {}
+        for f in self.findings:
+            counts[f.level] = counts.get(f.level, 0) + 1
+        parts = ["{} {}".format(v, k) for k, v in sorted(counts.items())]
+        return ", ".join(parts) or "no findings"
+
+    def render(self) -> str:
+        glyph = {"error": "✗", "warn": "!", "ok": "✓"}
+        lines = ["  {}  {:<12} {}  [{}]".format(
+            glyph.get(f.level, "?"), f.check, f.target, f.message)
+            for f in self.findings]
+        return "\n".join(lines) + ("\n" if lines else "") + "Report: " + self.summary()
+
+    def exit_code(self) -> int:
+        return 1 if self.errors() else 0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py::test_report_collects_and_renders -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): Report + Finding model with render/exit_code
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: CardUnit + target builders
+
+**Files:**
+- Modify: `spark_metabase_api/validate.py`
+- Test: `tests/test_validate.py`
+
+**Interfaces:**
+- Consumes: `iac.CollectionSpec` / `iac.CardSpec` (have `.name`, `.cards`, `.collections`, `.definition`).
+- Produces:
+  - `CardUnit(target, dataset_query, display=None, visualization_settings=None, live_card_id=None, expected_columns=None, metric_override=None)`.
+  - `units_from_spec(spec) -> List[CardUnit]`
+  - `unit_from_payload(target, payload: dict) -> CardUnit`
+  - `unit_from_card_id(client, card_id: int) -> CardUnit` (sets `live_card_id`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_units_from_spec_and_payload():
+    from spark_metabase_api import iac
+    spec = iac.spec_from_dict({
+        "name": "Acme",
+        "cards": [{"name": "Rev", "definition": {
+            "dataset_query": {"database": 2, "type": "native",
+                              "native": {"query": "SELECT 1"}},
+            "display": "table"}}],
+    })
+    units = V.units_from_spec(spec)
+    assert len(units) == 1
+    assert units[0].target == "Acme/Rev"
+    assert units[0].dataset_query["database"] == 2
+    assert units[0].live_card_id is None
+
+    u = V.unit_from_payload("c/X", {"dataset_query": {"database": 1, "type": "query",
+                                                      "query": {"source-table": 5}}})
+    assert u.dataset_query["type"] == "query"
+
+class FakeClient:
+    def __init__(self, cards): self._cards = cards
+    def get(self, ep, *a, **k):
+        cid = int(ep.rstrip("/").split("/")[-1])
+        return self._cards.get(cid, False)
+
+def test_unit_from_card_id():
+    client = FakeClient({7: {"dataset_query": {"database": 1, "type": "native",
+                                               "native": {"query": "SELECT 1"}},
+                             "display": "scalar"}})
+    u = V.unit_from_card_id(client, 7)
+    assert u.live_card_id == 7 and u.dataset_query["database"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k units -v`
+Expected: FAIL (`AttributeError: CardUnit`).
+
+- [ ] **Step 3: Implement**
+
+```python
+@dataclass
+class CardUnit:
+    target: str
+    dataset_query: Dict[str, Any] = field(default_factory=dict)
+    display: Optional[str] = None
+    visualization_settings: Optional[Dict[str, Any]] = None
+    live_card_id: Optional[int] = None
+    expected_columns: Optional[List[str]] = None
+    metric_override: Optional[Dict[str, Any]] = None
+
+def units_from_spec(spec) -> List["CardUnit"]:
+    units: List[CardUnit] = []
+    def walk(coll, path):
+        for card in coll.cards:
+            defn = card.definition or {}
+            units.append(CardUnit(
+                target=path + "/" + card.name,
+                dataset_query=defn.get("dataset_query") or {},
+                display=defn.get("display"),
+                visualization_settings=defn.get("visualization_settings"),
+            ))
+        for sub in coll.collections:
+            walk(sub, path + "/" + sub.name)
+    walk(spec, spec.name)
+    return units
+
+def unit_from_payload(target: str, payload: Dict[str, Any]) -> "CardUnit":
+    return CardUnit(
+        target=target,
+        dataset_query=payload.get("dataset_query") or {},
+        display=payload.get("display"),
+        visualization_settings=payload.get("visualization_settings"),
+    )
+
+def unit_from_card_id(client, card_id: int) -> "CardUnit":
+    card = client.get("/api/card/{}".format(card_id))
+    if not card:
+        raise ValueError("card {} not found".format(card_id))
+    return CardUnit(
+        target="card#{}".format(card_id),
+        dataset_query=card.get("dataset_query") or {},
+        display=card.get("display"),
+        visualization_settings=card.get("visualization_settings"),
+        live_card_id=card_id,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k units -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): CardUnit + target builders (spec/payload/live)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: check_structure
+
+**Files:** Modify `spark_metabase_api/validate.py`; Test `tests/test_validate.py`.
+
+**Interfaces:**
+- Produces: `check_structure(unit: CardUnit) -> Finding` (level "error" or "ok", check="structure").
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_check_structure():
+    ok = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "SELECT 1"}})
+    assert V.check_structure(ok).level == "ok"
+    no_db = V.CardUnit("c/B", {"type": "native", "native": {"query": "SELECT 1"}})
+    assert V.check_structure(no_db).level == "error"
+    empty = V.CardUnit("c/C", {"database": 1, "type": "native", "native": {"query": ""}})
+    assert V.check_structure(empty).level == "error"
+    bad_type = V.CardUnit("c/D", {"database": 1, "type": "weird"})
+    assert V.check_structure(bad_type).level == "error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k structure -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+def check_structure(unit: "CardUnit") -> Finding:
+    dq = unit.dataset_query
+    if not isinstance(dq, dict) or "database" not in dq:
+        return Finding(unit.target, "structure", "error", "dataset_query missing 'database'")
+    qtype = dq.get("type")
+    if qtype == "native":
+        if not (dq.get("native") or {}).get("query"):
+            return Finding(unit.target, "structure", "error", "native query is empty")
+    elif qtype == "query":
+        if not dq.get("query"):
+            return Finding(unit.target, "structure", "error", "MBQL query is empty")
+    else:
+        return Finding(unit.target, "structure", "error", "unknown query type {!r}".format(qtype))
+    return Finding(unit.target, "structure", "ok", "well-formed")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k structure -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): check_structure (well-formed payload)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: check_refs
+
+**Files:** Modify `spark_metabase_api/validate.py`; Test `tests/test_validate.py`.
+
+**Interfaces:**
+- Produces: `check_refs(client, unit: CardUnit) -> List[Finding]`. Verifies MBQL `source-table: "card__N"` and native field-filter `values_source_config.card_id` resolve to a live, non-archived card via `client.get("/api/card/N")`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_check_refs():
+    client = FakeClient({9: {"archived": False}})  # card 9 exists; 99 does not
+    src_ok = V.CardUnit("c/A", {"database": 1, "type": "query",
+                                "query": {"source-table": "card__9"}})
+    assert all(f.level != "error" for f in V.check_refs(client, src_ok))
+    src_bad = V.CardUnit("c/B", {"database": 1, "type": "query",
+                                 "query": {"source-table": "card__99"}})
+    assert any(f.level == "error" for f in V.check_refs(client, src_bad))
+    ff_bad = V.CardUnit("c/C", {"database": 1, "type": "native", "native": {
+        "query": "SELECT 1", "template-tags": {
+            "x": {"values_source_config": {"card_id": 99}}}}})
+    assert any(f.level == "error" for f in V.check_refs(client, ff_bad))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k refs -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _card_exists(client, card_id: int) -> bool:
+    card = client.get("/api/card/{}".format(card_id))
+    return bool(card) and not card.get("archived")
+
+def check_refs(client, unit: "CardUnit") -> List[Finding]:
+    findings: List[Finding] = []
+    dq = unit.dataset_query
+    if dq.get("type") == "query":
+        src = (dq.get("query") or {}).get("source-table")
+        if isinstance(src, str) and src.startswith("card__"):
+            cid = int(src.split("__")[1])
+            if not _card_exists(client, cid):
+                findings.append(Finding(unit.target, "refs", "error",
+                    "source card {} not found / archived".format(cid)))
+    for tag in ((dq.get("native") or {}).get("template-tags") or {}).values():
+        cid = (tag.get("values_source_config") or {}).get("card_id")
+        if cid and not _card_exists(client, cid):
+            findings.append(Finding(unit.target, "refs", "error",
+                "field-filter source card {} not found / archived".format(cid)))
+    if not findings:
+        findings.append(Finding(unit.target, "refs", "ok", "refs resolve"))
+    return findings
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k refs -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): check_refs (source-card + field-filter cards resolve)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: run_query wrapper + check_execution
+
+**Files:**
+- Modify: `spark_metabase_api/main_methods.py` (add `run_query` method).
+- Modify: `spark_metabase_api/validate.py` (add `_execute_unit`, `check_execution`).
+- Test: `tests/test_validate.py`.
+
+**Interfaces:**
+- Produces:
+  - `Metabase_API.run_query(self, dataset_query: dict, parameters: list = None) -> dict` — POST `/api/dataset`, returns decoded JSON (`{"data": {"rows", "cols"}, "status", "error"?}`).
+  - `_execute_unit(client, unit) -> (rows: List[dict], error: Optional[str])` — uses `get_card_data` for saved cards, `run_query` otherwise.
+  - `check_execution(client, unit) -> Finding`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class ExecClient:
+    def __init__(self, dataset_result=None, card_rows=None):
+        self._ds = dataset_result; self._rows = card_rows
+    def run_query(self, dq, parameters=None): return self._ds
+    def get_card_data(self, card_id=None, data_format="json"): return self._rows
+
+def test_check_execution():
+    good = ExecClient(dataset_result={"status": "completed",
+        "data": {"cols": [{"name": "n"}], "rows": [[1], [2]]}})
+    u = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "SELECT n"}})
+    f = V.check_execution(good, u)
+    assert f.level == "ok" and "2 rows" in f.message
+
+    failed = ExecClient(dataset_result={"status": "failed", "error": "SQL compilation error"})
+    assert V.check_execution(failed, u).level == "error"
+
+    empty = ExecClient(dataset_result={"status": "completed", "data": {"cols": [], "rows": []}})
+    assert V.check_execution(empty, u).level == "warn"
+
+    saved = ExecClient(card_rows=[{"n": 1}])
+    su = V.CardUnit("card#5", {"database": 1, "type": "native", "native": {"query": "x"}}, live_card_id=5)
+    assert V.check_execution(saved, su).level == "ok"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k execution -v` — Expected: FAIL.
+
+- [ ] **Step 3a: Add `run_query` to the wrapper**
+
+In `spark_metabase_api/main_methods.py`, add a method to the `Metabase_API` class (place near `get_card_data`):
+```python
+    def run_query(self, dataset_query, parameters=None):
+        """Run an ad-hoc dataset_query (POST /api/dataset) and return parsed JSON.
+
+        dataset_query is the shape stored in a card's definition:
+            {"database": <id>, "type": "native"|"query", "native"|"query": {...}}
+        """
+        body = dict(dataset_query)
+        body["parameters"] = parameters or []
+        res = self.post("/api/dataset", "raw", json=body)
+        try:
+            return res.json()
+        except Exception:
+            return {"status": "failed", "error": "non-JSON response ({})".format(
+                getattr(res, "status_code", "?"))}
+```
+
+- [ ] **Step 3b: Add `_execute_unit` + `check_execution` to validate.py**
+
+```python
+def _execute_unit(client, unit: "CardUnit"):
+    """Run the unit's query. Returns (rows: list[dict], error: str|None)."""
+    if unit.live_card_id is not None:
+        try:
+            rows = client.get_card_data(card_id=unit.live_card_id, data_format="json")
+        except Exception as e:
+            return [], str(e)
+        return rows or [], None
+    res = client.run_query(unit.dataset_query)
+    if not isinstance(res, dict) or res.get("status") == "failed" or res.get("error"):
+        err = res.get("error") if isinstance(res, dict) else "HTTP error"
+        return [], err or "query failed"
+    data = res.get("data") or {}
+    cols = [c.get("name") for c in (data.get("cols") or [])]
+    rows = [dict(zip(cols, r)) for r in (data.get("rows") or [])]
+    return rows, None
+
+def check_execution(client, unit: "CardUnit") -> Finding:
+    rows, error = _execute_unit(client, unit)
+    if error:
+        return Finding(unit.target, "execution", "error", "query failed: {}".format(error))
+    if not rows:
+        return Finding(unit.target, "execution", "warn", "query returned 0 rows")
+    if unit.expected_columns:
+        missing = [c for c in unit.expected_columns if c not in rows[0]]
+        if missing:
+            return Finding(unit.target, "execution", "warn",
+                           "missing expected columns: {}".format(missing))
+    return Finding(unit.target, "execution", "ok", "{} rows".format(len(rows)))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k execution -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/main_methods.py spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): run_query wrapper + check_execution (run via /api/dataset)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: check_differential
+
+**Files:** Modify `spark_metabase_api/validate.py`; Test `tests/test_validate.py`.
+
+**Interfaces:**
+- Produces:
+  - `_signature(rows) -> {"row_count": int, "columns": list, "sums": {col: number}}` (a column is numeric only if all non-null values are int/float and not bool).
+  - `check_differential(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]` — `mode="identical"` ⇒ deltas are errors; `mode="monitor"` ⇒ deltas are warns.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_check_differential():
+    before = [{"k": "a", "v": 10}, {"k": "b", "v": 20}]
+    same = [{"k": "a", "v": 10}, {"k": "b", "v": 20}]
+    assert all(f.level == "ok" for f in V.check_differential("t", before, same, mode="identical"))
+
+    dropped = [{"k": "a", "v": 10}]
+    fs = V.check_differential("t", before, dropped, mode="identical")
+    assert any(f.level == "error" and "row count" in f.message for f in fs)
+
+    drift = [{"k": "a", "v": 10}, {"k": "b", "v": 25}]
+    fs = V.check_differential("t", before, drift, mode="monitor")
+    assert any(f.level == "warn" and "sum(v)" in f.message for f in fs)
+    fs2 = V.check_differential("t", before, drift, mode="identical")
+    assert any(f.level == "error" for f in fs2)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k differential -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _signature(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    cols = list(rows[0].keys()) if rows else []
+    sums: Dict[str, float] = {}
+    for c in cols:
+        vals = [r.get(c) for r in rows if r.get(c) is not None]
+        if vals and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in vals):
+            sums[c] = sum(vals)
+    return {"row_count": len(rows), "columns": cols, "sums": sums}
+
+def check_differential(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]:
+    sb, sa = _signature(before), _signature(after)
+    level = "error" if mode == "identical" else "warn"
+    findings: List[Finding] = []
+    if sb["row_count"] != sa["row_count"]:
+        findings.append(Finding(target, "differential", level,
+            "row count {} -> {}".format(sb["row_count"], sa["row_count"]),
+            before=sb["row_count"], after=sa["row_count"]))
+    if set(sb["columns"]) != set(sa["columns"]):
+        findings.append(Finding(target, "differential", level, "columns changed",
+            before=sb["columns"], after=sa["columns"]))
+    for c, bsum in sb["sums"].items():
+        asum = sa["sums"].get(c)
+        if asum is None:
+            continue
+        denom = abs(bsum) or 1.0
+        if abs(asum - bsum) / denom > tolerance:
+            findings.append(Finding(target, "differential", level,
+                "sum({}) {} -> {}".format(c, bsum, asum), before=bsum, after=asum))
+    if not findings:
+        findings.append(Finding(target, "differential", "ok", "no significant change"))
+    return findings
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k differential -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): check_differential (row/column/numeric-sum, identical|monitor)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: gate + guarded_apply orchestration
+
+**Files:** Modify `spark_metabase_api/validate.py`; Test `tests/test_validate.py`.
+
+**Interfaces:**
+- Produces:
+  - `gate(client, units, execute=True) -> Report` — per unit: structure → (if ok) refs → (if no ref error and execute) execution. Fail-fast per unit.
+  - `guarded_apply(client, units, mutate_fn, differential="monitor", force=False, execute=True) -> Report` — capture baselines (units with `live_card_id`), run `gate`; if errors and not `force`, append an aborted finding and return WITHOUT calling `mutate_fn`; else call `mutate_fn()`, then diff each baselined unit.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_gate_and_guarded_apply():
+    # gate: a structurally broken unit short-circuits (no execution attempted)
+    broken = V.CardUnit("c/bad", {"type": "native", "native": {"query": "x"}})
+    g = V.gate(ExecClient(), [broken], execute=True)
+    assert not g.ok() and [f.check for f in g.findings] == ["structure"]
+
+    # guarded_apply: gate errors -> mutate_fn NOT called
+    calls = []
+    rep = V.guarded_apply(ExecClient(), [broken], lambda: calls.append(1),
+                          differential="off", force=False, execute=False)
+    assert calls == [] and not rep.ok()
+
+    # force=True runs mutate_fn despite errors
+    calls2 = []
+    V.guarded_apply(ExecClient(), [broken], lambda: calls2.append(1),
+                    differential="off", force=True, execute=False)
+    assert calls2 == [1]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k guarded -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+def gate(client, units, execute=True) -> Report:
+    report = Report()
+    for u in units:
+        s = check_structure(u)
+        report.add(s)
+        if s.level == "error":
+            continue
+        ref_findings = check_refs(client, u)
+        for f in ref_findings:
+            report.add(f)
+        if any(f.level == "error" for f in ref_findings):
+            continue
+        if execute:
+            report.add(check_execution(client, u))
+    return report
+
+def guarded_apply(client, units, mutate_fn, differential="monitor",
+                  force=False, execute=True) -> Report:
+    report = Report()
+    baselines: Dict[str, List[Dict[str, Any]]] = {}
+    if differential != "off":
+        for u in units:
+            if u.live_card_id is not None:
+                rows, err = _execute_unit(client, u)
+                if not err:
+                    baselines[u.target] = rows
+    g = gate(client, units, execute=execute)
+    report.findings.extend(g.findings)
+    if g.errors() and not force:
+        report.add(Finding("apply", "gate", "error",
+                           "aborted: pre-apply errors, nothing mutated"))
+        return report
+    mutate_fn()
+    if differential != "off":
+        mode = "identical" if differential == "identical" else "monitor"
+        for u in units:
+            if u.target in baselines:
+                after, err = _execute_unit(client, u)
+                if err:
+                    report.add(Finding(u.target, "differential", "error",
+                        "post-apply query failed: {}".format(err)))
+                    continue
+                for f in check_differential(u.target, baselines[u.target], after, mode=mode):
+                    report.add(f)
+    return report
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k guarded -v` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(validate): gate + guarded_apply (baseline -> gate -> mutate -> diff)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Integrate the gate into iac.apply
+
+**Files:**
+- Modify: `spark_metabase_api/iac.py` (`apply` signature + pre-apply gate).
+- Test: `tests/test_validate.py`.
+
+**Interfaces:**
+- Consumes: `validate.units_from_spec`, `validate.gate`.
+- Produces: `iac.apply(client, spec, parent_id=None, dry_run=False, validate=False, force=False)` — when `validate=True`, build units from the spec, run `gate(client, units, execute=True)`; if it has errors and not `force`, raise `ValidationError` (defined in `validate.py`) before any mutation. Returns the `Plan` as before.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_iac_apply_gate_aborts(monkeypatch):
+    from spark_metabase_api import iac, validate as V
+    spec = iac.spec_from_dict({"name": "Acme", "cards": [{"name": "Bad",
+        "definition": {"dataset_query": {"type": "native", "native": {"query": "x"}}}}]})  # no database -> structure error
+
+    called = {"executed": False}
+    monkeypatch.setattr(iac, "_execute_collection",
+                        lambda *a, **k: called.__setitem__("executed", True))
+    monkeypatch.setattr(iac, "plan", lambda *a, **k: iac.Plan())
+
+    try:
+        iac.apply(object(), spec, validate=True)
+        assert False, "expected ValidationError"
+    except V.ValidationError:
+        pass
+    assert called["executed"] is False  # gate aborted before mutation
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k iac_apply_gate -v` — Expected: FAIL (`TypeError: unexpected kwarg 'validate'`).
+
+- [ ] **Step 3: Implement**
+
+Add to `validate.py`:
+```python
+class ValidationError(Exception):
+    def __init__(self, report: "Report"):
+        self.report = report
+        super().__init__("validation failed:\n" + report.render())
+```
+
+Modify `iac.apply` in `iac.py`:
+```python
+def apply(client, spec: CollectionSpec, parent_id: Optional[int] = None,
+          dry_run: bool = False, validate: bool = False, force: bool = False) -> Plan:
+    p = plan(client, spec, parent_id=parent_id)
+    if dry_run:
+        return p
+    if validate:
+        from . import validate as _v
+        report = _v.gate(client, _v.units_from_spec(spec), execute=True)
+        if not report.ok() and not force:
+            raise _v.ValidationError(report)
+    by_path = {a.path: a for a in p.actions}
+    _execute_collection(client, spec, parent_id, parent_path="", by_path=by_path)
+    return p
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k iac_apply_gate -v` — Expected: PASS. Then run the full suite: `python -m pytest -q` — Expected: PASS (no regression in existing iac tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spark_metabase_api/iac.py spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(iac): apply(validate=True) runs the pre-apply gate, aborts on error
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: CLI `spark-metabase validate` subcommand
+
+**Files:**
+- Modify: `spark_metabase_api/iac.py` (`main` — add `validate` subparser + `resolve_cli_target`).
+- Test: `tests/test_validate.py`.
+
+**Interfaces:**
+- Consumes: `validate.units_from_spec`, `validate.unit_from_card_id`, `validate.gate`, `iac.load`, `iac.export`.
+- Produces:
+  - `validate.resolve_cli_target(client, target: str) -> List[CardUnit]` — a `.yaml/.yml/.json` path → `units_from_spec(load(path))`; an all-digit string → `[unit_from_card_id(client, int)]`; else a collection id/name → `units_from_spec(export(client, target))`.
+  - CLI: `spark-metabase validate <target> [--no-execute] [--differential identical|monitor|off]` printing `report.render()` and returning `report.exit_code()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_resolve_cli_target_spec(tmp_path):
+    from spark_metabase_api import iac, validate as V
+    spec_file = tmp_path / "s.json"
+    iac.dump(iac.spec_from_dict({"name": "Acme", "cards": [{"name": "R",
+        "definition": {"dataset_query": {"database": 1, "type": "native",
+                                         "native": {"query": "SELECT 1"}}}}]}), str(spec_file))
+    units = V.resolve_cli_target(object(), str(spec_file))
+    assert len(units) == 1 and units[0].target == "Acme/R"
+
+def test_resolve_cli_target_card_id():
+    from spark_metabase_api import validate as V
+    client = FakeClient({4: {"dataset_query": {"database": 1, "type": "native",
+                                               "native": {"query": "x"}}}})
+    units = V.resolve_cli_target(client, "4")
+    assert units[0].live_card_id == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_validate.py -k resolve_cli -v` — Expected: FAIL.
+
+- [ ] **Step 3a: Add `resolve_cli_target` to validate.py**
+
+```python
+def resolve_cli_target(client, target: str) -> List["CardUnit"]:
+    import os
+    from . import iac
+    if target.lower().endswith((".yaml", ".yml", ".json")) and os.path.exists(target):
+        return units_from_spec(iac.load(target))
+    if target.isdigit():
+        return [unit_from_card_id(client, int(target))]
+    return units_from_spec(iac.export(client, target))
+```
+
+- [ ] **Step 3b: Add the `validate` subcommand to `iac.main`**
+
+In the subparser block:
+```python
+    p_val = sub.add_parser("validate", help="Validate a spec / collection / card before applying")
+    p_val.add_argument("target", help="spec path | collection id/name | card id")
+    p_val.add_argument("--no-execute", action="store_true",
+                       help="skip running queries (structure+refs smoke check only)")
+```
+In the dispatch block (before `return 1`):
+```python
+    if args.cmd == "validate":
+        from . import validate as _v
+        units = _v.resolve_cli_target(client, args.target)
+        report = _v.gate(client, units, execute=not args.no_execute)
+        print(report.render())
+        return report.exit_code()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_validate.py -k resolve_cli -v` — Expected: PASS. Then `python -m pytest -q` — Expected: PASS.
+
+- [ ] **Step 5: Verify the CLI wiring end-to-end (smoke)**
+
+Run: `python -m spark_metabase_api.iac validate --help`
+Expected: usage text shows the `validate` subcommand and `--no-execute`. (Confirm the `spark-metabase` console entry point maps to `iac.main` in `setup.py`; if a different entry point is used, wire the subcommand there too.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spark_metabase_api/iac.py spark_metabase_api/validate.py tests/test_validate.py
+git commit -m "feat(cli): spark-metabase validate <spec|collection|card> [--no-execute]
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Opt-in live integration phase
+
+**Files:**
+- Modify: `tests/integration_test.py` (add a read-only validation phase against the sandbox).
+
+**Interfaces:**
+- Consumes: `validate.unit_from_card_id`, `validate.gate`, `validate.guarded_apply`.
+
+- [ ] **Step 1: Add a read-only validation phase**
+
+In the existing Phase 1 (read-only) section of `tests/integration_test.py`, after a card is known, add:
+```python
+    # Validation smoke (read-only): the sandbox source card must pass the gate.
+    from spark_metabase_api import validate as V
+    units = [V.unit_from_card_id(mb, args.source_dashboard_id)] if False else []
+    if card_id:  # an existing card id discovered earlier in the phase
+        report = V.gate(mb, [V.unit_from_card_id(mb, card_id)], execute=True)
+        print(report.render())
+        assert report.ok(), "validation gate failed on a known-good card"
+```
+
+- [ ] **Step 2: Run the integration test against a live sandbox (manual, opt-in)**
+
+Run:
+```bash
+python tests/integration_test.py --domain "$MB_URL" --email "$MB_USER" --password "$MB_PASS" --collection "My Reports" --source-dashboard-id 42
+```
+Expected: the new validation lines print a `Report` and the assertion passes on a known-good card.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration_test.py
+git commit -m "test(validate): opt-in live validation phase in integration test
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - §4.1 Target abstraction → Task 2. §4.2 checks: structure → T3, refs → T4, execution → T5, differential → T6. §4.3 Report → T1. §4.4 around-apply orchestration → T7. §4.5 integration: iac.apply → T8, CLI → T9, campaign libs → `guarded_apply` (T7, callable by libs). §4.6 wrapper `run_query` → T5. §6 testing → tests in every task + T10 live phase. ✓
+  - §4.5 "campaign libs call guarded_apply" — provided as a public function in T7; wiring each lib is part of using it during a campaign, not a code change here. Noted, not a gap.
+- **Placeholder scan:** every code step contains complete, runnable code; no TBD/TODO. ✓
+- **Type consistency:** `Finding`/`Report`/`CardUnit` field names, `check_structure`→`Finding`, `check_refs`/`check_execution`/`gate`/`guarded_apply` signatures, and `run_query` return shape are consistent across T1–T9. `_execute_unit` returns `(rows, error)` used identically in T5 and T7. ✓
+- **Risk (params for /api/dataset)** from spec §7: surfaced in execution (a failed run becomes an `error` Finding); deriving template-tag defaults is an enhancement, not required for the gate to function. Acceptable for v1.

--- a/docs/superpowers/plans/2026-06-20-repo-menage-leger.md
+++ b/docs/superpowers/plans/2026-06-20-repo-menage-leger.md
@@ -1,0 +1,209 @@
+# Repo Ménage Léger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Separate the durable, reusable core from spent one-shot scripts, commit critical uncommitted work, and delete version-cruft — so the validation layer (Phase 1) wires only to what survives.
+
+**Architecture:** Pure repo reorganization. Move spent one-shot drivers into `scripts/campaigns/<nom>/` (reversible `git mv`), commit untracked durable libs, delete superseded `_v2`/`_v3` after explicit confirmation. No behavior changes.
+
+**Tech Stack:** git, Python 3, pytest.
+
+## Global Constraints
+
+- This is Phase 0 of `docs/superpowers/specs/2026-06-20-metabase-pre-apply-validation-design.md`. Relocation only, **not** a rewrite.
+- **Never delete a file without explicit user confirmation of the keep/delete list** (Task 2 gate).
+- `pytest` must be green before and after the reorg.
+- All moves use `git mv` (reversible); deletions only after Task 2 confirmation.
+- Commit messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Commit untracked durable libs + their tests
+
+**Files:**
+- Commit (currently untracked): `scripts/conv_lib.py`, `scripts/bascule_lib.py`, `scripts/conv_tracker.py` and their tests `tests/test_conv_lib.py`, `tests/test_bascule_lib.py`, `tests/test_conv_tracker.py` (exact set discovered in Step 1).
+
+**Interfaces:**
+- Produces: a committed durable-lib baseline that Phase 1 and later tasks rely on existing in git.
+
+- [ ] **Step 1: Discover the untracked durable libs and their tests**
+
+Run:
+```bash
+git ls-files --others --exclude-standard scripts/ tests/ | grep -E '(_lib|_tracker|^tests/test_)' 
+```
+Expected: lists `scripts/conv_lib.py`, `scripts/bascule_lib.py`, `scripts/conv_tracker.py`, `tests/test_conv_lib.py`, `tests/test_bascule_lib.py`, `tests/test_conv_tracker.py` (a durable lib = imported by a `test_*.py` and not tied to one dashboard id).
+
+- [ ] **Step 2: Verify these tests pass before committing**
+
+Run: `python -m pytest tests/test_conv_lib.py tests/test_bascule_lib.py tests/test_conv_tracker.py -q`
+Expected: PASS (all green). If a test imports a module not in the discovered set, add that module to the commit set.
+
+- [ ] **Step 3: Stage ONLY the discovered durable libs + tests**
+
+```bash
+git add scripts/conv_lib.py scripts/bascule_lib.py scripts/conv_tracker.py \
+        tests/test_conv_lib.py tests/test_bascule_lib.py tests/test_conv_tracker.py
+git status --short   # confirm nothing else is staged
+```
+Expected: only the six files (adjust to the discovered set) are staged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "chore: commit durable campaign libs (conv, bascule, tracker) + tests
+
+Critical bulk-migration logic was untracked (local-only); commit it so it is
+versioned before the repo reorg.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit created; `git status` no longer lists those files as untracked.
+
+---
+
+### Task 2: Generate the evidence-based keep/archive/kill triage and CONFIRM
+
+**Files:**
+- Create: `docs/superpowers/plans/menage-triage.md` (the classified list, for the record).
+
+**Interfaces:**
+- Produces: a confirmed three-bucket classification (`KEEP` / `ARCHIVE` / `KILL`) that Tasks 3–4 act on. **Tasks 3–4 must not run until the user approves this list.**
+
+- [ ] **Step 1: Classify every script by evidence**
+
+Run these and record the output:
+```bash
+# durable libs (imported by tests) -> KEEP
+git grep -l "import " tests/ | xargs -I{} grep -hoE "from scripts\.[a-z_]+|import [a-z_]+_lib" {} 2>/dev/null | sort -u
+# version-cruft: a base name that also has _v2/_v3 -> KILL the superseded ones
+ls scripts/ | sed -E 's/_v[0-9]+//' | sort | uniq -d
+# one-shot drivers: reference a specific dashboard/card id or client -> ARCHIVE
+grep -lE "2457[0-9]|3249[0-9]|24642|quizroom|manucurist" scripts/*.py
+```
+
+- [ ] **Step 2: Write the classification table**
+
+Create `docs/superpowers/plans/menage-triage.md` with three sections:
+```markdown
+## KEEP (durable core, stays in scripts/lib/ or scripts/)
+- conv_lib.py, bascule_lib.py, swap_lib.py, audit_lib.py, rename_lib.py, reorg_lib.py, audit_report.py, conv_tracker.py  (+ any imported by tests)
+
+## ARCHIVE (one-shot drivers -> scripts/campaigns/<nom>/)
+- <list each driver + its target campaign folder, e.g. apply_fixes_32496.py -> campaigns/serp-32496/>
+
+## KILL (superseded version-cruft, after confirming the winner)
+- <list each loser + WHY it is superseded by which winner>
+```
+For every KILL entry, state which version is the winner and the evidence (newer, imported, referenced in a tracker doc).
+
+- [ ] **Step 3: GATE — present the list and get explicit confirmation**
+
+Show the user the KEEP/ARCHIVE/KILL table. **Do not proceed to Task 3 or 4 until the user confirms.** Record their edits in `menage-triage.md`, then commit the doc:
+```bash
+git add docs/superpowers/plans/menage-triage.md
+git commit -m "docs: ménage triage list (keep/archive/kill), confirmed
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Relocate one-shot drivers into scripts/campaigns/
+
+**Files:**
+- Create: `scripts/campaigns/<nom>/` directories.
+- Move: each ARCHIVE-bucket driver + its tracker/HANDOFF doc.
+
+**Interfaces:**
+- Consumes: the confirmed ARCHIVE list from Task 2.
+- Produces: a `scripts/campaigns/` tree; the flat `scripts/` root no longer holds spent drivers.
+
+- [ ] **Step 1: Create campaign folders and move files with git mv**
+
+For each ARCHIVE entry (example shown — repeat per confirmed entry):
+```bash
+mkdir -p scripts/campaigns/serp-32496
+git mv scripts/apply_fixes_32496.py scripts/campaigns/serp-32496/
+git mv docs/seo-manucurist-HANDOFF.md scripts/campaigns/serp-32496/ 2>/dev/null || true
+```
+
+- [ ] **Step 2: Verify no durable code imports a moved driver**
+
+Run: `git grep -nE "import (apply_fixes_32496|bilingual_24576|add_quizroom_disclaimer)" -- scripts/ tests/`
+Expected: no matches (drivers are leaf scripts). If a match exists, that file is NOT a leaf — move it back to KEEP and re-confirm with the user.
+
+- [ ] **Step 3: Commit the relocation**
+
+```bash
+git add -A scripts/campaigns/ && git add -u scripts/ docs/
+git commit -m "refactor: archive one-shot campaign drivers under scripts/campaigns/
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Delete confirmed version-cruft
+
+**Files:**
+- Delete: each KILL-bucket file (superseded `_v2`/`_v3` losers).
+
+**Interfaces:**
+- Consumes: the confirmed KILL list from Task 2.
+
+- [ ] **Step 1: Delete the confirmed losers (only those on the confirmed list)**
+
+```bash
+# example — use the exact confirmed KILL list
+git rm scripts/build_seo_dashboard.py scripts/build_seo_dashboard_v2.py \
+       scripts/build_seo_monitoring.py scripts/build_seo_monitoring_v2.py \
+       scripts/probe_v2.py
+```
+
+- [ ] **Step 2: Verify nothing imports the deleted files**
+
+Run: `git grep -nE "build_seo_dashboard_v2|build_seo_monitoring_v2|probe_v2" -- scripts/ tests/`
+Expected: no matches. If a match exists, restore that file (`git checkout HEAD -- <file>`) and flag it.
+
+- [ ] **Step 3: Commit the deletions**
+
+```bash
+git commit -m "chore: delete superseded version-cruft (kept the winning versions)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Fix imports broken by relocation and verify green
+
+**Files:**
+- Modify: any moved driver whose relative imports broke.
+- Test: full suite.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `python -m pytest -q`
+Expected: PASS. If a moved driver fails to import a lib, fix its import path (libs stayed in `scripts/`; a driver in `scripts/campaigns/<nom>/` imports a lib via `from scripts.conv_lib import ...` or an explicit `sys.path` insert — match the project's existing import style).
+
+- [ ] **Step 2: Confirm the flat scripts/ root is legible**
+
+Run: `ls scripts/`
+Expected: only durable libs + `campaigns/` + a small set of reusable utilities; no `_v2`/`_v3` duplicates, no dashboard-id-specific drivers at the root.
+
+- [ ] **Step 3: Commit any import fixes**
+
+```bash
+git add -u && git commit -m "fix: repair import paths after campaign relocation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Phase 0 rules 1–4 of the spec → Task 1 (commit untracked), Task 2 (triage + confirm), Task 3 (relocate), Task 4 (kill cruft), Task 5 (imports + pytest gate). ✓
+- **Placeholder scan:** Example file lists are explicitly marked "use the confirmed list"; the concrete list is produced in Task 2 by design (confirm-before-delete). ✓
+- **Safety:** No deletion before Task 2 confirmation; all moves reversible via git. ✓

--- a/docs/superpowers/plans/menage-triage.md
+++ b/docs/superpowers/plans/menage-triage.md
@@ -1,0 +1,130 @@
+# Ménage Triage — scripts/ classification
+
+**Date**: 2026-06-20
+**Status**: AWAITING USER CONFIRMATION (gate before Tasks 3 & 4)
+
+Pre-classified KEEP (not re-litigated): `conv_lib.py`, `bascule_lib.py`, `conv_tracker.py` (committed T1); `audit_lib.py`, `audit_report.py`, `rename_lib.py`, `reorg_lib.py`, `swap_lib.py` (already tracked).
+
+---
+
+## KEEP (durable core — stays in scripts/ or moves to scripts/lib/)
+
+- `audit_lib.py` — imported by `tests/test_audit_lib.py`; instance-wide scan/deep engine
+- `audit_report.py` — imported by `tests/test_audit_report.py`; report renderer for audit_lib
+- `rename_lib.py` — imported by `tests/test_rename_lib.py`; card-naming normalisation lib
+- `reorg_lib.py` — imported by `tests/test_reorg_lib.py`; collection-reorg state machine
+- `swap_lib.py` — imported by `tests/test_swap_lib.py`; card-swap safety-check + repoint
+- `conv_lib.py` — imported by tests + 10+ campaign drivers; conversion-column mapping core
+- `bascule_lib.py` — imported by `tests/test_bascule_lib.py`; time-filter bascule logic
+- `conv_tracker.py` — imported by `tests/test_conv_tracker.py` + `migrate_client.py`; migration tracker state
+- `archive_collections.py` — exports `connect_resilient()` imported by 8 scripts (audit_brand_clause, batch_brand_fix, convert_generic_temporal, migrate_client, fix_brand_clause_cards, tag_existing, validate_brand_batch, archive_superseded); durable connection helper even though it also has a `__main__`; default KEEP (non-leaf, would break imports)
+- `audit.py` — generic instance-wide audit CLI (scan/deep/report), no client id hardcoded; referenced in memory + spec as the audit engine entry point
+- `archive_stale_cards.py` — generic stale-card archiver (threshold-based, no client id); imports `audit_lib`; durable wave-0 tool
+- `archive_empty_collections.py` — generic empty-collection archiver; reusable ménage utility
+- `prune_unused.py` — archives unused cards from collection 215 (Generic Questions); generic utility tied to the library structure, not a specific campaign
+- `find_dupes.py` — duplicate-card detector on collection 215; generic read-only analysis tool
+- `reorg_phase1.py` — exports `_load_env()` + connection boilerplate imported by 46 scripts; also the Phase 1 CLI (done), but must stay as lib providing `_load_env`; default KEEP (non-leaf)
+- `rename_phase15.py` — Phase 1.5 card-naming CLI; campaign complete, but imports `rename_lib` and is the primary CLI for that lib; default KEEP (the lib has no other runner)
+- `reorg_xplat.py` — cross-platform reorg CLI; one-shot but has no client id hardcoded and could re-run; default KEEP (borderline — see note below)
+- `sql_antipattern_scan.py` — read-only scan for antipattern candidates; generic, no client/card id; reusable for future audits
+- `swap_card_on_dashboards.py` — generic card→canonical swap on all dashboards; parameterised by CLI args, no baked-in ids; durable utility
+- `build_antipattern_tasks.py` — splits antipattern candidates into per-task SQL files; generic pipeline step
+- `render_antipattern_report.py` — synthesises antipattern audit results into md+JSON; generic report renderer
+- `fix_antipatterns.py` — applies antipattern fixes with before/after proof; general-purpose card-fix engine parameterised by card ids (not baked in)
+
+---
+
+## ARCHIVE (one-shot drivers → scripts/campaigns/<nom>/)
+
+### campaigns/seo-manucurist/
+- `build_seo_monitoring_v3.py` — winner of the v1/v2/v3 sequence; referenced as active in `docs/seo-manucurist-HANDOFF.md`; stays WITH the campaign
+- `build_seo_dashboard_v3.py` — assembles Manucurist dashboard #25137; winner of the v1/v2/v3 sequence; referenced in HANDOFF
+- `build_seo_pages_model.py` — builds pages model #49062 for Manucurist (collection #13752)
+- `build_seo_saisonnalite.py` — builds saisonnalité model #49425 + pivot #49426 for Manucurist; imports `build_seo_monitoring_v3` (both move together)
+- `build_seo_global_dashboard.py` — Phase 1 global-tracking dashboard for Manucurist (#13752); client-specific card ids
+- `build_seo_grid.py` — builds the keyword-position grid card #48634 for Manucurist; historical V1 builder but not superseded by a v2/v3 grid builder
+- `build_seo_inverted.py` — builds inverted-view card for Manucurist (#49557); client-specific
+- `build_seo_polish.py` — V1 finishing touches on dashboard #25137 (layout, filters); one-shot
+- `probe_v2.py` — data-discovery probe V2 for Manucurist SEO (GSC markets, page templates, brand kw); referenced in HANDOFF as useful template
+- `probe_v3.py` — data-discovery probe V3 for Manucurist SEO (saisonnalité, CTR, URL, geo-clics); referenced in HANDOFF as active template
+- `probe_vol.py` — probes volume variation in model #48633 (Manucurist); tied to that model
+- `seo_collapse_fix.py` — applies pivot fold toggle + removes broken links on dashboard #25137 for Manucurist (V3.1 fix 2026-06-17)
+- `seo_collapse_probe.py` — probe/backup for the collapse fix on dashboard #25137
+- `seo_perf_probe.py` — perf diagnostic for Manucurist SEO dashboard #25137
+- `seo_persist_apply.py` — activates persistence on models #48633/#49062/#49425 (Manucurist)
+- `seo_persist_debug.py` — debug persistence endpoints for Manucurist models
+- `seo_persist_probe.py` — probes persistence config before activation (Manucurist)
+- `seo_persist_routes.py` — maps persistence routes for card #48633 (Manucurist)
+- `serp_difftest.py` — differential test for card #32496 (Manucurist SERP positions cleanup)
+- `apply_fixes_32496.py` — applied antipattern fixes to card #32496 (Manucurist SERP); one-shot, campaign done per memory 2026-06-11
+
+### campaigns/conv-migration/
+- `discover_conversion_targets.py` — crawls dashboards under collection 317 for old-conv tiles; conv-migration campaign driver
+- `conv_preflight.py` — resolves each conversion tile and produces the migration worklist; conv-migration driver
+- `export_conv_mapping.py` — transforms Airtable rows into client mapping JSON; conv-migration driver
+- `build_new_conv_index.py` — indexes new-conversion cards by (col, shape); conv-migration driver
+- `migrate_conversions_on_dashboard.py` — migrates conversion tiles on a single dashboard; conv-migration driver
+- `migrate_dashboard_reuse.py` — migrates a copy dashboard by reusing 11673 cards; conv-migration driver
+- `migrate_dashboard_full.py` — full migration (no tile left on old system) with generation; conv-migration driver
+- `migrate_client.py` — orchestrator: copy → reuse → swap → bascule per client; conv-migration driver
+- `generate_fallback.py` — generates fallback copies for tiles without an 11673 equivalent; conv-migration driver
+- `polish_generated_viz.py` — fixes viz settings on generated-card dashcards after migration
+- `swap_tables.py` — swaps multi-slot tables to mixed-family 11673 cards on a copy; conv-migration driver
+- `bascule_time_filter.py` — bascules the time filter from category→temporal-unit on a copy; conv-migration driver (imports `bascule_lib`)
+- `convert_generic_temporal.py` — creates temporal-unit copies of generic blocking cards (sandbox 13885); conv-migration driver
+- `tag_existing.py` — applies [conv-2026-06] anchor to already-migrated dashboards; conv-migration driver
+- `archive_superseded.py` — archives old dashboards superseded by migrated copies; conv-migration driver
+- `validate_brand_batch.py` — post-batch validation: re-runs 1967 cards, triages failures; brand-fix campaign driver
+
+### campaigns/brand-fix/
+- `audit_brand_clause.py` — read-only audit of brand-exclusion clauses on subtree 11673; brand-fix campaign
+- `batch_brand_fix.py` — batch-applies canonical brand rule to all 11673 cards with wrong clause; brand-fix driver
+- `fix_brand_clause_cards.py` — fixes brand clause on specific card ids with before/after proof; brand-fix driver
+
+### campaigns/quiz-room/
+- `add_quizroom_disclaimer.py` — adds disclaimer text card to Quiz Room dashboards; one-shot quizroom
+
+### campaigns/generic-questions-reorg/
+- `bilingual_24576.py` — adds EN bilingual columns to dashboard #24576 (Quiz Room FR); one-shot
+- `polish_headings_24576.py` — polishes heading heights/alignment on dashboard #24576 (Quiz Room FR); one-shot
+- `translate_en_24576.py` — creates EN translation of dashboard #24576; one-shot
+- `fit_text_cards.py` — adjusts text-card heights on dashboard #24576 (hardcoded); one-shot tied to that dash
+- `set_card_heights.py` — sets explicit text-card heights on dashboard #24576 (TARGETS hardcoded); one-shot
+
+### campaigns/audit-engine/
+- `audit_extract_checks.py` — extracts Metabase "check" cards → dbt backlog (audit-engine phase 2); one-shot survey driver
+
+---
+
+## KILL (superseded version-cruft)
+
+Evidence for each: the HANDOFF doc `docs/seo-manucurist-HANDOFF.md` explicitly lists v1/v2 as "historiques (cartes archivées)".
+
+- `build_seo_monitoring.py` (V1) — **KILL**; winner = `build_seo_monitoring_v3.py`. Evidence: HANDOFF lists it as "Historique V1"; v3 is newer (Jun 15 vs May 29), adds FR keywords, richer columns, updates #48633 in-place.
+- `build_seo_monitoring_v2.py` (V2) — **KILL**; winner = `build_seo_monitoring_v3.py`. Evidence: HANDOFF lists it as "Historique V2"; v3 is newer (Jun 15 vs Jun 11), adds Gamme/Catégorie/URL/traffic-potential columns.
+- `build_seo_dashboard.py` (V1) — **KILL**; winner = `build_seo_dashboard_v3.py`. Evidence: HANDOFF lists it as "Historique V1"; v3 is newer (Jun 15 vs May 29), adds 7 filters + saisonnalité tile.
+- `build_seo_dashboard_v2.py` (V2) — **KILL**; winner = `build_seo_dashboard_v3.py`. Evidence: HANDOFF lists it as "Historique V2"; v3 is newer (Jun 15 vs Jun 11), adds saisonnalité section + links.
+
+> **Note on probe_v2.py**: NOT a kill candidate despite the name. The HANDOFF explicitly keeps both `probe_v2.py` and `probe_v3.py` as "réutilisables comme gabarits de sondage" (useful reference templates). They probe different things (v2 = GSC markets/page templates, v3 = saisonnalité/CTR/URL/geo). Both go to ARCHIVE → campaigns/seo-manucurist/.
+
+---
+
+## NEEDS HUMAN DECISION
+
+- `reorg_xplat.py` — Cross-platform collection 214 reorg. It ran once (one-shot), but has no client-specific id hardcoded and is generic enough to re-run. Unclear if the reorg is considered "done" or may need re-running. **Decision needed**: ARCHIVE → campaigns/generic-questions-reorg/ (if done) or KEEP (if may re-run).
+
+- `audit_extract_checks.py` — Extracts Metabase "check" cards for dbt audit-engine phase 2 porting. The docstring says "audit engine, phase 2" which suggests it's a driver for a planned campaign, not yet run. **Decision needed**: ARCHIVE → campaigns/audit-engine/ (if phase 2 is shelved) or KEEP at root (if phase 2 is imminent).
+
+---
+
+## Counts summary
+
+| Bucket | Count |
+|--------|-------|
+| KEEP (incl. 8 pre-classified re-listed + 14 new) | 22 |
+| ARCHIVE (one-shot drivers) | 38 |
+| KILL (superseded version-cruft) | 4 |
+| NEEDS HUMAN DECISION | 2 |
+| **Total scripts/*.py classified** | **66** (all 72 files covered: 8 pre-classified + 64 new) |
+
+(All 72 `scripts/*.py` files accounted for. The 8 pre-classified libs appear at the top of KEEP for completeness.)

--- a/docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md
+++ b/docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md
@@ -1,0 +1,215 @@
+# Audit d'optimisation de l'instance Metabase — Design
+
+> **Date** : 2026-05-28
+> **Statut** : design validé en brainstorming, en attente de relecture
+> **Topic** : audit instance-wide → backlog de campagnes de nettoyage exécutables
+
+## 1. Contexte & objectif
+
+L'instance Metabase a accumulé de la dette : doublons, éléments inutilisés,
+collections vides, travail client logé dans des espaces personnels, structure
+incohérente. Les chantiers précédents (`reorg` Phase 1, `rename` Phase 1.5,
+`reorg-xplat`, `prune`, `find_dupes`) n'ont touché qu'**une seule** collection :
+le template `2. Generic Questions` (215).
+
+**Objectif** : faire ressortir, sur **toute l'instance**, les patterns
+d'optimisation, de façon quantifiée et priorisée, puis livrer un **plan de
+campagnes de nettoyage exécutables** — chacune suivant le workflow sûr déjà
+rodé (snapshot → test différentiel → échantillon → batch → invariant).
+
+Ce document conçoit l'**outil d'audit** et le **modèle de campagne**. Chaque
+campagne retenue dans le backlog fera ensuite l'objet de son propre plan
+d'exécution (à la manière des docs de Phase existants).
+
+## 2. Périmètre
+
+Toute l'instance. Photographie live au 2026-05-28 :
+
+| Élément | Volume |
+|---------|--------|
+| Collections | **868** (533 non-perso, 335 perso) |
+| Cartes actives | **5 654** (282 en collections perso, 5 372 en partagé) |
+| Dashboards | **735** |
+| Collections non-perso **vides** | **241 / 533** (45 %) |
+| Collections "…Nanga's Personal Collection" | **191** |
+| Collections perso préfixées d'un nom de client | **187** |
+| Noms de collections en double | 45 noms / 189 entrées redondantes |
+| ⚠️ Archivées | non comptées (l'API les masque par défaut) — à mesurer |
+
+> Note : le template 215 représente ~1 198 cartes ; l'essentiel du désordre est
+> **hors template**.
+
+## 3. Garde-fous & contraintes
+
+- **Toutes les actions sont autorisées** (archivage, suppression, déplacement,
+  rangement du sprawl perso, renommage) **mais validation à chaque action** :
+  je demande avant d'agir.
+- **Réversible d'abord** : archiver avant supprimer ; suppression seulement
+  après validation explicite + fenêtre de rétention.
+- **Risque = barrière** : tout finding qui touche aux collections personnelles
+  ou aux copies clientes passe *obligatoirement* par validation, quel que soit
+  son impact.
+- **Règle "hors sources"** : ne jamais prune/fusionner une carte qui sert de
+  source/modèle à une autre.
+
+## 4. Architecture
+
+Un outil CLI `scripts/audit.py`, même squelette que les scripts existants
+(connexion via `.env`, snapshots dans `migration/`). Trois commandes :
+
+```
+audit scan    →  passe LARGE (métadonnées, toute l'instance + archivées)
+                 écrit migration/audit-findings-YYYYMMDD.json
+audit deep    →  passe PROFONDE — fetch des requêtes du corpus complet
+                 (cache disque, reprenable), enrichit le JSON
+audit report  →  rend docs/audits/audit-YYYYMMDD.md (priorisé) + backlog
+```
+
+**Place dans l'existant** : l'audit ne remplace pas `find_dupes` / `prune_unused`
+/ `rename_lib` / `reorg_lib`. Il **généralise leur détection à toute l'instance**
+et **unifie la sortie**. Chaque campagne du backlog réutilise (ou fait évoluer)
+ces scripts comme *exécuteurs*. La détection de doublons passe en **v2**
+(comparaison sur requête réelle, paramètres inclus — voir #6).
+
+### Passes
+
+- **Passe large** (`scan`) — métadonnées uniquement (`/api/collection/`,
+  `/api/card/`, `/api/dashboard/`, + variantes archivées). Détecte tous les
+  patterns calculables sans ouvrir les requêtes.
+- **Passe profonde** (`deep`) — **corpus complet** : fetch de la requête de
+  chacune des ~5 654 cartes, **mise en cache disque et reprenable** (pas de
+  re-fetch, throttlé). Permet la détection exhaustive des doublons (#6), de la
+  dérive template (#8), des familles de variantes (#9) et la construction du
+  **graphe de sources** (#5).
+
+## 5. Catalogue de patterns
+
+5 familles, 11 patterns. `[L]` = passe large, `[P]` = passe profonde.
+
+### Famille 1 — Bruit structurel (collections)
+| # | Pattern | Détection | Observé |
+|---|---------|-----------|---------|
+| 1 | **Collections vides** (0 carte active, 0 dashboard, aucun descendant non-vide) | `[L]` | 241/533 non-perso |
+| 2 | **Sprawl perso** : travail client en collection personnelle + coquilles vides nominatives | `[L]` | 335 perso, 191 "Nanga…", 187 préfixées client |
+| 3 | **Noms de collections dupliqués**, surtout **rangé-par-type-de-viz** | `[L]` | `Bar/Combo/Line/Pie/Smartscalar` ×28 |
+| 4 | **Collections fourre-tout / staging** ("To sort"…) | `[L]` | "To sort" (7252) |
+
+### Famille 2 — Gaspillage au niveau carte
+| # | Pattern | Détection | Note |
+|---|---------|-----------|------|
+| 5 | **Cartes inutilisées** : 0 dashboard **ET** non-source d'une autre carte | `[L]`+`[P]` | template : 52 ; instance : à mesurer |
+| 6 | **Doublons fonctionnels v2** : même requête normalisée (paramètres + métrique inclus) | `[P]` | corrige les faux positifs d'empreinte |
+| 7 | **Backlog archivé** jamais purgé (cartes/dashboards/collections) | `[L]` | nécessite le fetch `archived=true` |
+
+### Famille 3 — Propagation / DRY
+| # | Pattern | Détection | Note |
+|---|---------|-----------|------|
+| 8 | **Dérive template** : copies clientes divergentes du maître 215 | `[P]` | 735 dashboards, bcp de copies |
+| 9 | **Variantes paramétrables** : familles quasi-identiques → 1 carte paramétrée | `[P]` | transforme les "faux positifs" en optimisation |
+
+### Famille 4 — Nommage / hygiène
+| # | Pattern | Détection | Note |
+|---|---------|-----------|------|
+| 10 | **Incohérences de nommage hors template** (cryptique, suffixe viz, double espace…) | `[L]` | étend la Phase 1.5 |
+
+### Famille 5 — Performance
+| # | Pattern | Détection | Note |
+|---|---------|-----------|------|
+| 11 | **Cartes coûteuses / lentes / jamais consultées** | `[P]` | si l'API expose `query_executions` / vues ; sinon best-effort |
+
+**#6 et #9 sont les deux faces d'une même pièce.** L'empreinte actuelle voit
+"clics/CTR/position" comme un doublon (faux positif). En passe profonde on lit
+la requête réelle : soit *vrai* doublon (→ #6, fusion), soit variantes légitimes
+(→ #9, candidat à une carte paramétrée unique).
+
+## 6. Scoring & priorisation
+
+Chaque finding est noté **Impact / Risque / Effort** (H-M-L) :
+
+- **Impact** — réduction de bruit / dette.
+- **Risque** — dangerosité du correctif (réversibilité, dépendances). *Sert
+  aussi de barrière de validation.*
+- **Effort** — automatisable vs jugement manuel.
+
+Le backlog sort ordonné en **4 vagues** (quick-wins d'abord) :
+
+| Vague | Critère | Exemples de campagnes |
+|-------|---------|------------------------|
+| **0 — Quick wins** | Impact H · Risque L · réversible | Archiver les 241 collections vides · purger le backlog archivé |
+| **1 — Automatisable forte valeur** | Impact H/M · Risque L/M | Doublons v2 · prune inutilisées (instance) · nommage |
+| **2 — Structurel** | Impact H · Effort M/H | Aplatir le rangé-par-viz · ranger le sprawl perso *(validation)* |
+| **3 — DRY / dérive** | Impact H · Effort H · jugement | Réconcilier la dérive template · paramétrer les variantes (#9) |
+
+## 7. Format de sortie
+
+1. **`migration/audit-findings-YYYYMMDD.json`** — machine. Par pattern : liste
+   des entités touchées (id, nom, location), compteurs, preuves de la passe
+   profonde. Consommé par les scripts exécuteurs.
+2. **`docs/audits/audit-YYYYMMDD.md`** — humain, priorisé, **court et scannable** :
+   - Résumé exécutif (chiffres-clés, top patterns par impact)
+   - Une section par pattern : définition en 1 ligne, compte, **3-5 exemples**
+     représentatifs (noms/id), action recommandée, I/R/E, vague
+   - Le **backlog de campagnes** ordonné : scope, volume estimé, barrière de
+     risque, checklist du workflow sûr
+
+   **Principe** : le `.md` est un digest — tableaux compacts, pas de pavés,
+   exemples limités. Les listes exhaustives d'entités vivent dans le JSON ;
+   le rapport y renvoie plutôt que de les dérouler.
+
+## 8. Modèle d'exécution d'une campagne
+
+```
+snapshot → plan (dry-run du diff) → test différentiel → échantillon
+        → batch + invariant → verify/rollback
+```
+
+- **Test différentiel** (campagnes qui modifient une requête : #6, #8) :
+  exécuter la carte avant/après, comparer — résultats identiques obligatoire.
+- **Invariant post-batch** : `lost / archived / moved / dashboard_count`
+  (harnais existant).
+- **Validation avant chaque action** ; obligatoire sur Risque-H.
+- Les **quick-wins (vague 0)** s'exécutent directement (snapshot + validation).
+  Toute campagne plus lourde reçoit son **propre plan court**.
+
+## 9. Sûreté / gestion d'erreurs
+
+- **Archivées cachées** : forcer le fetch archivé, sinon "inutilisé" et "backlog
+  archivé" sont faux.
+- **Quirk `dataset_query` vide** : via l'API, le nouveau format `dataset_query`
+  ressort souvent vide ; la passe profonde fetch l'objet carte complet
+  (`/api/card/:id`) et se rabat sur `legacy_query` pour l'empreinte (déjà
+  constaté lors de `find_dupes`). L'empreinte v2 doit normaliser à partir de la
+  représentation réellement peuplée, paramètres inclus.
+- **Graphe de sources** : construit en passe profonde ; protège la règle
+  "hors sources".
+- **Anti-faux-positif** : #6 exige une correspondance de requête réelle
+  (paramètres inclus) avant toute proposition de fusion — jamais sur l'empreinte
+  seule.
+- **Volume** : fetch mis en cache disque, reprenable, throttlé.
+- **Idempotence** : `scan`/`deep`/`report` sont en lecture seule ; les
+  exécuteurs sont idempotents (gardes de suffixe comme `rename`).
+
+## 10. Tests
+
+- Détecteurs : tests unitaires sur fixtures (patterns connus → findings
+  attendus), dans `tests/`.
+- **Garde-fou régression empreinte v2** : les faux positifs connus
+  (clics/CTR/position ; nuages/pluie/temp) doivent être classés **variantes
+  (#9), pas doublons (#6)** — assert explicite.
+- Exécuteurs : tests d'invariant (réutilise le harnais reorg/rename) + harnais
+  de test différentiel.
+
+## 11. Livrables & étapes suivantes
+
+1. `scripts/audit.py` (commandes `scan`, `deep`, `report`) + tests.
+2. `migration/audit-findings-YYYYMMDD.json` (généré).
+3. `docs/audits/audit-YYYYMMDD.md` — le diagnostic priorisé + le backlog.
+4. Exécution des campagnes une par une, dans l'ordre des vagues, chacune avec
+   son plan court (si non-trivial) et validation à chaque action.
+
+## 12. Hors périmètre (pour l'instant)
+
+- L'exécution des campagnes elles-mêmes (ce design produit le backlog ; chaque
+  campagne sera planifiée et exécutée séparément).
+- La refonte de fond de l'arborescence cible du template (relève des chantiers
+  reorg existants).

--- a/docs/superpowers/specs/2026-06-03-conversion-migration-design.md
+++ b/docs/superpowers/specs/2026-06-03-conversion-migration-design.md
@@ -1,0 +1,172 @@
+# Conversion migration (old positional → new named) — Design
+
+> **Status:** test/spike validated 2026-06-03 · scaling plan pending Airtable mapping.
+> **Spike artifacts (sandbox, safe to delete):** copy dashboard `25302`, collection `13851`.
+> Related: `docs/cleaning-roadmap.md` (invariant dashboard, swap tooling), `docs/generic-questions-reorg.md` (§5 Nouvelles Conversions).
+
+## 1. Problem
+
+Spark changed its conversion-counting system. Snowflake `global.campaign_daily_metrics`
+gained **new named columns** (`custom_conversions_1..5`, `custom_conversions_N_value`, and
+standard named conversions — purchases, leads, add-to-cart, …), replacing the old
+**positional** columns (`conversions`, `conversions_1..19`, `conversion_value*`).
+
+New Metabase questions already exist under collection **`11673 "Nouvelles Conversions"`**
+(`11871 Conversions génériques`, `11872 Conversions custom`), organised as
+`conversion type × chart type × variant` (e.g. `Custom Conversion 1 → Smartscalar → {Custom Conversion 1, value, CAC, COS, CR, ROAS, …}`).
+
+**Goal:** on each client's **custom** dashboards, replace every tile backed by an
+old-system conversion question with its new-system equivalent, preserving layout and
+filter wiring. Then scale across all clients with agents + task tracking.
+
+## 2. Architecture (as found)
+
+- Each client has a collection under `317`. Custom dashboards (vs templates) are
+  **client-pinned**: a dashboard `Client` param (default e.g. `["Pro Nutrition"]`) + a `Date` param.
+- Tiles reference **shared template cards** (in shared collections, *not* the client
+  collection), wired to the dashboard's params via `parameter_mappings`. Example tile:
+  `card 266 "Conversions 1"` (collection 13687), a native-SQL card summing
+  `conversions_1`, with ~19 filter template-tags; the dashcard wires only `clients` and `date`.
+- The new equivalent `card 42635 "Custom Conversion 1"` (collection 12311) sums
+  `custom_conversions_1`, same DB (144), same `smartscalar` display, exposes the same
+  `clients`/`date` tags ⇒ filter wiring survives a `card_id` swap untouched.
+
+**Mapping is per-client and positional→named.** The *same* old card maps to *different*
+new cards depending on the client. Source of truth: Airtable base `apptzpE1FqCMGH0dw`,
+table `tbliHOIPYGJCvLvas` ("Conversions"). Each row = one platform conversion per
+account/brand; designated reporting conversions carry `type` (slot) + `new_type` (named).
+
+Confirmed model (read 2026-06-03):
+- `type` ∈ {Main conversion, 1st…19th conversion, Add to cart, App install, runs}
+  → old column: `Main`→`CONVERSIONS`, `Nth`→`CONVERSIONS_N` (+ `*_VALUE` for value cards).
+- `new_type` ∈ {Purchases, Add to cart, Initiate checkouts, Content views/View Item,
+  Sign ups, Leads, MQL, SQL, Offline sales, App installs, Search visits…, Custom 1…15}
+  → new column: `Purchases`→`PURCHASES`, `Custom K`→`CUSTOM_CONVERSIONS_K`, etc. (+ `*_VALUE`).
+- Per client the slot→new_type is **consistent across the client's accounts/platforms**.
+  Pro Nutrition: `Main→Purchases`, `1st→Custom 1`, `3rd→Custom 2`.
+- **Slot number ≠ Custom number** (`3rd → Custom 2`) ⇒ Airtable is mandatory; never assume
+  `conversions_N → custom_conversions_N`.
+- Some (client, slot) rows have **empty `new_type`** (not yet mapped) ⇒ those tiles go to a
+  review/skip queue, never guessed.
+- The dashboard's `Client` param value (e.g. "Pro Nutrition") = Airtable `brand_name` → join key.
+
+## 3. Why the existing `swap_card_on_dashboards.py` can't be reused as-is
+
+It is a **dedup** tool. Four behaviours are wrong for migration:
+
+| dim | dedup tool (existing) | migration tool (new) |
+|---|---|---|
+| old→new source | "find the canonical duplicate" | per-client mapping (Airtable) |
+| safety check | **requires identical output fingerprint** | relaxed: same DB · new not archived · new covers wired tags |
+| tag extractor | `legacy_query.native.template-tags` only | **format-tolerant** (`dataset_query.stages[].template-tags`) — *required* |
+| scope / cleanup | all dashboards of old card, then **archive** | **one dashcard on one dashboard**, **never archive** the shared template |
+
+`swap_lib.rewrite_dashcards` is correct as-is and is reused (repoints `card_id`,
+`parameter_mappings.card_id`, `series`; targets stay valid — same tag names).
+
+## 4. Validated test (spike) — 2026-06-03
+
+Tile `266 → 42635` on a **shallow copy** of dashboard 14118 (Home Pro Nutrition).
+Live dashboard never touched. Results:
+
+- **Structural ✅** — `card_id` 266→42635; size/row/col preserved (`7×5 @ 6/17`);
+  both `parameter_mappings` repointed to 42635 with identical targets.
+- **Renders ✅** — new tile returns data.
+- **Value + Snowflake cross-check ✅ exact** (Pro Nutrition, 2026-05-01→05-31):
+  new tile current `646.225741` == independent `SUM(custom_conversions_1)` `646.225741`;
+  old tile `646.225741` == `SUM(conversions_1)`. Old==new here is *correct* (faithful
+  slot-1→Custom-1 remap); a wrong target would have diverged from the independent SUM.
+
+Confirmed required fixes: (1) format-tolerant tag extractor — the new card has **no
+`legacy_query`**, so plain `swap_lib` saw 0 tags and would have refused; (2) cosmetic:
+dashcard `column_settings` keyed on old column name `CONVERSIONS_1` won't apply to
+`CUSTOM_CONVERSIONS_1` → remap the keys.
+
+## 5. Migration tool — `scripts/migrate_conversions_on_dashboard.py`
+
+Inputs: `--dashboard <id>` (+ optional `--dashcard`), mapping resolved per client.
+Per conversion tile:
+
+1. **Identify** the tile as old-system: its card's native SQL references an old
+   conversion column (`conversions`, `conversions_1..19`, `conversion_value*`).
+2. **Resolve new card** = `mapping(client, old slot/type) → new type` (Airtable)
+   × **chart shape** (display + dimensions/breakdown + metric variant) within 11673.
+   Ambiguous/none → **manual-review queue** (no guess).
+3. **Safety (relaxed):** same DB · new not archived · new covers the tile's wired tags
+   (via format-tolerant extractor). Refuse otherwise.
+4. **Rewrite** dashcard via `swap_lib.rewrite_dashcards`; **remap** `column_settings`
+   keys old-column→new-column on the dashcard.
+5. **Snapshot** the dashboard's dashcards (rollback) before PUT. **Never archive** old cards.
+
+Helpers: format-tolerant `native_and_tags(card)`; `old_conversion_columns(sql)`;
+`resolve_new_card(client, old_card, tree_index)`.
+
+## 6. Validation strategy (per migrated tile)
+
+- **Structural:** card_id/size/pos/viz preserved; wired tags still mapped.
+- **Value readout:** run old & new tile for the client over a fixed window; record both.
+- **Snowflake cross-check:** independent native SQL via `/api/dataset` (DB 144), same
+  join chain (`utils.clients → client_ad_platforms → campaign_details →
+  campaign_daily_metrics`), summing the new column for the client+window; assert match
+  (exact for faithful remaps; for genuine recomputations, record both for human sign-off).
+- No local Snowflake creds in this env — Metabase `/api/dataset` is the SQL gateway.
+
+## 7. Sizing & match-coverage (measured 2026-06-03, offline over audit cache)
+
+Old/new columns are authoritative (Snowflake `information_schema`): old = positional
+`CONVERSIONS`, `CONVERSIONS_1..19`, `CONVERSION_VALUE`, `CONVERSION_1..19_VALUE`; new =
+`CUSTOM_CONVERSIONS_1..15(+_VALUE)` + named (`PURCHASES`, `LEADS`, `INITIATE_CHECKOUTS`,
+`SIGN_UPS`, `MARKETING_/SALES_QUALIFIED_LEADS`, `OFFLINE_SALES`, `ORGANIC_/PAID_SEARCH_VISITS`,
+`SEARCH_VISITS_COMBO`, `*_NEW`…).
+
+Over 5,659 cached cards:
+
+- **1,451** old-conversion cards; **1,114 live on dashboards** (target set); **337 dormant** (ignore).
+- Targets span 23,409 dashboard placements; displays: table 309 / smartscalar 301 / line 202 /
+  pie 109 / combo 78 / bar 78 / …; metric kinds: COUNT 611 / CAC 159 / ROAS 117 / RATE 114 / VALUE 65 / …
+- New tree: **2,095** cards — a clean generated grid (line/bar/pie/smartscalar/combo/table ×
+  COUNT/VALUE/CAC/COS/CR/ROAS × ~20 breakdowns incl. date, channel, network, category, country,
+  location, device, product, type, url, segment, adset, adgroup).
+- **Auto-match coverage** (shape = display+metric+breakdown, type-agnostic): **77%** strict
+  (862/1114), **93%** on display+metric only. Unmatched ~23% = low-frequency long tail
+  (funnels, brand/non-brand pies, `by medium/url/page`) → **review queue**, mostly 1–16 each.
+
+Implication: structural matching resolves ~3/4 automatically; the type-axis comes from Airtable;
+a bounded review queue (~80–250 distinct cards) needs human/agent sign-off. (Heuristic here is
+name-based/approximate; the tool will match structurally on SQL + viz.)
+
+## 8. Scaling plan (agents + task tracking)
+
+1. **Ingest mapping** from Airtable `apptzpE1FqCMGH0dw/tbliHOIPYGJCvLvas` → per-client
+   `{old slot/type → new named type}`. *(Pending Airtable auth to finalise schema.)*
+2. **Index the new tree** (11673): build `{new type × chart shape × variant → card_id}`.
+3. **Discover targets:** under each client collection in `317`, list **custom**
+   dashboards (exclude templates); for each, find tiles whose card uses an old
+   conversion column. Scope = **every card touching a conversion column** (incl.
+   value / CR / CAC / COS / ROAS / combos / funnels).
+4. **Unit of work = one custom dashboard.** Task tracker: one task per (client, dashboard).
+   Per task: snapshot → migrate all conversion tiles → validate → write report +
+   rollback artifact. Ambiguous matches → review queue, not auto-applied.
+5. **Orchestration:** agents run the validated tool per dashboard in parallel; a tracker
+   records status, diffs, and any review-queue items. Roll out in waves
+   (1 client end-to-end → sample → batch), mirroring the cleaning-roadmap discipline.
+
+## 9. Open questions / risks
+
+- **Airtable type-axis** — ✅ resolved: `type`(slot)→`new_type`(named), per-client,
+  consistent across accounts (see §2). Residual risk: some (client, slot) have empty
+  `new_type` (unmapped) → review/skip; and a few clients may have slot conflicts across
+  accounts → flag. Ingestion = group rows by `brand_name` where `type` non-empty.
+- **Custom-dashboard population** — how many custom dashboards per client (under `317`),
+  and how many conversion tiles each → the true project size. Needs a dashboard crawl +
+  a custom-vs-template heuristic (exclude names like "template"/"Spec"). *(plan step 8.3)*
+- **Match review queue** — measured ~23% long tail (~80–250 cards). Confirm tool's
+  structural matcher (SQL+viz, not names) lifts strict coverage above the 77% estimate.
+- **Standard-conversion value change** — validate one slot-0 `conversions` → `Purchases`
+  case where the number genuinely changes, before batch (the Custom-1 test had old==new).
+- **Tile titles** — preserved as-is (e.g. "NC (Platform data)"); renaming out of scope.
+
+## 10. Safety
+
+Copy-first for tests; snapshot + PUT for live; never archive shared templates; never
+auto-apply ambiguous matches; reversible at every step (restore dashcards from snapshot).

--- a/docs/superpowers/specs/2026-06-20-metabase-pre-apply-validation-design.md
+++ b/docs/superpowers/specs/2026-06-20-metabase-pre-apply-validation-design.md
@@ -1,0 +1,150 @@
+# Pre-apply validation layer + repo ménage léger — Design
+
+- **Date**: 2026-06-20
+- **Status**: Proposed (awaiting review)
+- **Author**: Louis + Claude (principal-eng pairing)
+
+## 1. Context & motivation
+
+Spark drives a live **Metabase + Snowflake** estate via the REST API: an IaC module
+(`iac.py`, declarative YAML `plan`/`apply`) plus ~70 operational scripts that mutate
+client dashboards/cards in bulk. **Neither has any pre-apply validation.** The only
+safety net today is a manual "differential test" (run a card before/after a change,
+eyeball the numbers) applied ad hoc per campaign.
+
+Our incident history is the design driver. The bugs that actually hurt — wrong
+conversion-column mapping, SERP `CTR>100`, multi-GSC paid-metric inflation ×N — **did
+not error**. They ran fine and produced wrong numbers. A correctness gate alone catches
+none of them; the differential test catches all of them. So the validator must do both.
+
+We evaluated Metabase's official [`agent-skills`](https://github.com/metabase/agent-skills)
+repo. It does **not** replace this repo (8 of 11 skills are embedding/SSO/SDK or learning,
+outside our domain). We take the *ideas* of three skills, rebuilt natively — live/REST,
+**no Enterprise JAR / Docker dependency**:
+
+| Skill source | What we take |
+|---|---|
+| `metabase-semantic-checker` | referential-integrity + query-correctness checks (live, not via the EE JAR) |
+| `metabase-representation-format` | the canonical entity schema for structural validation + `entity_id` as stable identity (field already in our specs) |
+| `metabase-cli` | a unified `spark-metabase validate` command + report/exit-code ergonomics |
+
+## 2. Goals / non-goals
+
+**Goals**
+- One reusable validation core, consumed by `iac.apply()`, the durable campaign libs, and a `spark-metabase validate` CLI.
+- Four checks, cheap→expensive, fail-fast: `structure → refs → execution → differential`.
+- **Execution is the source of truth**: run the real query via Metabase (same path the dashboard uses).
+- Differential regression detection with **caller-declared intent** (`identical` vs `monitor`).
+- A light repo ménage (Phase 0) that separates the durable core from spent one-shot scripts and commits the uncommitted critical work.
+
+**Non-goals (YAGNI)**
+- No chatbot integration (unused experiment).
+- No Enterprise serialization / JAR / Docker.
+- No static-only metadata cache — we execute instead.
+- No destroy-aware Terraform, no cross-instance migration, no embedding/SSO/SDK.
+- Phase 0 is relocation + cleanup, **not** a rewrite of the scripts.
+
+## 3. Phase 0 — Ménage léger (first, separate PR)
+
+**Why first**: it tells the validation layer exactly which libs survive and deserve wiring.
+
+Target layout:
+```
+scripts/
+  lib/             durable, reusable, tested libs (conv, bascule, swap, audit, rename, reorg, audit_report)
+  campaigns/<nom>/ one-shot drivers + their tracker/HANDOFF docs (archived, reversible via git mv)
+  *.py             (flat root emptied of disposable drivers and version-cruft)
+```
+Rules:
+1. **Commit first** the untracked durable libs + their tests (`conv_lib`, `bascule_lib`,
+   `test_conv_lib`, `test_bascule_lib`, `test_conv_tracker`, …). This work currently exists
+   only on the local machine (bus-factor).
+2. **Kill version-cruft**: keep the winning version, delete superseded `_v2`/`_v3`
+   (`build_seo_dashboard{,_v2}`, `build_seo_monitoring{,_v2}`, `probe{,_v2}`, …). The
+   concrete keep/delete list is generated from evidence and **confirmed before any deletion**.
+3. **Relocate** spent one-shot drivers (`apply_fixes_32496`, `*_24576`,
+   `add_quizroom_disclaimer`, finished `migrate_client`, …) into `scripts/campaigns/<nom>/`
+   with their docs, via `git mv` (reversible).
+4. Fix import paths broken by relocation; `pytest` green before merge.
+
+## 4. Phase 1 — Validation layer
+
+New module `spark_metabase_api/validate.py`.
+
+### 4.1 Target abstraction
+A `Target` normalizes the three things we validate into common **card units**:
+- an `iac.CollectionSpec` (cards/dashboards declared, pre-apply),
+- a raw card payload a campaign lib is about to PUT,
+- a live card/dashboard by id.
+
+Each card unit carries `dataset_query`, `display`, `visualization_settings`, identity, and
+an optional `live_card_id` (for baseline capture).
+
+### 4.2 Check pipeline
+Per card unit, fail-fast cheap→expensive; units run in parallel; **only the touched scope**
+is validated (never the whole instance).
+
+1. **`check_structure(unit)`** — our own structural rules, informed by the
+   representation-format conventions (no dependency on Metabase's schema files): required
+   fields present, `display` is a known type, `visualization_settings` shape valid,
+   `dataset_query` has `database` + (`native.query` | MBQL `query`). Offline. → **error** on fail. *(representation-format)*
+2. **`check_refs(unit, client)`** — every reference resolves: `collection_id`,
+   `dashboard_id`, dashcard `card_id`, `parameter_mappings` targets, field-filter
+   `values_source_config.card_id`. Intra-spec forward refs reuse `iac._resolve_card_names`;
+   plus live lookups. → **error** on dangling ref. *(semantic-checker)*
+3. **`check_execution(unit, client)`** — run the real query and inspect the result:
+   - saved card → `POST /api/card/:id/query`; not-yet-created → `POST /api/dataset` with the
+     `dataset_query` (+ default values for native template-tags / field filters).
+   - → **error** if the query fails; **warn** if 0 rows (configurable) or expected columns missing. *(toujours exécuter)*
+4. **`check_differential(baseline, after, mode)`** — only for updates with a baseline.
+   Compares row count, column set, and the sum of each numeric column.
+   - `mode=identical` (result-preserving refactors: anti-pattern fixes, swaps) → any change beyond tolerance (default tolerance = 0, i.e. exact) = **error**.
+   - `mode=monitor` (intentional changes: conversion migration) → changes reported as **warn**.
+   - metric: **auto** (row count + column set + per-numeric-column sums) with optional per-card **override** (pin columns / set tolerance). *(your differential test, automated)*
+
+### 4.3 Report model
+`Finding{target, level (error|warn|ok), check, message, before?, after?}`.
+`Report` aggregates findings, has `.render()` (Terraform-style glyphs, like `iac.Plan`) and
+maps to a process exit code (non-zero on any `error`). Findings are **collected, not raised
+mid-batch**, so a bulk run yields a full picture.
+
+### 4.4 Around-apply orchestration
+The differential is inherently before/after, so the validator exposes building blocks and a
+guarded wrapper:
+```
+for each card unit being updated:
+    baseline = capture(client, card_id)        # if differential enabled
+pre-apply gate: structure + refs + execution   # abort, do NOT mutate, if any error
+mutate (PUT/POST)
+after = execute(client, card_id)
+report += check_differential(baseline, after, mode)
+```
+For creates: no baseline; gate + post-create execution only.
+
+### 4.5 Integration points
+- `iac.apply(client, spec, ..., validate=True, differential="monitor", force=False)` — runs
+  the gate before mutating; aborts on error unless `force`.
+- Campaign libs call `validate.guarded_apply(client, payload, mutate_fn, mode=...)`.
+- CLI: `spark-metabase validate <spec.yaml | collection-name/id | card-id> [--differential identical|monitor|off] [--no-execute]`.
+
+### 4.6 Wrapper additions
+- Thin `run_query(dataset_query)` (POST `/api/dataset`); reuse existing `get_card_data` for saved cards.
+- *Nice-to-have, not v1-blocking*: retry/backoff hardening on the shared session.
+
+## 5. Error handling / safety
+- The pre-apply gate **never mutates** on error; default is abort, `--force` overrides (logged).
+- `--no-execute` falls back to `structure`+`refs` only (fast smoke check) — escape hatch when the warehouse is down.
+
+## 6. Testing
+- Each check is a pure-ish function tested in isolation (mock client / fixture payloads), mirroring our `test_*_lib.py` culture.
+- `Report.render()` snapshot-tested.
+- Differential logic unit-tested with synthetic before/after result sets (identical / dropped rows / sum drift / new column).
+- An opt-in live phase extends `tests/integration_test.py` against a sandbox collection.
+
+## 7. Decisions & risks
+- **Decided** (delegated to eng judgment): differential metric = auto (row count + column set + per-numeric-column sums) + optional per-card override.
+- **Risk**: native SQL with required template-tags / field filters needs default param values
+  to execute via `/api/dataset`. *Mitigation*: derive defaults from the card's `template-tags`;
+  else fall back to `/api/card/:id/query` for saved cards, and flag un-runnable unsaved cards
+  as **warn** ("execution skipped: needs params").
+- **Risk**: Phase 0 relocation breaks imports. *Mitigation*: `git mv` + import fix + green `pytest` gate before merge.

--- a/migration/antipattern-workflow.js
+++ b/migration/antipattern-workflow.js
@@ -1,0 +1,208 @@
+export const meta = {
+  name: 'sql-antipattern-audit',
+  description: 'Classify Metabase native cards for 2 SQL anti-patterns (kp JOIN missing language/zone; eaten regex escape), then adversarially verify every BUG',
+  phases: [
+    { title: 'Analyze', detail: 'one auditor per candidate card reads its SQL and renders a verdict' },
+    { title: 'Verify', detail: 'diverse-lens skeptics try to refute each BUG' },
+  ],
+}
+
+// Task list injected by build_antipattern_workflow.py (metadata only, no SQL —
+// each agent reads its own .sql file from disk).
+const TASKS = [{"task_id": "A-28512", "antipattern": "A", "card_id": 28512, "name": "Average bid cost (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28512.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": [11747, 13158, 16953]}, {"task_id": "A-28551", "antipattern": "A", "card_id": 28551, "name": "Best opportunity keywords (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28551.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics", "kp__keyword_aggregated_metrics"], "dashboards": [11747, 16953]}, {"task_id": "A-31648", "antipattern": "A", "card_id": 31648, "name": "Client rank group, estimated traffic, rank absolute, rank group, search volume by keyword, rank gap, url (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31648.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-15943", "antipattern": "A", "card_id": 15943, "name": "Concurrence scatter plot [share of voice vs presence top 10, scale estimated traffic] (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15943.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11509, 11721, 11747, 11885]}, {"task_id": "A-15948", "antipattern": "A", "card_id": 15948, "name": "Corpus search volume distribution (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15948.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11721, 11747, 11885, 11943, 12993]}, {"task_id": "A-28549", "antipattern": "A", "card_id": 28549, "name": "Flop trending keywords (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28549.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics", "kp__keyword_aggregated_metrics"], "dashboards": [11747, 16953]}, {"task_id": "A-15949", "antipattern": "A", "card_id": 15949, "name": "Keyword insights [focus client] (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15949.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993]}, {"task_id": "A-15999", "antipattern": "A", "card_id": 15999, "name": "Keyword insights [focus SERP functionality]", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15999.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11721, 11885, 11943, 12993]}, {"task_id": "A-15953", "antipattern": "A", "card_id": 15953, "name": "Keyword insights [top kw competitors] (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15953.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11721, 11747, 11885, 11943, 12993]}, {"task_id": "A-15952", "antipattern": "A", "card_id": 15952, "name": "Keyword insights [top kw corpus] (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15952.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993, 13489, 15176]}, {"task_id": "A-32433", "antipattern": "A", "card_id": 32433, "name": "Keyword insights w/ historic comparison [top kw corpus] (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-32433.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [14780, 17250, 17481, 17977, 18042, 18544, 19560, 20022]}, {"task_id": "A-16326", "antipattern": "A", "card_id": 16326, "name": "Keyword insights w/ SERP functionalities [focus client] (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-16326.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11376, 11721, 11747, 11885, 11943, 12993]}, {"task_id": "A-28100", "antipattern": "A", "card_id": 28100, "name": "Keyword overlap | table (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28100.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157]}, {"task_id": "A-32496", "antipattern": "A", "card_id": 32496, "name": "Keywords average ranking by date (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-32496.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [17250]}, {"task_id": "A-15938", "antipattern": "A", "card_id": 15938, "name": "KP monthly | Duplicates", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15938.sql", "has_join": false, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11343]}, {"task_id": "A-16650", "antipattern": "A", "card_id": 16650, "name": "Market share by domain (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-16650.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11509]}, {"task_id": "A-16707", "antipattern": "A", "card_id": 16707, "name": "Market share (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-16707.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11509]}, {"task_id": "A-31641", "antipattern": "A", "card_id": 31641, "name": "Max traffic on best possible keyword rankings (monthly) (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31641.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-15939", "antipattern": "A", "card_id": 15939, "name": "Monthly estimated traffic by domain (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15939.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11721, 11747, 11885, 11943, 12993]}, {"task_id": "A-15937", "antipattern": "A", "card_id": 15937, "name": "Monthly estimated traffic only on client position keywords (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15937.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-18400", "antipattern": "A", "card_id": 18400, "name": "Monthly max estimated traffic on best possible keyword rankings (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-18400.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 12993, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-15942", "antipattern": "A", "card_id": 15942, "name": "Monthly max estimated traffic only on client position keywords (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15942.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993, 14780, 17481, 17977, 18042, 18544, 19560, 20022]}, {"task_id": "A-28550", "antipattern": "A", "card_id": 28550, "name": "Most expensive keywords (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28550.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics", "kp__keyword_aggregated_metrics"], "dashboards": [11747, 16953]}, {"task_id": "A-28614", "antipattern": "A", "card_id": 28614, "name": "Performances by keyword (GSC) | Quiz Room", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28614.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [13587, 14577]}, {"task_id": "A-31645", "antipattern": "A", "card_id": 31645, "name": "Ranking, share of voice by domain (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31645.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-15946", "antipattern": "A", "card_id": 15946, "name": "Search volume by month (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15946.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993, 18544, 20022]}, {"task_id": "A-28206", "antipattern": "A", "card_id": 28206, "name": "Search volume by month (SERP) w/ date filter", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28206.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [12069, 13257, 13489, 15176]}, {"task_id": "A-28513", "antipattern": "A", "card_id": 28513, "name": "Search volume by month YoY (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28513.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11747, 13158, 16953]}, {"task_id": "A-16708", "antipattern": "A", "card_id": 16708, "name": "Search volume last month (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-16708.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11509]}, {"task_id": "A-48633", "antipattern": "A", "card_id": 48633, "name": "SEO Keyword Monitoring — Manucurist (model)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-48633.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-28715", "antipattern": "A", "card_id": 28715, "name": "SEO/SEA synergy by keyword", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28715.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": [10189, 14911, 19335]}, {"task_id": "A-30516", "antipattern": "A", "card_id": 30516, "name": "SEO/SEA synergy by keyword (IA report) | Ecommerce", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-30516.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": []}, {"task_id": "A-30517", "antipattern": "A", "card_id": 30517, "name": "SEO/SEA synergy by keyword (IA report) | Lead gen", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-30517.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": []}, {"task_id": "A-16647", "antipattern": "A", "card_id": 16647, "name": "SEO value (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-16647.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993, 15831]}, {"task_id": "A-31642", "antipattern": "A", "card_id": 31642, "name": "SEO value (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31642.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": []}, {"task_id": "A-28471", "antipattern": "A", "card_id": 28471, "name": "Share of voice by domain, top 100 only (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28471.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11747]}, {"task_id": "A-15941", "antipattern": "A", "card_id": 15941, "name": "Share of voice by domain, top 10 only (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15941.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11747, 11885, 11943, 12993, 19758]}, {"task_id": "A-28923", "antipattern": "A", "card_id": 28923, "name": "Share of voice by domain, top 10 only w/ historic comparison (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28923.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 14780, 17250, 17481, 17977, 18042, 18544, 19560, 20022]}, {"task_id": "A-38733", "antipattern": "A", "card_id": 38733, "name": "Share of voice client all extraction dates (SERP) | Arrago", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-38733.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-15940", "antipattern": "A", "card_id": 15940, "name": "Share of voice client (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-15940.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 11509, 11721, 11885, 11943, 12993, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-31609", "antipattern": "A", "card_id": 31609, "name": "Share of voice (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31609.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-28922", "antipattern": "A", "card_id": 28922, "name": "Share of voice w/ historic comparison (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28922.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 14780, 17250, 17481, 17977, 18042, 18544, 19560, 20022]}, {"task_id": "A-34378", "antipattern": "A", "card_id": 34378, "name": "Spark score (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-34378.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_aggregated_metrics"], "dashboards": [10157]}, {"task_id": "A-31611", "antipattern": "A", "card_id": 31611, "name": "Top keyword client : position 11 to 30, top 10 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31611.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-31610", "antipattern": "A", "card_id": 31610, "name": "Top keyword client : position 4 to 10, top 10 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-31610.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": []}, {"task_id": "A-28554", "antipattern": "A", "card_id": 28554, "name": "Top keywords & associated competitor results", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28554.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11747, 16953]}, {"task_id": "A-28553", "antipattern": "A", "card_id": 28553, "name": "Top keywords & associated top result (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28553.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11747]}, {"task_id": "A-28869", "antipattern": "A", "card_id": 28869, "name": "Top kw client position 11 to 30 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28869.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-28867", "antipattern": "A", "card_id": 28867, "name": "Top kw client position 1 to 3 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28867.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-28870", "antipattern": "A", "card_id": 28870, "name": "Top kw client position 31 to 100 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28870.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-28868", "antipattern": "A", "card_id": 28868, "name": "Top kw client position 4 to 10 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28868.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "A-28547", "antipattern": "A", "card_id": 28547, "name": "Top trending keywords (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28547.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics", "kp__keyword_aggregated_metrics"], "dashboards": [11747, 16953]}, {"task_id": "A-28125", "antipattern": "A", "card_id": 28125, "name": "Total corpus search volumes YoY (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/A-28125.sql", "has_join": true, "mentions_airtable_record_id": false, "kp_tables": ["kp__keyword_monthly_metrics"], "dashboards": [11747, 13158, 16953]}, {"task_id": "B-11277", "antipattern": "B", "card_id": 11277, "name": "audit details | naming des éléments de structure non conforme | --", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-11277.sql", "regex_funcs": ["REGEXP_LIKE"], "escaped_metachars": ["\\|"], "dashboards": []}, {"task_id": "B-11276", "antipattern": "B", "card_id": 11276, "name": "audit | naming des éléments de structure non conforme | --", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-11276.sql", "regex_funcs": ["REGEXP_LIKE"], "escaped_metachars": ["\\|"], "dashboards": []}, {"task_id": "B-35963", "antipattern": "B", "card_id": 35963, "name": "Benchmark blended CTR agency level", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-35963.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11917]}, {"task_id": "B-36028", "antipattern": "B", "card_id": 36028, "name": "Benchmark blended CTR e-commerce", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-36028.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11917]}, {"task_id": "B-36027", "antipattern": "B", "card_id": 36027, "name": "Benchmark blended CTR lead gen", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-36027.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11917]}, {"task_id": "B-35632", "antipattern": "B", "card_id": 35632, "name": "Benchmark blended CTR (model) by date", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-35632.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11917]}, {"task_id": "B-35631", "antipattern": "B", "card_id": 35631, "name": "Blended CTR agency level by date", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-35631.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11917]}, {"task_id": "B-16748", "antipattern": "B", "card_id": 16748, "name": "Blended CTR, cost by date (cross search)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-16748.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11666, 11702, 11917, 11920, 12898, 12974, 13885, 17151, 17184, 18801, 21210, 23589]}, {"task_id": "B-16756", "antipattern": "B", "card_id": 16756, "name": "Blended CTR [total = paid + organic] (cross search)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-16756.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11666, 11917, 11920, 12898, 12974, 13885, 18801]}, {"task_id": "B-31011", "antipattern": "B", "card_id": 31011, "name": "CTR [paid only] (brand monitoring) - smartscallar", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-31011.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11702, 17151, 17184, 21210, 23589]}, {"task_id": "B-8233", "antipattern": "B", "card_id": 8233, "name": "goals checked by date", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-8233.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\[", "\\]"], "dashboards": [6160]}, {"task_id": "B-32496", "antipattern": "B", "card_id": 32496, "name": "Keywords average ranking by date (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-32496.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\."], "dashboards": [17250]}, {"task_id": "B-31641", "antipattern": "B", "card_id": 31641, "name": "Max traffic on best possible keyword rankings (monthly) (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-31641.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\."], "dashboards": []}, {"task_id": "B-18400", "antipattern": "B", "card_id": 18400, "name": "Monthly max estimated traffic on best possible keyword rankings (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-18400.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\."], "dashboards": [10157, 12993, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "B-16747", "antipattern": "B", "card_id": 16747, "name": "Paid clicks, organic clicks, no clicks by date [stack 100%] (cross search)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-16747.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11666, 11702, 11917, 11920, 12898, 12974, 13885, 17151, 17184, 18801, 21210, 23589]}, {"task_id": "B-16746", "antipattern": "B", "card_id": 16746, "name": "Paid clicks, organic clicks, no clicks by date [stack] (cross search)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-16746.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11666, 11702, 11917, 11920, 12898, 12974, 13885, 17151, 17184, 18801, 21210, 23589]}, {"task_id": "B-16739", "antipattern": "B", "card_id": 16739, "name": "Paid/SEO impressions allocation by date (cross search)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-16739.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11666, 11702, 11917, 11920, 12898, 12974, 13885, 17151, 17184, 18801, 21210, 23589]}, {"task_id": "B-16749", "antipattern": "B", "card_id": 16749, "name": "Paid/SEO impressions allocation by keyword (cross search)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-16749.sql", "regex_funcs": ["REGEXP_REPLACE", "REGEXP_LIKE"], "escaped_metachars": ["\\(", "\\)", "\\?"], "dashboards": [11666, 11702, 11917, 11920, 12898, 13885, 17151, 17184, 18801, 21210, 23589]}, {"task_id": "B-8235", "antipattern": "B", "card_id": 8235, "name": "paused accounts by checkpoint", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-8235.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\[", "\\]"], "dashboards": [6160]}, {"task_id": "B-8232", "antipattern": "B", "card_id": 8232, "name": "ratio valid checks by date", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-8232.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\[", "\\]"], "dashboards": [6160]}, {"task_id": "B-14908", "antipattern": "B", "card_id": 14908, "name": "SERP corpus details", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-14908.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\."], "dashboards": [10157, 11509, 11721, 11732, 11747, 11885, 11943, 12993, 14780, 17250, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "B-31611", "antipattern": "B", "card_id": 31611, "name": "Top keyword client : position 11 to 30, top 10 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-31611.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\.", "\\?"], "dashboards": []}, {"task_id": "B-31610", "antipattern": "B", "card_id": 31610, "name": "Top keyword client : position 4 to 10, top 10 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-31610.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\.", "\\?"], "dashboards": []}, {"task_id": "B-28554", "antipattern": "B", "card_id": 28554, "name": "Top keywords & associated competitor results", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-28554.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\."], "dashboards": [11747, 16953]}, {"task_id": "B-28869", "antipattern": "B", "card_id": 28869, "name": "Top kw client position 11 to 30 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-28869.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\.", "\\?"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "B-28867", "antipattern": "B", "card_id": 28867, "name": "Top kw client position 1 to 3 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-28867.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\.", "\\?"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "B-28870", "antipattern": "B", "card_id": 28870, "name": "Top kw client position 31 to 100 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-28870.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\.", "\\?"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "B-28868", "antipattern": "B", "card_id": 28868, "name": "Top kw client position 4 to 10 (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-28868.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\.", "\\?"], "dashboards": [10157, 14780, 17481, 17977, 18042, 18544, 19560, 19758, 20022]}, {"task_id": "B-28125", "antipattern": "B", "card_id": 28125, "name": "Total corpus search volumes YoY (SERP)", "path": "/Users/louismonier/Dev/Pro/spark-metabase-api/migration/antipattern-tasks/B-28125.sql", "regex_funcs": ["REGEXP_REPLACE"], "escaped_metachars": ["\\."], "dashboards": [11747, 13158, 16953]}];
+
+const ANALYSIS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['card_id', 'antipattern', 'verdict', 'confidence', 'evidence',
+             'reasoning', 'fix_find', 'fix_replace', 'review_question', 'inflation_note'],
+  properties: {
+    card_id: { type: 'integer' },
+    antipattern: { type: 'string', enum: ['A', 'B'] },
+    verdict: { type: 'string', enum: ['BUG', 'OK', 'REVIEW'] },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    evidence: { type: 'string', description: 'Exact SQL extract that is the crux (the JOIN..ON for A, the REGEXP pattern literal for B)' },
+    reasoning: { type: 'string', description: 'Why this verdict, citing the SQL' },
+    fix_find: { type: 'string', description: 'Exact substring to find for a copy-paste fix; empty string if not BUG' },
+    fix_replace: { type: 'string', description: 'Exact replacement substring; empty string if not BUG' },
+    review_question: { type: 'string', description: 'For REVIEW: the precise question a human must resolve; else empty' },
+    inflation_note: { type: 'string', description: 'For A BUG: which displayed metric inflates and rough factor; else empty' },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['refuted', 'corrected_verdict', 'reason'],
+  properties: {
+    refuted: { type: 'boolean', description: 'true if the BUG claim is WRONG / does not hold' },
+    corrected_verdict: { type: 'string', enum: ['BUG', 'OK', 'REVIEW'] },
+    reason: { type: 'string', description: 'Concise justification citing the SQL' },
+  },
+}
+
+const TEMPLATING_NOTE =
+  'The SQL is Snowflake dialect and contains Metabase templating: {{client}}, {{date}}, ' +
+  '{{corpus_name}}, and optional [[ ... ]] blocks. Treat every template tag as an opaque ' +
+  'filter; NEVER try to execute the SQL. Base your verdict only on the static structure.'
+
+function analyzePromptA(t) {
+  return [
+    'You are a meticulous SQL auditor. Analyze EXACTLY ONE Metabase card for SQL anti-pattern A.',
+    '',
+    'Read the file (it starts with comment metadata, then the full native SQL): ' + t.path,
+    TEMPLATING_NOTE,
+    '',
+    'ANTI-PATTERN A — cartesian JOIN on keyword-planner tables.',
+    'The tables google_keyword_planner.kp__keyword_monthly_metrics and kp__keyword_aggregated_metrics',
+    'store the SAME keyword under MULTIPLE (language, zone) pairs (one client can have corpora for',
+    'France, Germany, Netherlands, UK...). Joining such a table ON the keyword column ALONE — without',
+    'also matching the kp table language AND zone columns — produces a cartesian fan-out: each source',
+    'row matches N kp rows, so SUM/aggregates of volume/traffic/cost inflate (x2-3) for multi-zone clients.',
+    '',
+    'VERDICT RUBRIC (judge the CURRENT SQL in the file):',
+    '- BUG: a JOIN to a kp__ table whose ON clause matches the keyword column but matches NEITHER the kp',
+    '       language NOR the kp zone column, and nothing upstream guarantees a single (language,zone) per keyword.',
+    '- OK:  every kp__ JOIN matches keyword AND language AND zone (a month/date equality may also appear).',
+    '       Calibration: card 15946 currently matches keyword+language+zone -> OK. Its historical BUG form',
+    '       matched the keyword only.',
+    '- REVIEW: genuinely ambiguous — the kp table is reached via subquery/implicit join; OR the rows feeding',
+    '       the join are already reduced to one (language,zone) per keyword upstream (QUALIFY ROW_NUMBER,',
+    '       GROUP BY, DISTINCT); OR an upstream filter on airtable_record_id scopes to a single corpus',
+    '       (known heuristic: such a filter usually removes the cartesian risk -> lean OK, but use REVIEW',
+    '       with a clear note if you are not certain). Quote the exact extract and pose the precise question.',
+    '',
+    'Track table aliases carefully (the kp table is usually aliased, e.g. AS kp; the source another alias).',
+    'If BUG: set fix_find to the EXACT current ON-clause text copied verbatim from the file, and fix_replace',
+    'to that same text with two equalities ADDED matching the kp language/zone to the source language/zone',
+    '(use the real aliases you see). evidence = the exact "JOIN ... ON ..." extract. inflation_note = which',
+    'displayed metric inflates (the SUM/aggregate) and a rough factor if inferable.',
+    'Set card_id=' + t.card_id + ', antipattern="A".',
+  ].join('\n')
+}
+
+function analyzePromptB(t) {
+  return [
+    'You are a meticulous SQL auditor. Analyze EXACTLY ONE Metabase card for SQL anti-pattern B.',
+    '',
+    'Read the file (comment metadata, then the full native SQL): ' + t.path,
+    TEMPLATING_NOTE,
+    '',
+    'ANTI-PATTERN B — eaten regex escape in Snowflake.',
+    'In Snowflake REGEXP_* / RLIKE the pattern is a SQL string literal. A SINGLE backslash before a regex',
+    'metacharacter (dot, question-mark, plus, parentheses, brackets, braces, pipe, caret, dollar, star) is',
+    'NOT honored as the author expects: the backslash is consumed and the metacharacter KEEPS its special',
+    'meaning. The classic case: a backslash before a dot, intended to match a LITERAL dot, instead matches',
+    'ANY single character. Confirmed impact: a Share-of-Voice query used backslash-dot to anchor a domain',
+    'suffix and instead mis-stripped a character (e.g. domain handling for manucurist.com went wrong ->',
+    'Share of Voice 118%). The correct robust form is a CHARACTER CLASS: wrap the metachar in [ ] (a literal',
+    'dot becomes the two-character class open-bracket dot close-bracket).',
+    '',
+    'VERDICT RUBRIC (judge the CURRENT SQL):',
+    '- BUG: a REGEXP pattern contains a single-backslash-escaped metacharacter CLEARLY meant as a LITERAL',
+    '       (matching/stripping a real dot, parenthesis, etc. in a domain, URL, or number), so the eaten',
+    '       escape changes matching and thus the card output.',
+    '- OK:  the metachar is already inside a character class, OR its special meaning is actually intended,',
+    '       OR the difference cannot affect this card result.',
+    '- REVIEW: intent genuinely ambiguous — quote the pattern and pose the question.',
+    '',
+    'For each REGEXP call, extract the pattern string literal and reason about author intent. If BUG: fix_find',
+    '= the exact pattern literal as written in the file; fix_replace = the corrected pattern (wrap each wrongly',
+    'escaped metachar in a character class). evidence = the exact REGEXP_... call. Set card_id=' + t.card_id + ', antipattern="B".',
+  ].join('\n')
+}
+
+const LENSES_A = [
+  { key: 'aliases', title: 'alias & ON-clause re-read',
+    body: 'Re-read the kp__ JOIN and ALL alias definitions. Verify the ON clause TRULY omits BOTH the kp ' +
+          'language and the kp zone columns. Perhaps language/zone ARE matched under different aliases, via ' +
+          'USING, or via an equivalent WHERE/QUALIFY predicate; or the prior auditor misread a non-kp join. ' +
+          'If matching on language/zone is in fact present, refute.' },
+  { key: 'upstream', title: 'upstream dedup / scoping',
+    body: 'Determine the row grain feeding the kp JOIN. If an upstream CTE already reduces to exactly one ' +
+          '(language,zone) per keyword (QUALIFY ROW_NUMBER, GROUP BY, DISTINCT), or the query is scoped to a ' +
+          'single corpus via airtable_record_id, the cartesian fan-out does not occur on real data -> verdict ' +
+          'should be OK/REVIEW. Refute if such a guard exists.' },
+  { key: 'impact', title: 'does it actually inflate output',
+    body: 'Check how the kp columns are consumed. If they are aggregated immune to row duplication (MAX of a ' +
+          'per-keyword-constant column; or joined rows are de-duplicated by a later QUALIFY/DISTINCT/GROUP BY ' +
+          'before any SUM/COUNT/AVG), the displayed metric is NOT inflated -> refute. Keep the bug only if a ' +
+          'SUM/COUNT/AVG over the fanned-out rows is actually displayed.' },
+]
+
+const LENSES_B = [
+  { key: 'intent', title: 'literal-intent check',
+    body: 'Is the escaped metacharacter truly meant as a literal? If it is already inside a character class, ' +
+          'or its regex special meaning is what the author wants, refute.' },
+  { key: 'behavior', title: 'behavioral impact',
+    body: 'Confirm Snowflake actually mis-handles this escape in a string-literal REGEXP pattern here AND that ' +
+          'it changes the card output (not a harmless cosmetic match). If there is no observable output ' +
+          'difference, refute.' },
+]
+
+function verifyPrompt(t, analysis, lens) {
+  return [
+    'You are an adversarial verifier. A prior auditor classified card #' + t.card_id + ' as a BUG for SQL',
+    'anti-pattern ' + t.antipattern + '. Try HARD to REFUTE the claim through ONE specific lens. Conclude',
+    'refuted=false only if the bug clearly survives your scrutiny.',
+    '',
+    'Read the SQL file: ' + t.path,
+    TEMPLATING_NOTE,
+    '',
+    'Prior auditor evidence: ' + (analysis.evidence || '(none)'),
+    'Prior auditor reasoning: ' + (analysis.reasoning || '(none)'),
+    'Proposed fix find: ' + (analysis.fix_find || '(none)'),
+    '',
+    'LENS — ' + lens.title + ':',
+    lens.body,
+    '',
+    'Decide: is the BUG claim wrong (refuted=true) or does it hold (refuted=false)? Give corrected_verdict',
+    '(BUG if it holds; OK or REVIEW if you refute) and a concise reason citing the SQL.',
+  ].join('\n')
+}
+
+log('Auditing ' + TASKS.length + ' candidate cards (' +
+    TASKS.filter(t => t.antipattern === 'A').length + ' for A, ' +
+    TASKS.filter(t => t.antipattern === 'B').length + ' for B)')
+
+const results = await pipeline(
+  TASKS,
+  // STAGE 1 — analyze
+  (t) => agent(t.antipattern === 'A' ? analyzePromptA(t) : analyzePromptB(t),
+               { label: 'analyze:' + t.task_id, phase: 'Analyze', schema: ANALYSIS_SCHEMA }),
+  // STAGE 2 — verify BUGs only (per item, no barrier)
+  async (analysis, t) => {
+    if (!analysis) {
+      return { ...t, analysis: null, verifications: [], final_verdict: 'ERROR', confirmed: null }
+    }
+    if (analysis.verdict !== 'BUG') {
+      return { ...t, analysis, verifications: [], final_verdict: analysis.verdict, confirmed: false }
+    }
+    const lenses = t.antipattern === 'A' ? LENSES_A : LENSES_B
+    const votes = (await parallel(lenses.map(L => () =>
+      agent(verifyPrompt(t, analysis, L),
+            { label: 'verify:' + t.task_id + ':' + L.key, phase: 'Verify', schema: VERDICT_SCHEMA })
+        .then(v => v ? { lens: L.key, ...v } : null)
+    ))).filter(Boolean)
+    const refutes = votes.filter(v => v.refuted).length
+    const need = Math.ceil(votes.length / 2)        // majority must NOT refute
+    const confirmed = votes.length > 0 && refutes < need
+    const final_verdict = confirmed ? 'BUG' : 'REVIEW'  // downgrade refuted bugs to human REVIEW
+    return { ...t, analysis, verifications: votes, refutes, votes_total: votes.length,
+             final_verdict, confirmed }
+  }
+)
+
+const clean = results.filter(Boolean)
+const tally = (verd) => clean.filter(r => r.final_verdict === verd).length
+log('Done. BUG=' + tally('BUG') + ' OK=' + tally('OK') + ' REVIEW=' + tally('REVIEW') + ' ERROR=' + tally('ERROR'))
+
+return {
+  summary: {
+    analyzed: clean.length,
+    bug: tally('BUG'), ok: tally('OK'), review: tally('REVIEW'), error: tally('ERROR'),
+    a: clean.filter(r => r.antipattern === 'A').length,
+    b: clean.filter(r => r.antipattern === 'B').length,
+  },
+  results: clean,
+}

--- a/migration/antipattern-workflow.template.js
+++ b/migration/antipattern-workflow.template.js
@@ -1,0 +1,208 @@
+export const meta = {
+  name: 'sql-antipattern-audit',
+  description: 'Classify Metabase native cards for 2 SQL anti-patterns (kp JOIN missing language/zone; eaten regex escape), then adversarially verify every BUG',
+  phases: [
+    { title: 'Analyze', detail: 'one auditor per candidate card reads its SQL and renders a verdict' },
+    { title: 'Verify', detail: 'diverse-lens skeptics try to refute each BUG' },
+  ],
+}
+
+// Task list injected by build_antipattern_workflow.py (metadata only, no SQL —
+// each agent reads its own .sql file from disk).
+const TASKS = __TASKS_JSON__;
+
+const ANALYSIS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['card_id', 'antipattern', 'verdict', 'confidence', 'evidence',
+             'reasoning', 'fix_find', 'fix_replace', 'review_question', 'inflation_note'],
+  properties: {
+    card_id: { type: 'integer' },
+    antipattern: { type: 'string', enum: ['A', 'B'] },
+    verdict: { type: 'string', enum: ['BUG', 'OK', 'REVIEW'] },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    evidence: { type: 'string', description: 'Exact SQL extract that is the crux (the JOIN..ON for A, the REGEXP pattern literal for B)' },
+    reasoning: { type: 'string', description: 'Why this verdict, citing the SQL' },
+    fix_find: { type: 'string', description: 'Exact substring to find for a copy-paste fix; empty string if not BUG' },
+    fix_replace: { type: 'string', description: 'Exact replacement substring; empty string if not BUG' },
+    review_question: { type: 'string', description: 'For REVIEW: the precise question a human must resolve; else empty' },
+    inflation_note: { type: 'string', description: 'For A BUG: which displayed metric inflates and rough factor; else empty' },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['refuted', 'corrected_verdict', 'reason'],
+  properties: {
+    refuted: { type: 'boolean', description: 'true if the BUG claim is WRONG / does not hold' },
+    corrected_verdict: { type: 'string', enum: ['BUG', 'OK', 'REVIEW'] },
+    reason: { type: 'string', description: 'Concise justification citing the SQL' },
+  },
+}
+
+const TEMPLATING_NOTE =
+  'The SQL is Snowflake dialect and contains Metabase templating: {{client}}, {{date}}, ' +
+  '{{corpus_name}}, and optional [[ ... ]] blocks. Treat every template tag as an opaque ' +
+  'filter; NEVER try to execute the SQL. Base your verdict only on the static structure.'
+
+function analyzePromptA(t) {
+  return [
+    'You are a meticulous SQL auditor. Analyze EXACTLY ONE Metabase card for SQL anti-pattern A.',
+    '',
+    'Read the file (it starts with comment metadata, then the full native SQL): ' + t.path,
+    TEMPLATING_NOTE,
+    '',
+    'ANTI-PATTERN A — cartesian JOIN on keyword-planner tables.',
+    'The tables google_keyword_planner.kp__keyword_monthly_metrics and kp__keyword_aggregated_metrics',
+    'store the SAME keyword under MULTIPLE (language, zone) pairs (one client can have corpora for',
+    'France, Germany, Netherlands, UK...). Joining such a table ON the keyword column ALONE — without',
+    'also matching the kp table language AND zone columns — produces a cartesian fan-out: each source',
+    'row matches N kp rows, so SUM/aggregates of volume/traffic/cost inflate (x2-3) for multi-zone clients.',
+    '',
+    'VERDICT RUBRIC (judge the CURRENT SQL in the file):',
+    '- BUG: a JOIN to a kp__ table whose ON clause matches the keyword column but matches NEITHER the kp',
+    '       language NOR the kp zone column, and nothing upstream guarantees a single (language,zone) per keyword.',
+    '- OK:  every kp__ JOIN matches keyword AND language AND zone (a month/date equality may also appear).',
+    '       Calibration: card 15946 currently matches keyword+language+zone -> OK. Its historical BUG form',
+    '       matched the keyword only.',
+    '- REVIEW: genuinely ambiguous — the kp table is reached via subquery/implicit join; OR the rows feeding',
+    '       the join are already reduced to one (language,zone) per keyword upstream (QUALIFY ROW_NUMBER,',
+    '       GROUP BY, DISTINCT); OR an upstream filter on airtable_record_id scopes to a single corpus',
+    '       (known heuristic: such a filter usually removes the cartesian risk -> lean OK, but use REVIEW',
+    '       with a clear note if you are not certain). Quote the exact extract and pose the precise question.',
+    '',
+    'Track table aliases carefully (the kp table is usually aliased, e.g. AS kp; the source another alias).',
+    'If BUG: set fix_find to the EXACT current ON-clause text copied verbatim from the file, and fix_replace',
+    'to that same text with two equalities ADDED matching the kp language/zone to the source language/zone',
+    '(use the real aliases you see). evidence = the exact "JOIN ... ON ..." extract. inflation_note = which',
+    'displayed metric inflates (the SUM/aggregate) and a rough factor if inferable.',
+    'Set card_id=' + t.card_id + ', antipattern="A".',
+  ].join('\n')
+}
+
+function analyzePromptB(t) {
+  return [
+    'You are a meticulous SQL auditor. Analyze EXACTLY ONE Metabase card for SQL anti-pattern B.',
+    '',
+    'Read the file (comment metadata, then the full native SQL): ' + t.path,
+    TEMPLATING_NOTE,
+    '',
+    'ANTI-PATTERN B — eaten regex escape in Snowflake.',
+    'In Snowflake REGEXP_* / RLIKE the pattern is a SQL string literal. A SINGLE backslash before a regex',
+    'metacharacter (dot, question-mark, plus, parentheses, brackets, braces, pipe, caret, dollar, star) is',
+    'NOT honored as the author expects: the backslash is consumed and the metacharacter KEEPS its special',
+    'meaning. The classic case: a backslash before a dot, intended to match a LITERAL dot, instead matches',
+    'ANY single character. Confirmed impact: a Share-of-Voice query used backslash-dot to anchor a domain',
+    'suffix and instead mis-stripped a character (e.g. domain handling for manucurist.com went wrong ->',
+    'Share of Voice 118%). The correct robust form is a CHARACTER CLASS: wrap the metachar in [ ] (a literal',
+    'dot becomes the two-character class open-bracket dot close-bracket).',
+    '',
+    'VERDICT RUBRIC (judge the CURRENT SQL):',
+    '- BUG: a REGEXP pattern contains a single-backslash-escaped metacharacter CLEARLY meant as a LITERAL',
+    '       (matching/stripping a real dot, parenthesis, etc. in a domain, URL, or number), so the eaten',
+    '       escape changes matching and thus the card output.',
+    '- OK:  the metachar is already inside a character class, OR its special meaning is actually intended,',
+    '       OR the difference cannot affect this card result.',
+    '- REVIEW: intent genuinely ambiguous — quote the pattern and pose the question.',
+    '',
+    'For each REGEXP call, extract the pattern string literal and reason about author intent. If BUG: fix_find',
+    '= the exact pattern literal as written in the file; fix_replace = the corrected pattern (wrap each wrongly',
+    'escaped metachar in a character class). evidence = the exact REGEXP_... call. Set card_id=' + t.card_id + ', antipattern="B".',
+  ].join('\n')
+}
+
+const LENSES_A = [
+  { key: 'aliases', title: 'alias & ON-clause re-read',
+    body: 'Re-read the kp__ JOIN and ALL alias definitions. Verify the ON clause TRULY omits BOTH the kp ' +
+          'language and the kp zone columns. Perhaps language/zone ARE matched under different aliases, via ' +
+          'USING, or via an equivalent WHERE/QUALIFY predicate; or the prior auditor misread a non-kp join. ' +
+          'If matching on language/zone is in fact present, refute.' },
+  { key: 'upstream', title: 'upstream dedup / scoping',
+    body: 'Determine the row grain feeding the kp JOIN. If an upstream CTE already reduces to exactly one ' +
+          '(language,zone) per keyword (QUALIFY ROW_NUMBER, GROUP BY, DISTINCT), or the query is scoped to a ' +
+          'single corpus via airtable_record_id, the cartesian fan-out does not occur on real data -> verdict ' +
+          'should be OK/REVIEW. Refute if such a guard exists.' },
+  { key: 'impact', title: 'does it actually inflate output',
+    body: 'Check how the kp columns are consumed. If they are aggregated immune to row duplication (MAX of a ' +
+          'per-keyword-constant column; or joined rows are de-duplicated by a later QUALIFY/DISTINCT/GROUP BY ' +
+          'before any SUM/COUNT/AVG), the displayed metric is NOT inflated -> refute. Keep the bug only if a ' +
+          'SUM/COUNT/AVG over the fanned-out rows is actually displayed.' },
+]
+
+const LENSES_B = [
+  { key: 'intent', title: 'literal-intent check',
+    body: 'Is the escaped metacharacter truly meant as a literal? If it is already inside a character class, ' +
+          'or its regex special meaning is what the author wants, refute.' },
+  { key: 'behavior', title: 'behavioral impact',
+    body: 'Confirm Snowflake actually mis-handles this escape in a string-literal REGEXP pattern here AND that ' +
+          'it changes the card output (not a harmless cosmetic match). If there is no observable output ' +
+          'difference, refute.' },
+]
+
+function verifyPrompt(t, analysis, lens) {
+  return [
+    'You are an adversarial verifier. A prior auditor classified card #' + t.card_id + ' as a BUG for SQL',
+    'anti-pattern ' + t.antipattern + '. Try HARD to REFUTE the claim through ONE specific lens. Conclude',
+    'refuted=false only if the bug clearly survives your scrutiny.',
+    '',
+    'Read the SQL file: ' + t.path,
+    TEMPLATING_NOTE,
+    '',
+    'Prior auditor evidence: ' + (analysis.evidence || '(none)'),
+    'Prior auditor reasoning: ' + (analysis.reasoning || '(none)'),
+    'Proposed fix find: ' + (analysis.fix_find || '(none)'),
+    '',
+    'LENS — ' + lens.title + ':',
+    lens.body,
+    '',
+    'Decide: is the BUG claim wrong (refuted=true) or does it hold (refuted=false)? Give corrected_verdict',
+    '(BUG if it holds; OK or REVIEW if you refute) and a concise reason citing the SQL.',
+  ].join('\n')
+}
+
+log('Auditing ' + TASKS.length + ' candidate cards (' +
+    TASKS.filter(t => t.antipattern === 'A').length + ' for A, ' +
+    TASKS.filter(t => t.antipattern === 'B').length + ' for B)')
+
+const results = await pipeline(
+  TASKS,
+  // STAGE 1 — analyze
+  (t) => agent(t.antipattern === 'A' ? analyzePromptA(t) : analyzePromptB(t),
+               { label: 'analyze:' + t.task_id, phase: 'Analyze', schema: ANALYSIS_SCHEMA }),
+  // STAGE 2 — verify BUGs only (per item, no barrier)
+  async (analysis, t) => {
+    if (!analysis) {
+      return { ...t, analysis: null, verifications: [], final_verdict: 'ERROR', confirmed: null }
+    }
+    if (analysis.verdict !== 'BUG') {
+      return { ...t, analysis, verifications: [], final_verdict: analysis.verdict, confirmed: false }
+    }
+    const lenses = t.antipattern === 'A' ? LENSES_A : LENSES_B
+    const votes = (await parallel(lenses.map(L => () =>
+      agent(verifyPrompt(t, analysis, L),
+            { label: 'verify:' + t.task_id + ':' + L.key, phase: 'Verify', schema: VERDICT_SCHEMA })
+        .then(v => v ? { lens: L.key, ...v } : null)
+    ))).filter(Boolean)
+    const refutes = votes.filter(v => v.refuted).length
+    const need = Math.ceil(votes.length / 2)        // majority must NOT refute
+    const confirmed = votes.length > 0 && refutes < need
+    const final_verdict = confirmed ? 'BUG' : 'REVIEW'  // downgrade refuted bugs to human REVIEW
+    return { ...t, analysis, verifications: votes, refutes, votes_total: votes.length,
+             final_verdict, confirmed }
+  }
+)
+
+const clean = results.filter(Boolean)
+const tally = (verd) => clean.filter(r => r.final_verdict === verd).length
+log('Done. BUG=' + tally('BUG') + ' OK=' + tally('OK') + ' REVIEW=' + tally('REVIEW') + ' ERROR=' + tally('ERROR'))
+
+return {
+  summary: {
+    analyzed: clean.length,
+    bug: tally('BUG'), ok: tally('OK'), review: tally('REVIEW'), error: tally('ERROR'),
+    a: clean.filter(r => r.antipattern === 'A').length,
+    b: clean.filter(r => r.antipattern === 'B').length,
+  },
+  results: clean,
+}

--- a/migration/conv-client-mapping.json
+++ b/migration/conv-client-mapping.json
@@ -1,0 +1,848 @@
+{
+"100% Print": {
+"0": "Purchases"
+},
+"24S": {
+"0": "Purchases",
+"1": "__UNMAPPED__",
+"2": "Custom 1",
+"3": "Organic search visits (custom conv meta)"
+},
+"900.care": {
+"0": "Purchases",
+"2": "__UNMAPPED__"
+},
+"AG2R La Mondiale": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"AMV Assurance": {
+"0": "Leads"
+},
+"Absolut Cashmere": {
+"0": "Purchases",
+"2": "Initiate checkouts"
+},
+"Acquisit": {
+"0": "__UNMAPPED__"
+},
+"Anacours": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__",
+"8": "__UNMAPPED__",
+"9": "__UNMAPPED__"
+},
+"Aquitaine containers": {
+"0": "Leads"
+},
+"Arrago": {
+"0": "Sales Qualified Leads",
+"1": "__CONFLICT__",
+"2": "__CONFLICT__",
+"3": "__UNMAPPED__"
+},
+"Atelier Box": {
+"0": "__UNMAPPED__",
+"4": "__UNMAPPED__"
+},
+"Audilo": {
+"0": "__UNMAPPED__"
+},
+"BYmyCAR": {
+"0": "__CONFLICT__",
+"7": "Custom 7",
+"15": "Custom 15"
+},
+"Balto": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Bambinos": {
+"0": "Leads"
+},
+"Be Radiance": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Belveo": {
+"0": "Purchases",
+"2": "Leads",
+"3": "Marketing Qualified Leads",
+"4": "Offline sales"
+},
+"BeneBono": {
+"0": "Purchases",
+"1": "__CONFLICT__",
+"2": "__CONFLICT__",
+"3": "Custom 3",
+"5": "Custom 5"
+},
+"Biosyl": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__"
+},
+"Bonsoirs": {
+"0": "__UNMAPPED__"
+},
+"Braxton": {
+"0": "Leads",
+"2": "Custom 1",
+"3": "Custom 2"
+},
+"Butt Butter": {
+"0": "__UNMAPPED__"
+},
+"Cambox": {
+"0": "__UNMAPPED__"
+},
+"Canopea Paris": {
+"0": "Purchases"
+},
+"CapCar": {
+"0": "__CONFLICT__",
+"1": "Content views OR View Item",
+"2": "Leads",
+"3": "Sales Qualified Leads"
+},
+"Capitole Energy": {
+"0": "Leads"
+},
+"Ceercle": {
+"0": "__UNMAPPED__"
+},
+"Cheerz": {
+"0": "__UNMAPPED__"
+},
+"Chilowé": {
+"0": "Marketing Qualified Leads"
+},
+"Cica Manuka": {
+"0": "Purchases",
+"2": "Initiate checkouts",
+"4": "Content views OR View Item"
+},
+"Cirque du Soleil": {
+"0": "Purchases",
+"1": "Purchases",
+"2": "Sign ups",
+"3": "__UNMAPPED__"
+},
+"Codexial": {
+"0": "__CONFLICT__",
+"2": "Initiate checkouts",
+"3": "Leads",
+"4": "Content views OR View Item"
+},
+"Colorbox": {
+"0": "Purchases"
+},
+"Comptastar": {
+"0": "Leads",
+"1": "Marketing Qualified Leads",
+"2": "Sales Qualified Leads",
+"3": "Offline sales"
+},
+"Cowool": {
+"0": "__UNMAPPED__"
+},
+"Dedikazio": {
+"0": "Marketing Qualified Leads"
+},
+"Demo Nanga": {
+"0": "Purchases",
+"1": "__CONFLICT__",
+"2": "__CONFLICT__",
+"3": "Content views OR View Item",
+"5": "Custom 5",
+"6": "Custom 3",
+"7": "__UNMAPPED__",
+"14": "__UNMAPPED__",
+"19": "Custom 3"
+},
+"Dermalogica": {
+"0": "Purchases"
+},
+"Detective Box": {
+"0": "__UNMAPPED__"
+},
+"Distingo Bank": {
+"0": "__CONFLICT__",
+"3": "Custom 3",
+"4": "Custom 2",
+"5": "Custom 1",
+"6": "Leads",
+"7": "Custom 1"
+},
+"Dougs": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "Custom 2",
+"4": "Custom 4",
+"5": "Custom 5"
+},
+"Dualsun": {
+"0": "__UNMAPPED__"
+},
+"Ecopia": {
+"0": "__CONFLICT__",
+"1": "Leads"
+},
+"Elmy": {
+"0": "__UNMAPPED__"
+},
+"En Voiture Simone (EVS)": {
+"0": "Purchases",
+"1": "Custom 1",
+"2": "Custom 2",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"8": "__UNMAPPED__",
+"9": "__UNMAPPED__"
+},
+"Enlaps": {
+"0": "__CONFLICT__",
+"1": "Purchases"
+},
+"Everping": {
+"0": "Leads",
+"1": "Custom 1"
+},
+"Exaprint": {
+"0": "Purchases",
+"1": "Custom 1"
+},
+"Father and Sons": {
+"0": "Purchases",
+"1": "__CONFLICT__",
+"2": "Custom 1"
+},
+"Fauré Le Page": {
+"0": "Purchases",
+"1": "Content views OR View Item",
+"2": "Custom 1"
+},
+"Felicity (Otium)": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Figaret": {
+"0": "Purchases",
+"1": "__UNMAPPED__",
+"2": "Offline sales"
+},
+"Fleex": {
+"0": "__UNMAPPED__"
+},
+"France Toner": {
+"0": "Purchases"
+},
+"FranginFrangine": {
+"0": "__UNMAPPED__"
+},
+"Free": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__"
+},
+"Funkie": {
+"0": "Purchases",
+"1": "Sign ups"
+},
+"G-Heat": {
+"0": "Purchases",
+"14": "Add to cart",
+"16": "Content views OR View Item",
+"17": "Purchases"
+},
+"Gamin Tout Terrain": {
+"0": "__CONFLICT__",
+"1": "Add to cart"
+},
+"Gestion immobilière Walter inc.": {
+"0": "__CONFLICT__",
+"1": "Custom 2",
+"2": "Custom 3",
+"3": "Custom 4",
+"4": "Custom 5",
+"5": "Custom 6",
+"6": "Custom 7",
+"7": "Custom 8",
+"8": "__UNMAPPED__",
+"9": "Custom 10",
+"10": "Custom 11"
+},
+"Goodiespub": {
+"3": "Custom 3",
+"0": "Purchases",
+"2": "Marketing Qualified Leads",
+"1": "Custom 1"
+},
+"GreenGo": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Groover": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Hapni": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__"
+},
+"Hiprof": {
+"0": "__UNMAPPED__"
+},
+"HomeExchange": {
+"0": "__CONFLICT__",
+"1": "Purchases",
+"2": "__CONFLICT__",
+"3": "Sign ups",
+"5": "__UNMAPPED__"
+},
+"Horace": {
+"0": "__UNMAPPED__"
+},
+"Hosman": {
+"0": "__UNMAPPED__"
+},
+"Hugy": {
+"0": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__"
+},
+"Hydratis": {
+"0": "__UNMAPPED__"
+},
+"INGA": {
+"0": "__UNMAPPED__"
+},
+"Inoui Editions": {
+"0": "Purchases",
+"1": "Initiate checkouts",
+"2": "Leads"
+},
+"Inter Invest": {
+"0": "Leads"
+},
+"Inter Invest Outre Mer": {
+"0": "Marketing Qualified Leads"
+},
+"Inty": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__"
+},
+"Investissement Locatif": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__"
+},
+"Iskn": {
+"0": "__UNMAPPED__"
+},
+"JP Océan": {
+"0": "Leads"
+},
+"Jerome Dreyfuss": {
+"0": "Purchases",
+"2": "__UNMAPPED__"
+},
+"Jiliti": {
+"0": "__CONFLICT__"
+},
+"Jimmy Fairly": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__"
+},
+"Jott": {
+"0": "__UNMAPPED__"
+},
+"Kazidomi": {
+"0": "__UNMAPPED__"
+},
+"Kipli": {
+"0": "__UNMAPPED__"
+},
+"Komilfo": {
+"0": "__UNMAPPED__"
+},
+"LA Bruket": {
+"0": "Purchases"
+},
+"La Cheese Experience": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"La retraite en clair": {
+"0": "Marketing Qualified Leads",
+"2": "Content views OR View Item",
+"3": "Content views OR View Item",
+"4": "Custom 4",
+"5": "Content views OR View Item"
+},
+"Le Slip Français": {
+"0": "Purchases"
+},
+"Leet Design": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Les Tricots Marcel": {
+"0": "__UNMAPPED__"
+},
+"Les petits culottés": {
+"0": "Purchases",
+"1": "Purchases",
+"2": "Purchases",
+"3": "Purchases",
+"4": "Purchases",
+"7": "Purchases",
+"10": "__UNMAPPED__",
+"11": "__UNMAPPED__",
+"13": "__UNMAPPED__",
+"14": "__UNMAPPED__",
+"17": "__UNMAPPED__",
+"18": "__UNMAPPED__"
+},
+"Let's Tolk": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__"
+},
+"LocaBoat Group": {
+"0": "Custom 4",
+"1": "Add to cart",
+"2": "Initiate checkouts",
+"3": "Custom 3",
+"4": "Purchases",
+"5": "Leads",
+"6": "Leads",
+"7": "Custom 1",
+"8": "Sign ups",
+"9": "Custom 2",
+"10": "Organic search visits (custom conv meta)",
+"11": "Paid search visits (custom conv meta)"
+},
+"Lunii": {
+"0": "Purchases",
+"1": "Custom 1",
+"2": "Custom 2",
+"3": "Custom 3",
+"4": "Custom 4",
+"5": "Custom 5",
+"6": "Custom 5",
+"7": "Custom 6",
+"8": "Search visits (combo organic + sea custom conv meta)",
+"9": "Custom 7",
+"10": "Custom 8",
+"11": "Custom 9",
+"12": "Custom 10",
+"13": "Custom 11",
+"14": "Custom 12",
+"15": "__UNMAPPED__"
+},
+"Lutèce Cosmetics": {
+"0": "Purchases",
+"2": "Initiate checkouts",
+"5": "__UNMAPPED__"
+},
+"Madame d'Alexis": {
+"0": "Purchases"
+},
+"Maison Kitsune": {
+"0": "__UNMAPPED__"
+},
+"Manucurist": {
+"0": "Purchases"
+},
+"Mavala": {
+"0": "Purchases",
+"5": "__UNMAPPED__"
+},
+"Memo Bank": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"3": "__UNMAPPED__"
+},
+"Merci Walter": {
+"0": "Purchases",
+"2": "Initiate checkouts",
+"3": "__CONFLICT__"
+},
+"Modz": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Montblanc": {
+"0": "__UNMAPPED__"
+},
+"Morning": {
+"0": "Leads",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__",
+"8": "__UNMAPPED__",
+"9": "__UNMAPPED__",
+"10": "__UNMAPPED__",
+"11": "__UNMAPPED__",
+"12": "__UNMAPPED__"
+},
+"My Big Bang": {
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__"
+},
+"My Blend": {
+"0": "Purchases",
+"1": "Leads"
+},
+"Naali": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__"
+},
+"Naitways": {
+"0": "Leads",
+"2": "Leads",
+"3": "Leads",
+"4": "Leads",
+"5": "Leads",
+"6": "Leads",
+"7": "Leads",
+"8": "Leads",
+"9": "Leads",
+"10": "Leads",
+"11": "Leads",
+"12": "Leads"
+},
+"Neveo": {
+"0": "__UNMAPPED__"
+},
+"Nonna Lab": {
+"0": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"4": "__UNMAPPED__"
+},
+"Nora Beauty": {
+"0": "__UNMAPPED__"
+},
+"Néo Viager": {
+"0": "Marketing Qualified Leads"
+},
+"OMAJ": {
+"0": "__UNMAPPED__"
+},
+"Oli's Lab": {
+"0": "Purchases"
+},
+"Opla": {
+"0": "__UNMAPPED__"
+},
+"Orisha": {
+"0": "__UNMAPPED__"
+},
+"Osée": {
+"0": "Purchases",
+"2": "__UNMAPPED__"
+},
+"PF - Saint Gobain": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__"
+},
+"Passage du désir": {
+"0": "__UNMAPPED__"
+},
+"Païdou": {
+"0": "__UNMAPPED__"
+},
+"Perifit": {
+"0": "Purchases"
+},
+"Petit Picotin": {
+"0": "Purchases"
+},
+"Polène": {
+"0": "Purchases",
+"1": "Custom 1",
+"2": "Purchases",
+"7": "__UNMAPPED__"
+},
+"Poupette": {
+"0": "__UNMAPPED__"
+},
+"Pro Nutrition": {
+"0": "Purchases",
+"1": "Custom 1",
+"3": "Custom 2"
+},
+"Proteogenix": {
+"0": "__UNMAPPED__"
+},
+"Pulse Protein": {
+"0": "Purchases"
+},
+"Quitoque": {
+"0": "Purchases",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__"
+},
+"Quiz Room": {
+"0": "Leads",
+"1": "__CONFLICT__",
+"2": "Leads",
+"3": "Leads",
+"4": "Custom 4"
+},
+"Ray Studios": {
+"0": "Purchases"
+},
+"Rayon Coworking": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__",
+"8": "__UNMAPPED__"
+},
+"Redesk": {
+"0": "Add to cart",
+"1": "Purchases",
+"2": "Initiate checkouts",
+"3": "Leads",
+"4": "Custom 1"
+},
+"Reno": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"3": "__UNMAPPED__"
+},
+"Reputation": {
+"0": "Leads",
+"1": "__CONFLICT__",
+"2": "Leads",
+"3": "Leads"
+},
+"Richardson": {
+"1": "Leads",
+"2": "Custom 2",
+"3": "Custom 3",
+"4": "Leads"
+},
+"Rivadouce": {
+"0": "Purchases",
+"1": "__CONFLICT__",
+"2": "__CONFLICT__",
+"3": "Content views OR View Item"
+},
+"Rue du commerce": {
+"0": "__UNMAPPED__"
+},
+"SBG Systems": {
+"0": "Leads",
+"1": "Custom 1"
+},
+"Sami.eco": {
+"0": "__CONFLICT__"
+},
+"Shining": {
+"0": "Purchases"
+},
+"Shopinvest": {
+"0": "Purchases",
+"1": "Custom 1",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__"
+},
+"Smile and Pay": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"3": "__UNMAPPED__",
+"4": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__",
+"8": "__UNMAPPED__",
+"9": "__UNMAPPED__",
+"10": "__UNMAPPED__",
+"11": "__UNMAPPED__",
+"12": "__UNMAPPED__",
+"15": "__UNMAPPED__"
+},
+"Sober Spirits": {
+"0": "Purchases"
+},
+"Solarock": {
+"0": "Leads"
+},
+"Spark": {
+"0": "Leads"
+},
+"Sports d'époque": {
+"0": "Purchases"
+},
+"Steel Shed Solutions": {
+"0": "Leads",
+"1": "Purchases"
+},
+"Still & Slow": {
+"0": "Purchases"
+},
+"Superdiet": {
+"0": "Purchases"
+},
+"Séfia": {
+"0": "Purchases"
+},
+"Sélection M": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Tantor": {
+"0": "__UNMAPPED__"
+},
+"The Cool Republic": {
+"0": "__UNMAPPED__"
+},
+"Timeleft": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Toploc": {
+"0": "Purchases",
+"1": "Leads"
+},
+"Totemia": {
+"0": "__CONFLICT__",
+"1": "__CONFLICT__",
+"2": "__CONFLICT__"
+},
+"Tradis": {
+"0": "Purchases",
+"1": "Leads",
+"2": "Leads",
+"3": "Leads",
+"7": "Custom 1"
+},
+"Treezor": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"3": "__UNMAPPED__"
+},
+"Trustpair": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__",
+"5": "__UNMAPPED__",
+"6": "__UNMAPPED__",
+"8": "__UNMAPPED__"
+},
+"TuneCore": {
+"0": "Purchases",
+"1": "Sign ups"
+},
+"U2P": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "Content views OR View Item",
+"3": "Leads",
+"4": "__CONFLICT__",
+"5": "Custom 1"
+},
+"Vestiaire Collective": {
+"0": "Purchases",
+"1": "Sign ups",
+"2": "Custom 1",
+"3": "Custom 2",
+"4": "Custom 3"
+},
+"Violette_FR": {
+"0": "Purchases"
+},
+"Virgil": {
+"0": "Sign ups",
+"1": "Leads",
+"2": "Sales Qualified Leads",
+"3": "Custom 1",
+"4": "Custom 2",
+"5": "Custom 3",
+"6": "Organic search visits (custom conv meta)",
+"7": "Paid search visits (custom conv meta)",
+"8": "Custom 4"
+},
+"Walter": {
+"0": "__CONFLICT__",
+"2": "Content views OR View Item"
+},
+"Welcome to the Jungle": {
+"0": "__CONFLICT__",
+"1": "Leads",
+"2": "__UNMAPPED__",
+"3": "Sign ups",
+"5": "__CONFLICT__"
+},
+"Wonderbox": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__"
+},
+"Wup Networking": {
+"0": "__UNMAPPED__",
+"1": "__UNMAPPED__",
+"2": "__UNMAPPED__"
+},
+"Yooji": {
+"0": "Purchases",
+"1": "__CONFLICT__",
+"2": "Custom 3",
+"3": "__CONFLICT__",
+"5": "Custom 2",
+"6": "__UNMAPPED__",
+"7": "__UNMAPPED__"
+},
+"Zefir": {
+"0": "__UNMAPPED__"
+},
+"Zenchef": {
+"0": "Leads",
+"4": "Marketing Qualified Leads",
+"5": "Offline sales"
+},
+"Zeplug": {
+"0": "Leads",
+"1": "Custom 1"
+}
+}

--- a/migration/merge_41335_41336_step1.py
+++ b/migration/merge_41335_41336_step1.py
@@ -1,0 +1,37 @@
+"""Step 1 — fetch pair 41335 (generic) / 41336 (custom), assert tags, dry-run merge."""
+import sys, json
+sys.path.insert(0, 'scripts')
+sys.path.insert(0, 'migration')
+from archive_collections import connect_resilient
+from merge_tables import merge_sqls, MergeBlocked
+
+mb = connect_resilient()
+
+GEN, CUS = 41335, 41336
+cards = {}
+for cid in (GEN, CUS):
+    c = mb.get(f'/api/card/{cid}')
+    cards[cid] = c
+    st = c['dataset_query']['stages'][0]
+    print(f"#{cid} name={c['name']!r} db={c['dataset_query']['database']} "
+          f"collection={c.get('collection_id')} display={c.get('display')} "
+          f"sql_lines={len(st['native'].splitlines())} tags={sorted(st['template-tags'].keys())}")
+    json.dump(c, open(f'migration/snapshots/card-{cid}-full.json', 'w'), indent=1)
+
+tg = set(cards[GEN]['dataset_query']['stages'][0]['template-tags'])
+tc = set(cards[CUS]['dataset_query']['stages'][0]['template-tags'])
+assert tg == tc, f"template-tag sets differ: only-generic={tg-tc} only-custom={tc-tg}"
+print("template-tag sets identical:", sorted(tg))
+
+sql_g = cards[GEN]['dataset_query']['stages'][0]['native']
+sql_c = cards[CUS]['dataset_query']['stages'][0]['native']
+try:
+    merged = merge_sqls(sql_g, sql_c)
+except MergeBlocked as e:
+    print("MERGE_BLOCKED:", e)
+    sys.exit(3)
+
+open('migration/merged-41335-41336.sql', 'w').write(merged)
+print(f"merged sql: {len(merged.splitlines())} lines "
+      f"(generic {len(sql_g.splitlines())}, custom {len(sql_c.splitlines())})")
+print("parameters(custom):", json.dumps(cards[CUS].get('parameters'), indent=1)[:1500])

--- a/migration/merge_tables.py
+++ b/migration/merge_tables.py
@@ -1,0 +1,295 @@
+"""Fusion de cartes jumelles Metabase (SQL natif) : générique + custom -> « toutes conversions ».
+
+Contexte
+--------
+Chaque paire jumelle (ex. 41347 générique / 41348 custom) partage EXACTEMENT le même
+échafaudage SQL (CTEs de dates, fenêtres de comparaison, FROM/JOIN/WHERE/GROUP BY,
+SELECT final) ; seuls diffèrent les blocs de colonnes-métriques par conversion
+(13 conversions standard côté générique, CUSTOM_CONVERSIONS_1..15 côté custom).
+
+Méthode (merge_sqls)
+--------------------
+1. difflib.SequenceMatcher sur les LIGNES des deux SQL (autojunk=False, déterministe).
+2. Hunks 'equal'  -> gardés tels quels (l'échafaudage commun).
+3. Hunks non-equal -> union des items de liste SELECT : items du côté générique PUIS
+   items du côté custom, en dédupliquant les items textuellement identiques
+   (ex. préfixe partagé « impressions, clicks, cost, » dans une même ligne) et en
+   réparant les virgules de jonction. Le découpage en items se fait aux virgules de
+   profondeur 0 (scanner conscient des parenthèses, chaînes '...', commentaires -- et /* */),
+   ce qui préserve indentation et commentaires.
+
+Garde-fous (MergeBlocked)
+-------------------------
+- L'échafaudage commun (lignes 'equal') doit représenter une part substantielle :
+  >= MIN_EQUAL_LINES lignes ET >= MIN_EQUAL_RATIO de la longueur du plus long SQL.
+- Chaque hunk non-equal ne doit contenir QUE des expressions de colonnes
+  (motif ' AS ', listes d'identifiants, continuations, commentaires). Toute ligne
+  commençant par un mot-clé structurel (FROM/JOIN/WHERE/GROUP BY/ORDER BY/HAVING/
+  LIMIT/UNION/SELECT/WITH/ON/')'/';') déclenche MergeBlocked avec diagnostic.
+- Incohérence de virgule terminale entre les deux côtés d'un hunk -> MergeBlocked.
+
+Limites connues
+---------------
+- Suppose un formatage « une expression de colonne par ligne ou liste d'identifiants » ;
+  ne réécrit jamais l'échafaudage. Si les jumelles divergent structurellement
+  (FROM/JOIN/WHERE différents), la fusion est refusée plutôt que devinée.
+- La déduplication d'items est textuelle (espaces normalisés, commentaires ignorés,
+  casefold) : deux expressions sémantiquement identiques mais écrites différemment
+  ne seront pas dédupliquées (le SQL résultant échouerait alors sur alias dupliqué,
+  ce que la vérification d'exécution détecte).
+
+Vérification (compare_runs)
+---------------------------
+Compare le résultat d'exécution de la carte fusionnée avec celui d'une jumelle :
+mêmes nombres de lignes, colonnes de la fusionnée ⊇ colonnes de la jumelle, et pour
+chaque colonne de la jumelle valeurs identiques ligne à ligne (tri préalable par la
+colonne de dimension, tolérance RELATIVE rel_tol pour les flottants — jamais
+d'égalité stricte, les floats Snowflake varient entre runs).
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+
+MIN_EQUAL_LINES = 20
+MIN_EQUAL_RATIO = 0.10
+
+_STRUCTURAL_RE = re.compile(
+    r"(?i)^\s*("
+    r"from\b|join\b|inner\b|left\b|right\b|full\b|cross\b|where\b|"
+    r"group\s+by\b|order\s+by\b|having\b|limit\b|union\b|select\b|with\b|on\b|"
+    r"\)|;"
+    r")"
+)
+
+
+class MergeBlocked(Exception):
+    """La fusion est refusée : diagnostic précis dans str(exc)."""
+
+
+# ---------------------------------------------------------------------------
+# Découpage d'un fragment de liste SELECT en items (virgules de profondeur 0)
+# ---------------------------------------------------------------------------
+
+def _split_top_level(text: str):
+    """Découpe `text` aux virgules de profondeur 0 (hors (), '...', -- et /* */).
+
+    Retourne (items, trailing) où `trailing` est True si le fragment se termine
+    par une virgule de profondeur 0 (la liste continue dans le hunk suivant).
+    Un éventuel reliquat final sans contenu (espaces/commentaires) est rattaché
+    au dernier item.
+    """
+    items, buf = [], []
+    depth = 0
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "'":  # chaîne SQL (les '' internes sont deux quotes successives)
+            buf.append(ch)
+            i += 1
+            while i < n:
+                buf.append(text[i])
+                if text[i] == "'":
+                    i += 1
+                    break
+                i += 1
+            continue
+        if ch == "-" and text[i : i + 2] == "--":  # commentaire de ligne
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            buf.append(text[i:j])
+            i = j
+            continue
+        if ch == "/" and text[i : i + 2] == "/*":  # commentaire bloc
+            j = text.find("*/", i)
+            j = n if j == -1 else j + 2
+            buf.append(text[i:j])
+            i = j
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            items.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+
+    tail = "".join(buf)
+    trailing = False
+    if _norm_item(tail) == "":
+        # le fragment finissait par une virgule (+ éventuels commentaires/espaces)
+        trailing = bool(items)
+        if items and tail:
+            items[-1] += ","  # on ré-attache le reliquat (commentaires) ...
+            items[-1] += tail  # ... après la virgule pour préserver le texte
+            trailing = False  # la virgule est déjà réinsérée
+    else:
+        items.append(tail)
+    return items, trailing
+
+
+def _norm_item(item: str) -> str:
+    """Forme normalisée d'un item pour déduplication : sans commentaires de ligne,
+    espaces normalisés, casefold (identifiants SQL insensibles à la casse)."""
+    lines = []
+    for ln in item.splitlines():
+        s = ln.strip()
+        if not s or s.startswith("--"):
+            continue
+        lines.append(s)
+    return re.sub(r"\s+", " ", " ".join(lines)).casefold()
+
+
+# ---------------------------------------------------------------------------
+# Garde-fous
+# ---------------------------------------------------------------------------
+
+def _check_hunk_lines(lines, side: str, hunk_desc: str):
+    """Vérifie qu'un hunk non-equal ne contient que des expressions de colonnes."""
+    for ln in lines:
+        s = ln.strip()
+        if not s or s.startswith("--"):
+            continue
+        if _STRUCTURAL_RE.match(s):
+            raise MergeBlocked(
+                f"Hunk {hunk_desc} côté {side} : ligne structurelle "
+                f"(FROM/JOIN/WHERE/...) dans un bloc supposé colonnes-métriques : {s[:120]!r}"
+            )
+        if ";" in s.split("--", 1)[0]:
+            raise MergeBlocked(
+                f"Hunk {hunk_desc} côté {side} : point-virgule inattendu : {s[:120]!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fusion
+# ---------------------------------------------------------------------------
+
+def merge_sqls(generic_sql: str, custom_sql: str) -> str:
+    """Fusionne les SQL de deux cartes jumelles (générique, custom) -> SQL « toutes conversions ».
+
+    Voir le docstring du module pour la méthode et les garde-fous.
+    Lève MergeBlocked (avec diagnostic) si les jumelles ne respectent pas les invariants.
+    Déterministe : même entrée -> même sortie.
+    """
+    a = generic_sql.splitlines()
+    b = custom_sql.splitlines()
+    ops = difflib.SequenceMatcher(None, a, b, autojunk=False).get_opcodes()
+
+    equal_lines = sum(i2 - i1 for tag, i1, i2, _, _ in ops if tag == "equal")
+    longest = max(len(a), len(b)) or 1
+    if equal_lines < MIN_EQUAL_LINES or equal_lines / longest < MIN_EQUAL_RATIO:
+        raise MergeBlocked(
+            f"Échafaudage commun insuffisant : {equal_lines} lignes 'equal' "
+            f"({equal_lines / longest:.0%} du plus long SQL) ; "
+            f"seuils : >= {MIN_EQUAL_LINES} lignes et >= {MIN_EQUAL_RATIO:.0%}. "
+            "Les deux cartes ne sont probablement pas jumelles."
+        )
+
+    out: list[str] = []
+    for tag, i1, i2, j1, j2 in ops:
+        if tag == "equal":
+            out.extend(a[i1:i2])
+            continue
+
+        hunk_desc = f"a[{i1}:{i2}]/b[{j1}:{j2}] ({tag})"
+        _check_hunk_lines(a[i1:i2], "générique", hunk_desc)
+        _check_hunk_lines(b[j1:j2], "custom", hunk_desc)
+
+        if tag == "delete":  # lignes seulement côté générique : on les garde
+            out.extend(a[i1:i2])
+            continue
+        if tag == "insert":  # lignes seulement côté custom : on les garde
+            out.extend(b[j1:j2])
+            continue
+
+        # tag == "replace" : union des items, générique PUIS custom, dédupliqués
+        items_a, trail_a = _split_top_level("\n".join(a[i1:i2]))
+        items_b, trail_b = _split_top_level("\n".join(b[j1:j2]))
+        if trail_a != trail_b:
+            raise MergeBlocked(
+                f"Hunk {hunk_desc} : virgule terminale incohérente entre les deux côtés "
+                f"(générique={trail_a}, custom={trail_b}) — structure de liste divergente."
+            )
+        seen = {_norm_item(it) for it in items_a}
+        merged_items = list(items_a)
+        for it in items_b:
+            if _norm_item(it) not in seen:
+                merged_items.append(it)
+        text = ",".join(merged_items)
+        if trail_a:
+            text += ","
+        out.extend(text.split("\n"))
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Comparaison de résultats d'exécution
+# ---------------------------------------------------------------------------
+
+def _sort_rows(cols, rows, dim_col):
+    idx = cols.index(dim_col)
+    return sorted(rows, key=lambda r: (r[idx] is None, str(r[idx])))
+
+
+def _values_equal(x, y, rel_tol):
+    if x is None or y is None:
+        return x is None and y is None
+    if isinstance(x, bool) or isinstance(y, bool):
+        return x == y
+    if isinstance(x, (int, float)) and isinstance(y, (int, float)):
+        fx, fy = float(x), float(y)
+        if fx == fy:
+            return True
+        return abs(fx - fy) <= rel_tol * max(abs(fx), abs(fy))
+    return x == y
+
+
+def compare_runs(merged_cols, merged_rows, twin_cols, twin_rows, dim_col, *,
+                 rel_tol: float = 1e-9, twin_label: str = "twin"):
+    """Compare le run de la carte fusionnée au run d'une jumelle.
+
+    merged_cols / twin_cols : listes de noms de colonnes (résultat d'exécution).
+    merged_rows / twin_rows : listes de lignes (listes de valeurs).
+    dim_col : nom de la colonne de dimension (tri des lignes avant comparaison).
+
+    Retourne (ok: bool, problems: list[str]). Vérifie :
+    - même nombre de lignes ;
+    - colonnes de la fusionnée ⊇ colonnes de la jumelle ;
+    - pour CHAQUE colonne de la jumelle, valeurs identiques ligne à ligne
+      (tolérance relative rel_tol pour les nombres, égalité stricte sinon).
+    """
+    problems = []
+    if len(merged_rows) != len(twin_rows):
+        problems.append(
+            f"[{twin_label}] nombre de lignes : fusionnée={len(merged_rows)} vs jumelle={len(twin_rows)}"
+        )
+    missing = [c for c in twin_cols if c not in merged_cols]
+    if missing:
+        problems.append(f"[{twin_label}] colonnes absentes de la fusionnée : {missing}")
+    if problems:
+        return False, problems
+
+    if dim_col not in merged_cols or dim_col not in twin_cols:
+        return False, [f"[{twin_label}] colonne de dimension {dim_col!r} introuvable"]
+
+    ms = _sort_rows(merged_cols, merged_rows, dim_col)
+    ts = _sort_rows(twin_cols, twin_rows, dim_col)
+    m_idx = {c: k for k, c in enumerate(merged_cols)}
+    for col in twin_cols:
+        t_i = twin_cols.index(col)
+        m_i = m_idx[col]
+        for r, (mr, tr) in enumerate(zip(ms, ts)):
+            if not _values_equal(mr[m_i], tr[t_i], rel_tol):
+                problems.append(
+                    f"[{twin_label}] colonne {col!r} ligne {r} : "
+                    f"fusionnée={mr[m_i]!r} vs jumelle={tr[t_i]!r}"
+                )
+                break  # un mismatch par colonne suffit au diagnostic
+    return (not problems), problems

--- a/migration/phase1-plan.yaml
+++ b/migration/phase1-plan.yaml
@@ -1,0 +1,56 @@
+# Manifeste de migration Phase 1 — collection 215 « 2. Generic Questions »
+# Restructure pure : créations / déplacements / renommages de COLLECTIONS.
+# Aucune carte n'est renommée ni archivée. « 18. Nouvelles Conversions » est exclue.
+
+families:
+  - key: ad_platforms
+    name: "Ad platforms"
+    description: "Questions spécifiques à une plateforme publicitaire ou un MMP"
+  - key: web_analytics
+    name: "Web & Analytics"
+    description: "Analytics web, e-commerce et SEO"
+  - key: benchmarks_strategy
+    name: "Benchmarks & Strategy"
+    description: "Benchmarks sectoriels, objectifs clients et planification"
+
+collection_moves:
+  # ex-« 01. Global » : renommée en place, reste à la racine de 215
+  - {id: 214,  new_parent: root,                new_name: "Cross-platform"}
+  # --- Ad platforms ---
+  - {id: 209,  new_parent: ad_platforms,        new_name: "Google Ads"}
+  - {id: 210,  new_parent: ad_platforms,        new_name: "Meta"}
+  - {id: 443,  new_parent: ad_platforms,        new_name: "Adjust"}
+  - {id: 5466, new_parent: ad_platforms,        new_name: "Amazon Ads"}
+  # --- Web & Analytics ---
+  - {id: 232,  new_parent: web_analytics,       new_name: "Google Analytics 4"}
+  - {id: 2301, new_parent: web_analytics,       new_name: "Shopify"}
+  - {id: 344,  new_parent: web_analytics,       new_name: "SEO"}
+  - {id: 6984, new_parent: web_analytics,       new_name: "Magento"}
+  # --- Benchmarks & Strategy ---
+  - {id: 9660, new_parent: benchmarks_strategy, new_name: "AI"}
+  - {id: 216,  new_parent: benchmarks_strategy, new_name: "Industry benchmarks"}
+  - {id: 346,  new_parent: benchmarks_strategy, new_name: "Client Goals"}
+  - {id: 4546, new_parent: benchmarks_strategy, new_name: "Brand Monitoring"}
+  - {id: 7680, new_parent: benchmarks_strategy, new_name: "Business Plan"}
+
+# Les 9 cartes de « To sort » -> Cross-platform (214) ou Industry benchmarks (216)
+card_filing:
+  45729: 214   # Branding vs engagement vs trafic
+  45730: 214   # Branding vs engagement vs trafic - Bar Chart
+  46851: 214   # Branding vs engagement vs trafic - Table
+  17923: 214   # Cac3
+  17922: 214   # Conv3
+  27619: 214   # Perifit_check  (carte de test client — à archiver hors Phase 1)
+  3102:  214   # ROAS by date, account_name
+  17511: 216   # Social ad performance agency benchmark (2 dimensions)
+  17512: 216   # Social video ad performance agency benchmark (2 dimensions)
+
+# Collections vides supprimées (vacuité revérifiée en live avant suppression)
+delete_empty:
+  - 211    # 04. Microsoft
+  - 545    # 09. Appsflyer
+  - 2202   # 10. Pinterest
+  - 7185   # 16. Spotify
+  - 2829   # 5. Correlation cost & key metrics  (sous Global)
+  - 1454   # Attribution windows  (sous Meta / 1. Campaign)
+  - 7252   # To sort  (après déplacement de ses 9 cartes)

--- a/migration/tu_1567_baseline.py
+++ b/migration/tu_1567_baseline.py
@@ -1,0 +1,32 @@
+"""Baseline runs of original card 1567 (field-filter time_period) for day/week/month/year."""
+import sys, json
+sys.path.insert(0, 'scripts')
+from archive_collections import connect_resilient
+
+mb = connect_resilient()
+CARD = 1567
+DATE_VALUE = "2026-05-01~2026-05-31"  # same pinned window as 41349/41350 baselines
+
+PINNED = [
+    {"type": "category", "target": ["dimension", ["template-tag", "clients"]], "value": ["Pro Nutrition"]},
+    {"type": "date/all-options", "target": ["dimension", ["template-tag", "date"]], "value": DATE_VALUE},
+]
+
+out = {}
+for g in ["day", "week", "month", "year"]:
+    params = [{"type": "category", "target": ["dimension", ["template-tag", "time_period"]], "value": [g]}] + PINNED
+    r = mb.post(f"/api/card/{CARD}/query", json={"parameters": params}, timeout=240)
+    status = r.get("status")
+    if status != "completed":
+        print(f"{g}: FAILED status={status} error={str(r.get('error'))[:300]}")
+        out[g] = {"status": status, "error": str(r.get("error"))[:1000]}
+        continue
+    data = r["data"]
+    cols = [c["name"] for c in data["cols"]]
+    rows = sorted(data["rows"], key=lambda row: (row[0] is None, str(row[0])))
+    out[g] = {"status": "completed", "run_params": params, "columns": cols, "row_count": len(rows), "rows": rows}
+    print(f"{g}: OK cols={cols} rows={len(rows)} first={rows[0] if rows else None}")
+
+with open('migration/snapshots/card-1567-baseline-results.json', 'w') as f:
+    json.dump(out, f, indent=2, ensure_ascii=False)
+print("saved migration/snapshots/card-1567-baseline-results.json")

--- a/migration/tu_1567_create.py
+++ b/migration/tu_1567_create.py
@@ -1,0 +1,103 @@
+"""Create temporal-unit copy of card 1567 in collection 13885."""
+import sys, json, uuid
+sys.path.insert(0, 'scripts')
+from archive_collections import connect_resilient
+
+mb = connect_resilient()
+card = json.load(open('migration/snapshots/card-1567-before.json'))
+sql = card['dataset_query']['stages'][0]['native']
+tags = dict(card['dataset_query']['stages'][0]['template-tags'])
+
+# --- 1. Granularity CTE (verbatim from live card 41350) ---
+GRANULARITY_CTE = open('migration/snapshots/card-41350-granularity-cte.txt').read()
+assert GRANULARITY_CTE.startswith('WITH granularity AS (') and GRANULARITY_CTE.rstrip().endswith('),')
+
+OLD_WITH = 'WITH data AS ('
+assert sql.count(OLD_WITH) == 1
+new_sql = sql.replace(OLD_WITH, GRANULARITY_CTE + 'data AS (', 1)
+
+# --- 2. Replace the time_periods LATERAL (motif: SELECT * ... WHERE {{time_period}}, required filter) ---
+OLD_LATERAL = "LATERAL (SELECT * FROM metabase_filters.time_periods WHERE {{time_period}} LIMIT 1) AS t"
+assert new_sql.count(OLD_LATERAL) == 1
+new_sql = new_sql.replace(OLD_LATERAL, "LATERAL (SELECT name FROM granularity LIMIT 1) AS t", 1)
+
+# --- 3. Add quarter branch to the CASE on t.name (label only; no comparison shift in this card) ---
+OLD_YEAR = "WHEN t.name = 'year' THEN to_char(date, 'YYYY')\r\n"
+assert new_sql.count(OLD_YEAR) == 1
+QUARTER = "WHEN t.name = 'year' THEN to_char(date, 'YYYY')\r\n            WHEN t.name = 'quarter' THEN to_char(date, 'YYYY') || '_Q' || QUARTER(date)::TEXT\r\n"
+new_sql = new_sql.replace(OLD_YEAR, QUARTER, 1)
+
+assert '{{time_period}}' in new_sql  # only inside granularity CTE now
+assert new_sql.count('{{time_period}}') == 1
+assert 'metabase_filters.time_periods' not in new_sql
+
+# --- 4. New temporal-unit template tag (field 419201 = UTILS.CALENDAR.DATE; CTE probes utils.calendar) ---
+tag_id = str(uuid.uuid4())
+tags['time_period'] = {
+    "type": "temporal-unit",
+    "name": "time_period",
+    "id": tag_id,
+    "display-name": "Time Period",
+    "dimension": ["field", {"lib/uuid": str(uuid.uuid4())}, 419201],
+    "default": "week",
+    "required": False,
+}
+
+dq = {
+    "database": card['dataset_query']['database'],
+    "lib/type": "mbql/query",
+    "stages": [{
+        "lib/type": "mbql.stage/native",
+        "native": new_sql,
+        "template-tags": tags,
+    }],
+}
+
+# --- Parameters: original card has parameters=None; build full list mirroring tags (41350 pattern) ---
+parameters = [{
+    "id": tag_id,
+    "type": "temporal-unit",
+    "target": ["dimension", ["template-tag", "time_period"]],
+    "name": "Time Period",
+    "slug": "time_period",
+    "temporal_units": ["day", "week", "month", "quarter", "year"],
+    "default": "week",
+    "required": False,
+    "isMultiSelect": False,
+}]
+for name, t in tags.items():
+    if name == 'time_period':
+        continue
+    ptype = "date/all-options" if t.get("widget-type") == "date/all-options" else "category"
+    p = {
+        "id": t["id"],
+        "type": ptype,
+        "target": ["dimension", ["template-tag", name]],
+        "name": t.get("display-name") or name,
+        "slug": name,
+    }
+    if ptype == "category":
+        p["isMultiSelect"] = True
+    parameters.append(p)
+
+payload = {
+    "name": card['name'],
+    "description": card.get('description'),
+    "display": card['display'],
+    "visualization_settings": card.get('visualization_settings') or {},
+    "dataset_query": dq,
+    "parameters": parameters,
+    "collection_id": 13885,
+}
+
+r = mb.post('/api/card', 'raw', json=payload, timeout=120)
+print('POST status:', r.status_code)
+if r.status_code not in (200, 202):
+    print(r.text[:2000])
+    sys.exit(1)
+new_card = r.json()
+print('NEW CARD ID:', new_card['id'])
+with open('migration/snapshots/card-1567-new-card.json', 'w') as f:
+    json.dump(new_card, f, indent=2, ensure_ascii=False)
+with open('migration/snapshots/card-1567-new-sql.txt', 'w') as f:
+    f.write(new_sql)

--- a/migration/tu_1567_verify.py
+++ b/migration/tu_1567_verify.py
@@ -1,0 +1,76 @@
+"""Verify new card 49097 against baseline of card 1567 (rel tol 1e-9)."""
+import sys, json
+sys.path.insert(0, 'scripts')
+from archive_collections import connect_resilient
+
+mb = connect_resilient()
+NEW = 49097
+DATE_VALUE = "2026-05-01~2026-05-31"
+baseline = json.load(open('migration/snapshots/card-1567-baseline-results.json'))
+
+# Sanity: stored SQL/tags as intended
+live = mb.get(f'/api/card/{NEW}')
+st = live['dataset_query']['stages'][0]
+assert 'WITH granularity AS (' in st['native']
+assert st['template-tags']['time_period']['type'] == 'temporal-unit'
+print('stored card OK: granularity CTE present, tag type temporal-unit, collection', live.get('collection_id'))
+
+PINNED = [
+    {"type": "category", "target": ["dimension", ["template-tag", "clients"]], "value": ["Pro Nutrition"]},
+    {"type": "date/all-options", "target": ["dimension", ["template-tag", "date"]], "value": DATE_VALUE},
+]
+
+def relequal(a, b, tol=1e-9):
+    if a is None or b is None:
+        return a is b
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        if a == b:
+            return True
+        return abs(a - b) <= tol * max(abs(a), abs(b))
+    return a == b
+
+report = {}
+all_ok = True
+for g in ["day", "week", "month", "year"]:
+    params = [{"type": "temporal-unit", "target": ["dimension", ["template-tag", "time_period"]], "value": g}] + PINNED
+    r = mb.post(f"/api/card/{NEW}/query", json={"parameters": params}, timeout=240)
+    if r.get("status") != "completed":
+        print(f"{g}: RUN FAILED {str(r.get('error'))[:300]}")
+        report[g] = {"identical": False, "error": str(r.get("error"))[:1000]}
+        all_ok = False
+        continue
+    cols = [c["name"] for c in r["data"]["cols"]]
+    rows = sorted(r["data"]["rows"], key=lambda row: (row[0] is None, str(row[0])))
+    base = baseline[g]
+    ok = cols == base["columns"] and len(rows) == base["row_count"]
+    if ok:
+        for nr, br in zip(rows, base["rows"]):
+            if not all(relequal(x, y) for x, y in zip(nr, br)):
+                ok = False
+                print(f"{g}: ROW DIFF new={nr} base={br}")
+                break
+    else:
+        print(f"{g}: SHAPE DIFF cols {cols} vs {base['columns']}, rows {len(rows)} vs {base['row_count']}")
+    report[g] = {"identical": ok, "rows": len(rows), "columns": cols}
+    all_ok = all_ok and ok
+    print(f"{g}: identical={ok} rows={len(rows)}")
+
+# Quarter sanity run
+params = [{"type": "temporal-unit", "target": ["dimension", ["template-tag", "time_period"]], "value": "quarter"}] + PINNED
+r = mb.post(f"/api/card/{NEW}/query", json={"parameters": params}, timeout=240)
+if r.get("status") == "completed":
+    rows = sorted(r["data"]["rows"], key=lambda row: (row[0] is None, str(row[0])))
+    import re
+    labels_ok = bool(rows) and all(re.fullmatch(r"\d{4}_Q[1-4]", row[0]) for row in rows)
+    report["quarter"] = {"identical": labels_ok, "rows": len(rows), "labels": [row[0] for row in rows]}
+    all_ok = all_ok and labels_ok
+    print(f"quarter: ran OK rows={len(rows)} labels={[row[0] for row in rows]} plausible={labels_ok}")
+else:
+    report["quarter"] = {"identical": False, "error": str(r.get("error"))[:1000]}
+    all_ok = False
+    print(f"quarter: RUN FAILED {str(r.get('error'))[:300]}")
+
+with open('migration/snapshots/card-1567-verify-results.json', 'w') as f:
+    json.dump(report, f, indent=2, ensure_ascii=False)
+print('ALL_OK:', all_ok)
+sys.exit(0 if all_ok else 2)

--- a/scripts/add_quizroom_disclaimer.py
+++ b/scripts/add_quizroom_disclaimer.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Ajoute une note (disclaimer) sur la donnée "joueurs" issue de l'API Quiz Room.
+
+Ciblage par (onglet, préfixe de texte). Append d'une note en italique + hauteur
+réglée pour qu'elle soit entièrement visible. Reflow des cartes en dessous.
+Snapshot + réversible.
+
+  python3 scripts/add_quizroom_disclaimer.py --dashboard 24576         # dry-run
+  python3 scripts/add_quizroom_disclaimer.py --dashboard 24576 --yes   # applique
+"""
+import argparse, json, sys, copy, requests
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+MIG = REPO / "migration"
+
+NOTE_FR = ("\n\n_ℹ️ La fréquentation (nombre de joueurs) provient de l'API Quiz Room. "
+           "Elle peut être temporairement indisponible lors d'une mise à jour technique côté Quiz Room ; "
+           "le suivi reprend automatiquement une fois celle-ci terminée._")
+NOTE_EN = ("\n\n_ℹ️ Footfall (player count) comes from the Quiz Room API. "
+           "It may be temporarily unavailable during a technical update on the Quiz Room side; "
+           "tracking resumes automatically once it is completed._")
+
+# (tab, prefix, note, new_h)
+TARGETS = [
+    ("Global", "Le nombre de joueurs", NOTE_FR, 4),
+    ("Global", "The player count is your center's", NOTE_EN, 4),
+    ("SEO", "Combien de personnes trouvent", NOTE_FR, 3),
+    ("SEO", "How many people find", NOTE_EN, 3),
+]
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    d = mb.get(f"/api/dashboard/{args.dashboard}")
+    dcs = copy.deepcopy(d.get("dashcards") or [])
+    tabname = {t["id"]: t["name"] for t in (d.get("tabs") or [])}
+    orig_row = {dc["id"]: dc.get("row") for dc in dcs}
+
+    deltas = []
+    for dc in dcs:
+        vs = dc.get("visualization_settings") or {}
+        if (vs.get("virtual_card") or {}).get("display") != "text":
+            continue
+        txt = (vs.get("text") or "").lstrip()
+        tab = tabname.get(dc.get("dashboard_tab_id"))
+        for ttab, prefix, note, new_h in TARGETS:
+            if tab == ttab and txt.startswith(prefix):
+                if "Quiz Room" in (vs.get("text") or "") and "API" in (vs.get("text") or ""):
+                    print(f"[{tab}] row={dc['row']} note déjà présente, skip")
+                    break
+                cur = dc.get("size_y")
+                vs["text"] = (vs.get("text") or "") + note
+                if new_h != cur:
+                    deltas.append((dc["dashboard_tab_id"], dc["row"] + cur - 1, new_h - cur))
+                    dc["size_y"] = new_h
+                print(f"[{tab}] row={dc['row']} h {cur}->{new_h} + note")
+                break
+
+    if not deltas:
+        print("Rien à faire."); return
+    for dc in dcs:
+        tab = dc.get("dashboard_tab_id")
+        shift = sum(delta for tb, b, delta in deltas if tb == tab and b < orig_row[dc["id"]])
+        dc["row"] += shift
+
+    if not args.yes:
+        print("\n(DRY-RUN.)"); return
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"disclaimer-snapshot-{args.dashboard}-{ts}.json").write_text(
+        json.dumps({"dashboard": args.dashboard, "dashcards": d.get("dashcards"), "tabs": d.get("tabs")}, ensure_ascii=False, indent=2))
+    payload = {"dashcards": dcs}
+    if d.get("tabs"):
+        payload["tabs"] = d["tabs"]
+    r = requests.put(mb.domain + f"/api/dashboard/{args.dashboard}", headers=mb.header, auth=mb.auth, json=payload, timeout=120)
+    print("PUT:", r.status_code); r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/apply_fixes_32496.py
+++ b/scripts/apply_fixes_32496.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Applique les 3 fixes validés à l'ORIGINAL #32496 (table à plat).
+
+Changements (validés par diff test, 0 régression) :
+- supprime la CTE + INNER JOIN ctr_scenario (récupère positions > 100),
+- supprime le code mort (4 CTE + 2 colonnes),
+- dédup déterministe (meilleure position par url/crawl).
+Garde TOUTES les colonnes de sortie + display=table + viz (nettoyée des
+réglages pivot obsolètes). Backup déjà fait ; re-vérifie le run après PUT.
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+import build_serp_pivot as B
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; CLIENT="Manucurist"; CORPUS="Corpus transactionnel FR - Mots clés stratégiques"
+
+def main():
+    mb=B.connect(); print("connected")
+    d=mb.get("/api/card/32496")
+    lq=d.get("legacy_query"); lq=json.loads(lq) if isinstance(lq,str) else lq
+    orig_sql=lq["native"]["query"]; tags=dict(lq["native"].get("template-tags") or {})
+
+    new_sql=B.transform(orig_sql, trim_columns=False)  # garde toutes les colonnes
+    print(f"SQL: {len(orig_sql)} -> {len(new_sql)} chars")
+    # garder les 6 colonnes finales
+    assert "AS avg_search_volume" in new_sql and "AS nb_points" in new_sql and "AS avg_rank_group" in new_sql, "colonnes finales perdues!"
+
+    print("validation compile (Manucurist)...")
+    res,err=B.run_dataset(mb, B.substitute(new_sql))
+    if err: print("  ÉCHEC COMPILE:", err[:400]); sys.exit(1)
+    print(f"  OK: {len(res['rows'])} lignes, cols={[c.get('name') for c in res['cols']]}")
+
+    tags.pop("ctr_scenario", None)
+    params=[p for p in (d.get("parameters") or []) if p.get("slug")!="ctr_scenario"]
+    viz=dict(d.get("visualization_settings") or {})
+    viz.pop("table.pivot_column", None); viz.pop("table.cell_column", None)  # réglages pivot obsolètes
+
+    payload={
+      "name": d.get("name"),
+      "collection_id": d.get("collection_id"),
+      "dataset_query": {"database":DB,"type":"native","native":{"query":new_sql,"template-tags":tags}},
+      "display": d.get("display"),               # reste 'table'
+      "visualization_settings": viz,
+      "parameters": params,
+      "description": d.get("description"),
+    }
+    print("PUT #32496 ...")
+    r=mb.put("/api/card/32496","raw",json=payload,timeout=180)
+    print("  status:", getattr(r,"status_code","?"))
+
+    # vérif run (table)
+    P=[{"type":"string/=","value":[CLIENT],"target":["dimension",["template-tag","client"]]},
+       {"type":"string/=","value":[CORPUS],"target":["dimension",["template-tag","corpus_name"]]},
+       {"type":"string/=","value":["day"],"target":["dimension",["template-tag","time_period"]]},
+       {"type":"date/all-options","value":"2026-03-01~2026-05-29","target":["dimension",["template-tag","date"]]}]
+    rr=mb.post("/api/card/32496/query/json","raw",data={"parameters":json.dumps(P)},timeout=240)
+    b=rr.json() if hasattr(rr,"json") else rr
+    if isinstance(b,list): print(f"  RUN OK: {len(b)} lignes")
+    else: print("  RUN ERR:", str((b.get('via') or [{}])[0].get('error') if isinstance(b,dict) else b)[:200])
+    # confirme tag ctr_scenario retiré
+    d2=mb.get("/api/card/32496")
+    lq2=d2.get("legacy_query"); lq2=json.loads(lq2) if isinstance(lq2,str) else lq2
+    print("  template-tags après:", list((lq2.get("native",{}).get("template-tags") or {}).keys()) if lq2 else "?")
+    print("  display:", d2.get("display"))
+
+if __name__=="__main__":
+    main()

--- a/scripts/archive_collections.py
+++ b/scripts/archive_collections.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Archive des collections par id (générique, réversible).
+
+- Children-first (tri par profondeur de location) pour gérer les sous-arbres.
+- Saute les collections système (type non nul : 'library'… — non archivables).
+- Dry-run par défaut ; --yes pour archiver. Écrit la liste pour rollback.
+
+Usage :
+  python3 scripts/archive_collections.py --ids 11344,9330,12399          # dry-run
+  python3 scripts/archive_collections.py --ids 11344,9330,12399 --yes    # archive
+  Rollback : PUT /api/collection/<id> {archived:false} pour les ids du log.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+
+
+def connect_resilient():
+    env = _load_env()
+    d, e, p = env.get("METABASE_DOMAIN"), env.get("METABASE_EMAIL"), env.get("METABASE_PASSWORD")
+    if not (d and e and p):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env.")
+    return Metabase_API(domain=d, email=e, password=p)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--ids", required=True, help="ids de collections, séparés par des virgules")
+    ap.add_argument("--yes", action="store_true", help="archive réellement (sinon dry-run)")
+    args = ap.parse_args()
+    ids = [int(x) for x in args.ids.split(",") if x.strip().isdigit()]
+
+    mb = connect_resilient()
+    cols = {c.get("id"): c for c in (mb.get("/api/collection/") or [])}
+
+    def depth(cid):
+        return len((cols.get(cid, {}).get("location") or "/").strip("/").split("/"))
+
+    targets = []
+    for cid in ids:
+        c = cols.get(cid)
+        if not c:
+            print(f"  #{cid}: absente de l'actif (déjà archivée ?) — sautée")
+            continue
+        if c.get("type"):
+            print(f"  #{cid} «{c.get('name')}» : système (type={c.get('type')}) — sautée")
+            continue
+        targets.append(cid)
+    targets.sort(key=depth, reverse=True)  # enfants avant parents
+
+    print("\nCible :")
+    for cid in targets:
+        print(f"  #{cid:>6}  «{cols[cid].get('name')}»  ({cols[cid].get('location')})")
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log = MIGRATION_DIR / f"archive-collections-{ts}.json"
+    log.write_text(json.dumps(targets, indent=2))
+    print(f"\nListe / rollback : {log}")
+
+    if not args.yes:
+        print("\n(DRY-RUN — rien archivé. --yes pour archiver.)")
+        return
+
+    done, miss = [], []
+    for cid in targets:
+        rc = mb.put(f"/api/collection/{cid}", json={"archived": True})
+        if rc == 200:
+            done.append(cid)
+            print(f"  archivée #{cid} «{cols[cid].get('name')}»")
+        else:
+            miss.append(cid)
+            print(f"  ÉCHEC #{cid} «{cols[cid].get('name')}» (HTTP {rc})")
+    print(f"\n=== {len(done)} archivée(s), {len(miss)} échec ===")
+    print(f"Rollback : PUT /api/collection/<id> {{archived:false}} pour les ids de {log}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/archive_empty_collections.py
+++ b/scripts/archive_empty_collections.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Archive les collections vides détectées par l'audit (vague 0, réversible).
+
+Sécurité :
+- Re-vérification LIVE de la vacuité via /api/collection/<id>/items : on n'archive
+  que si la collection ne contient QUE des sous-collections elles-mêmes candidates
+  vides (toute carte / dashboard / dataset / sous-collection non-candidate -> on saute).
+- Exclut par défaut le template (sous /215/) : ces vides sont des placeholders curés
+  (ex. « 18. Nouvelles Conversions »). --include-template pour les inclure.
+- Archivage réversible (PUT archived:false pour annuler). Écrit la liste pour rollback.
+
+Usage :
+  python3 scripts/archive_empty_collections.py                    # dry-run (catégorise)
+  python3 scripts/archive_empty_collections.py --yes              # archive le set "safe"
+  python3 scripts/archive_empty_collections.py --include-template --yes
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+TEMPLATE_ROOT_ID = 215
+
+
+def connect_resilient() -> Metabase_API:
+    env = _load_env()
+    d, e, p = env.get("METABASE_DOMAIN"), env.get("METABASE_EMAIL"), env.get("METABASE_PASSWORD")
+    if not (d and e and p):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env.")
+    return Metabase_API(domain=d, email=e, password=p)
+
+
+def _latest_findings():
+    fs = sorted(MIGRATION_DIR.glob("audit-findings-*.json"))
+    if not fs:
+        sys.exit("Aucun audit-findings : lancer `audit.py scan` d'abord.")
+    return json.loads(fs[-1].read_text())
+
+
+def _is_template(col):
+    return col.get("id") == TEMPLATE_ROOT_ID or f"/{TEMPLATE_ROOT_ID}/" in (col.get("location") or "")
+
+
+def _top_ancestor_name(col, live):
+    parts = [p for p in (col.get("location") or "/").strip("/").split("/") if p.isdigit()]
+    if parts and int(parts[0]) in live:
+        return live[int(parts[0])].get("name") or "?"
+    return "(racine)"
+
+
+def _under_personal(col, live):
+    """True si un ancêtre (via location) est une collection personnelle.
+
+    find_empty_collections exclut les collections perso elles-mêmes, mais pas leurs
+    sous-collections vides — qui relèvent de la campagne sprawl (zone sensible).
+    """
+    for part in (col.get("location") or "/").strip("/").split("/"):
+        if part.isdigit():
+            anc = live.get(int(part))
+            if anc and anc.get("personal_owner_id"):
+                return True
+    return False
+
+
+def _get_retry(mb, endpoint, tries=3):
+    for attempt in range(tries):
+        try:
+            r = mb.get(endpoint)
+        except Exception:
+            r = None
+        if r is not False and r is not None:
+            return r
+        time.sleep(1.0 * (attempt + 1))
+    return None
+
+
+def reverify_empty(mb, cid, candidate_ids):
+    """True si la collection ne contient que des sous-collections candidates vides.
+
+    Retourne None si la lecture échoue (incertain -> on ne touche pas).
+    """
+    r = _get_retry(mb, f"/api/collection/{cid}/items?limit=2000")
+    if not isinstance(r, dict):
+        return None
+    for it in r.get("data", []):
+        if it.get("model") == "collection" and it.get("id") in candidate_ids:
+            continue
+        return False  # carte / dashboard / dataset / sous-collection non-candidate
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--yes", action="store_true", help="archive réellement (sinon dry-run)")
+    ap.add_argument("--include-template", action="store_true",
+                    help="inclure aussi les vides sous le template 215")
+    ap.add_argument("--include-personal-nested", action="store_true",
+                    help="inclure aussi les vides nichées sous une collection personnelle (sprawl)")
+    ap.add_argument("--exclude", default="",
+                    help="ids à retirer de la cible, séparés par des virgules (ex. 11212,11345)")
+    args = ap.parse_args()
+    exclude_ids = {int(x) for x in args.exclude.split(",") if x.strip().isdigit()}
+
+    mb = connect_resilient()
+    blob = _latest_findings()
+    candidates = blob["findings"]["empty_collections"]["items"]
+    cand_ids = {c["id"] for c in candidates}
+    live = {c.get("id"): c for c in (mb.get("/api/collection/") or [])}
+
+    print(f"Re-vérification live de {len(candidates)} collections vides...")
+    safe, template, personal_nested, skipped = [], [], [], []
+    for c in candidates:
+        cid = c["id"]
+        col = live.get(cid)
+        if col is None:
+            skipped.append({**c, "why": "absente de la liste active"})
+            continue
+        if col.get("type"):  # collection système (Metrics Library) — non archivable
+            skipped.append({**c, "why": f"système (type={col.get('type')})"})
+            continue
+        verdict = reverify_empty(mb, cid, cand_ids)
+        if verdict is not True:
+            skipped.append({**c, "why": "non vide" if verdict is False else "lecture échouée"})
+            continue
+        entry = {"id": cid, "name": col.get("name"), "location": col.get("location")}
+        if _under_personal(col, live):
+            personal_nested.append(entry)
+        elif _is_template(col):
+            template.append(entry)
+        else:
+            safe.append(entry)
+
+    print(f"\n=== {len(safe)} VIDES sûres (hors template, hors perso) ===")
+    for c in sorted(safe, key=lambda x: str(x["name"])):
+        print(f"  #{c['id']:>6}  {c['name']}")
+    print(f"\n=== {len(template)} vides SOUS TEMPLATE (exclues par défaut — placeholders curés) ===")
+    for c in sorted(template, key=lambda x: str(x["name"])):
+        print(f"  #{c['id']:>6}  {c['name']}  ({c['location']})")
+    print(f"\n=== {len(personal_nested)} vides NICHÉES EN PERSO (exclues par défaut — campagne sprawl) ===")
+    for c in sorted(personal_nested, key=lambda x: str(x["name"])):
+        print(f"  #{c['id']:>6}  {c['name']}  ({c['location']})")
+    if skipped:
+        print(f"\n=== {len(skipped)} sautées (contenu gagné / disparues / lecture KO) ===")
+        for c in skipped[:15]:
+            print(f"  #{c['id']:>6}  {str(c.get('name'))[:40]:40} — {c['why']}")
+
+    target = safe + (template if args.include_template else []) \
+        + (personal_nested if args.include_personal_nested else [])
+    if exclude_ids:
+        kept = [c for c in target if c["id"] not in exclude_ids]
+        print(f"\n--exclude : {len(target) - len(kept)} retirée(s) de la cible.")
+        target = kept
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log = MIGRATION_DIR / f"archive-empty-collections-{ts}.json"
+    log.write_text(json.dumps([c["id"] for c in target], indent=2))
+
+    # CSV de relecture (toutes les catégories), pour validation humaine
+    review = MIGRATION_DIR / f"empty-collections-review-{ts}.csv"
+    with review.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(["categorie", "id", "nom", "dossier_racine", "location"])
+        for label, rows_ in (("safe", safe), ("template", template), ("perso_niche", personal_nested)):
+            for c in sorted(rows_, key=lambda x: str(x["name"])):
+                w.writerow([label, c["id"], c["name"], _top_ancestor_name(c, live), c.get("location")])
+    print(f"\nCible d'archivage : {len(target)} collections — liste/rollback : {log}")
+    print(f"Relecture (CSV, {len(safe)+len(template)+len(personal_nested)} lignes) : {review}")
+
+    if not args.yes:
+        print("\n(DRY-RUN — rien archivé. Relancer avec --yes pour archiver.)")
+        return
+
+    print(f"\n=== Archivage de {len(target)} collections (réversible)... ===")
+    done, miss = [], []
+    for c in sorted(target, key=lambda x: len(x.get("location") or ""), reverse=True):  # enfants d'abord
+        cid = c["id"]
+        if reverify_empty(mb, cid, cand_ids) is not True:
+            print(f"  SAUTÉ #{cid} «{c['name']}» : non vide à la re-vérif")
+            miss.append(cid)
+            continue
+        rc = mb.put(f"/api/collection/{cid}", json={"archived": True})
+        if rc == 200:
+            done.append(cid)
+            print(f"  archivée #{cid} «{c['name']}»")
+        else:
+            print(f"  ÉCHEC #{cid} «{c['name']}» (HTTP {rc})")
+            miss.append(cid)
+    print(f"\n=== {len(done)} archivée(s), {len(miss)} sautée(s)/échec ===")
+    print(f"Rollback : PUT /api/collection/<id> {{archived:false}} pour les ids de {log}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/archive_stale_cards.py
+++ b/scripts/archive_stale_cards.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Archive les cartes « périmées » (0 dashboard, dormantes ≥ seuil) issues de l'audit. Réversible.
+
+Sécurité :
+- Source = dernier audit-findings (unused_cards avec stale=True). Récence = last_used_at.
+- Re-vérification LIVE avant chaque archivage : dashboard_count==0 ET non archivée
+  (instance active — saute si la carte a été remise sur un dashboard depuis le scan).
+- Exclut par défaut : template (collection sous /215/) et cartes en collection personnelle.
+- Réversible (PUT archived:false). Écrit rollback JSON + CSV de relecture.
+
+Usage :
+  python3 scripts/archive_stale_cards.py                       # dry-run (catégorise)
+  python3 scripts/archive_stale_cards.py --yes                 # archive le set "safe"
+  python3 scripts/archive_stale_cards.py --min-days 365 --yes  # dormance ≥ 1 an
+  python3 scripts/archive_stale_cards.py --include-template --include-personal --exclude 1,2
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+import audit_lib  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+CACHE_DIR = MIGRATION_DIR / "audit-cache"
+TEMPLATE_ROOT_ID = 215
+
+
+def connect_resilient():
+    env = _load_env()
+    d, e, p = env.get("METABASE_DOMAIN"), env.get("METABASE_EMAIL"), env.get("METABASE_PASSWORD")
+    if not (d and e and p):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env.")
+    return Metabase_API(domain=d, email=e, password=p)
+
+
+def _latest_findings():
+    fs = sorted(MIGRATION_DIR.glob("audit-findings-*.json"))
+    if not fs:
+        sys.exit("Aucun audit-findings : lancer `audit.py scan` puis `deep`.")
+    return json.loads(fs[-1].read_text())
+
+
+def _collection_id(card_id):
+    f = CACHE_DIR / f"card-{card_id}.json"
+    if f.exists():
+        try:
+            return json.loads(f.read_text()).get("collection_id")
+        except Exception:
+            return None
+    return None
+
+
+# marqueur humain explicite « ne pas toucher » sur un nom de collection
+_FROZEN_RE = re.compile(r"do not modify|do not touch|ne pas (?:modifier|toucher)|☠", re.I)
+
+
+def _zone(coll_id, cols):
+    """frozen (marqueur 'ne pas toucher'), template (/215/), personal, ou other."""
+    if coll_id is None:
+        return "other"
+    col = cols.get(coll_id) or {}
+    loc = col.get("location") or ""
+    anc_ids = [coll_id] + [int(p) for p in loc.strip("/").split("/") if p.isdigit()]
+    for i in anc_ids:
+        if _FROZEN_RE.search((cols.get(i) or {}).get("name") or ""):
+            return "frozen"
+    for i in anc_ids:
+        if (cols.get(i) or {}).get("personal_owner_id"):
+            return "personal"
+    if coll_id == TEMPLATE_ROOT_ID or f"/{TEMPLATE_ROOT_ID}/" in loc:
+        return "template"
+    return "other"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--yes", action="store_true", help="archive réellement (sinon dry-run)")
+    ap.add_argument("--min-days", type=int, default=audit_lib.STALE_DAYS,
+                    help=f"seuil de dormance en jours (défaut {audit_lib.STALE_DAYS})")
+    ap.add_argument("--include-template", action="store_true")
+    ap.add_argument("--include-personal", action="store_true")
+    ap.add_argument("--exclude", default="", help="ids de cartes à retirer, séparés par des virgules")
+    ap.add_argument("--exclude-collection", default="",
+                    help="ids de collections à exclure entièrement, séparés par des virgules")
+    args = ap.parse_args()
+    exclude = {int(x) for x in args.exclude.split(",") if x.strip().isdigit()}
+    exclude_cols = {int(x) for x in args.exclude_collection.split(",") if x.strip().isdigit()}
+
+    blob = _latest_findings()
+    items = blob["findings"]["unused_cards"]["items"]
+    stale = [c for c in items if c.get("stale") and (c.get("days_since_used") or 0) >= args.min_days]
+
+    mb = connect_resilient()
+    cols = {c.get("id"): c for c in (mb.get("/api/collection/") or [])}
+
+    buckets = {"other": [], "template": [], "personal": [], "frozen": []}
+    for c in stale:
+        coll = _collection_id(c["id"])
+        z = _zone(coll, cols)
+        buckets[z].append({**c, "collection_id": coll, "collection": (cols.get(coll) or {}).get("name")})
+
+    print(f"Cartes périmées ≥{args.min_days}j : {len(stale)}")
+    for z in ("other", "template", "personal", "frozen"):
+        print(f"  {z:9}: {len(buckets[z])}")
+
+    target = list(buckets["other"])
+    if args.include_template:
+        target += buckets["template"]
+    if args.include_personal:
+        target += buckets["personal"]
+    target = [c for c in target if c["id"] not in exclude and c.get("collection_id") not in exclude_cols]
+    target.sort(key=lambda x: -(x.get("days_since_used") or 0))
+
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    review = MIGRATION_DIR / f"stale-cards-review-{ts}.csv"
+    with review.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(["zone", "id", "nom", "collection", "jours_inactif", "vues", "last_used_at"])
+        for z in ("other", "template", "personal"):
+            for c in sorted(buckets[z], key=lambda x: -(x.get("days_since_used") or 0)):
+                w.writerow([z, c["id"], c.get("name"), c.get("collection"),
+                            c.get("days_since_used"), c.get("view_count"), c.get("last_used_at")])
+    log = MIGRATION_DIR / f"archive-stale-cards-{ts}.json"
+    log.write_text(json.dumps([c["id"] for c in target], indent=2))
+    print(f"\nCible (safe, ≥{args.min_days}j, hors template/perso) : {len(target)} cartes")
+    print(f"CSV de relecture : {review}")
+    print(f"Rollback : {log}")
+    print("\nTop 12 plus dormantes de la cible :")
+    for c in target[:12]:
+        print(f"  #{c['id']:>6} {str(c.get('name'))[:36]:36} {c.get('days_since_used')}j, "
+              f"{c.get('view_count')} vues  [{str(c.get('collection'))[:24]}]")
+
+    if not args.yes:
+        print("\n(DRY-RUN — rien archivé. --yes pour archiver.)")
+        return
+
+    print(f"\n=== Archivage de {len(target)} cartes (re-vérif live)... ===")
+    done, skip = [], []
+    for c in target:
+        cid = c["id"]
+        live = mb.get(f"/api/card/{cid}")
+        if not isinstance(live, dict):
+            print(f"  SAUTÉ #{cid} : lecture KO")
+            skip.append(cid)
+            continue
+        if live.get("archived"):
+            skip.append(cid)
+            continue
+        if live.get("dashboard_count", 0) != 0:
+            print(f"  SAUTÉ #{cid} «{c.get('name')}» : {live['dashboard_count']} dashboard(s) maintenant")
+            skip.append(cid)
+            continue
+        rc = mb.put(f"/api/card/{cid}", json={"archived": True})
+        if rc == 200:
+            done.append(cid)
+        else:
+            print(f"  ÉCHEC #{cid} (HTTP {rc})")
+            skip.append(cid)
+    print(f"\n=== {len(done)} archivée(s), {len(skip)} sautée(s) ===")
+    print(f"Rollback : PUT /api/card/<id> {{archived:false}} pour les ids de {log}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/archive_superseded.py
+++ b/scripts/archive_superseded.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Archive les ANCIENS dashboards remplacés par une copie migrée (delete-by-presence, réversible).
+
+Pilote = migration/conv-migration-tracker.json. N'archive QUE les lignes avec `archive_old: true`
+(OPT-IN explicite), dont l'original est connu et pas déjà archivé. Garde-fou : refuse d'archiver un
+dashboard qui porte l'ancre [conv-2026-06] (= jamais une copie neuve).
+
+⚠️ On n'archive JAMAIS « tout ce qui n'a pas le tag » (delete-by-absence) : on cible UNIQUEMENT les
+anciens explicitement marqués dans le tracker. Archivage Metabase = réversible (PUT archived:false).
+
+Dry-run par défaut. --yes archive réellement.
+
+Usage :
+  python3 scripts/archive_superseded.py          # dry-run : liste ce qui serait archivé
+  python3 scripts/archive_superseded.py --yes     # archive + marque old_archived dans le tracker
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import conv_tracker as T  # noqa: E402
+from archive_collections import connect_resilient  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--yes", action="store_true", help="archive réellement (sinon dry-run)")
+    args = ap.parse_args()
+
+    tracker = T.load()
+    ids = set(T.archivable_originals(tracker))
+    if not ids:
+        print("Rien à archiver : aucune ligne `archive_old: true` (original connu, non archivé).")
+        print("→ Pose `archive_old: true` sur les lignes validées du tracker pour activer l'archivage.")
+        return
+
+    mb = connect_resilient()
+    print(f"{len(ids)} ancien(s) candidat(s) à l'archivage :\n")
+    done = 0
+    for e in tracker:
+        if e.get("original_id") not in ids or e.get("old_archived"):
+            continue
+        oid = e["original_id"]
+        d = mb.get(f"/api/dashboard/{oid}")
+        name = d.get("name") if d else None
+        if name is None:
+            print(f"  ⛔ #{oid} introuvable — sauté"); continue
+        if T.is_tagged(name):
+            print(f"  🛡️  #{oid} «{name}» porte l'ancre {T.TAG} → REFUSÉ (c'est une copie neuve)")
+            continue
+        if not args.yes:
+            print(f"  [dry-run] archiverait #{oid} «{name[:48]}» "
+                  f"(remplacé par copie {e.get('copy_id')}, {e.get('client')})")
+            continue
+        res = mb.put(f"/api/dashboard/{oid}", "raw", json={"archived": True})
+        ok = res.ok and (mb.get(f"/api/dashboard/{oid}") or {}).get("archived") is True
+        if ok:
+            e["old_archived"] = True; done += 1
+            print(f"  ✅ #{oid} «{name[:48]}» archivé (réversible)")
+        else:
+            print(f"  ❌ #{oid} échec PUT {res.status_code} {res.text[:160]}")
+
+    if args.yes and done:
+        T.save(tracker); T.render_to_file(tracker)
+        print(f"\n{done} ancien(s) archivé(s). Tracker + markdown mis à jour. Rollback : PUT archived:false.")
+    elif not args.yes:
+        print("\n(DRY-RUN — rien archivé. --yes pour archiver.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Audit instance-wide Metabase : scan (large) → deep (profond) → report.
+
+Lecture seule. Voir :
+  docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md
+  docs/superpowers/plans/2026-05-28-metabase-instance-audit.md
+
+Usage :
+  python3 scripts/audit.py scan
+  python3 scripts/audit.py deep [--limit N]
+  python3 scripts/audit.py report
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+import audit_lib  # noqa: E402
+from audit_report import render_report  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+CACHE_DIR = MIGRATION_DIR / "audit-cache"
+DOCS_DIR = REPO_ROOT / "docs" / "audits"
+
+
+def connect_resilient():
+    """Connexion email/password (résiste à l'expiration de session sur run long)."""
+    env = _load_env()
+    domain, email, password = (env.get("METABASE_DOMAIN"),
+                               env.get("METABASE_EMAIL"),
+                               env.get("METABASE_PASSWORD"))
+    if not (domain and email and password):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env (run long).")
+    return Metabase_API(domain=domain, email=email, password=password)
+
+
+def _safe_get(mb, endpoint):
+    """GET tolérant : retourne [] sur erreur réseau/HTTP au lieu de tuer le run.
+
+    L'endpoint des archivées est volumineux et l'instance renvoie parfois un
+    ConnectionError transitoire (constaté lors de la conception).
+    """
+    try:
+        r = mb.get(endpoint)
+    except Exception as e:  # ConnectionError, Timeout, ...
+        print(f"  ⚠️  {endpoint} a échoué ({type(e).__name__}) — ignoré.")
+        return []
+    return r or []
+
+
+def _latest(prefix):
+    files = sorted(MIGRATION_DIR.glob(f"{prefix}-*.json"))
+    return files[-1] if files else None
+
+
+def _template_card_ids(collections, cards):
+    """Ids des cartes sous l'arbre du template (215), via location."""
+    root = audit_lib.TEMPLATE_ROOT_ID
+    tpl_cols = {c.get("id") for c in collections
+                if c.get("id") == root or f"/{root}/" in (c.get("location") or "")}
+    tpl_cols.add(root)
+    return {c["id"] for c in cards if c.get("collection_id") in tpl_cols}
+
+
+def cmd_scan(args):
+    mb = connect_resilient()
+    print("Passe large : collections, cartes, dashboards (+ archivés)...")
+    collections = _safe_get(mb, "/api/collection/")
+    arch_cols = _safe_get(mb, "/api/collection/?archived=true")
+    cards = _safe_get(mb, "/api/card/")
+    arch_cards = _safe_get(mb, "/api/card/?f=archived")
+    dashboards = _safe_get(mb, "/api/dashboard/")
+
+    template_ids = _template_card_ids(collections, cards)
+
+    findings = {}
+    empty = audit_lib.find_empty_collections(collections, cards, dashboards)
+    findings["empty_collections"] = {"count": len(empty), "items": empty}
+    junk = audit_lib.find_junk_collections(collections)
+    findings["junk_collections"] = {"count": len(junk), "items": junk}
+    dn = audit_lib.find_duplicate_collection_names(collections)
+    findings["dup_collection_names"] = {"count": len(dn), "items": dn}
+    sprawl = audit_lib.find_personal_sprawl(collections, cards)
+    findings["personal_sprawl"] = {"count": len(sprawl), "items": sprawl}
+    naming = audit_lib.find_naming_issues(cards, template_ids)
+    findings["naming_issues"] = {"count": len(naming), "items": naming}
+    findings["archived_backlog"] = {
+        "count": len(arch_cards) + len(arch_cols),
+        "items": [{"archived_cards": len(arch_cards), "archived_collections": len(arch_cols)}],
+    }
+    # #5 inutilisées : compte provisoire (sans graphe de sources), affiné en `deep`
+    prelim = [c for c in cards if c.get("dashboard_count", 0) == 0 and not c.get("archived")]
+    findings["unused_cards"] = {"count": len(prelim),
+                                "items": [{"id": c["id"], "name": c.get("name")} for c in prelim],
+                                "preliminary": True}
+    # patterns enrichis par la passe profonde
+    for k in ("pure_dups", "variant_families", "template_drift", "expensive_cards"):
+        findings.setdefault(k, {"count": 0, "items": []})
+
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = MIGRATION_DIR / f"audit-findings-{ts}.json"
+    out.write_text(json.dumps({
+        "meta": {"scanned_collections": len(collections), "scanned_cards": len(cards),
+                 "archived_cards": len(arch_cards), "archived_collections": len(arch_cols),
+                 "template_card_ids": sorted(template_ids), "deep_done": False},
+        "findings": findings,
+    }, indent=2, ensure_ascii=False))
+    print(f"  {len(collections)} collections, {len(cards)} cartes, {len(dashboards)} dashboards")
+    print(f"  vides:{len(empty)} fourre-tout:{len(junk)} noms-dupes:{len(dn)} "
+          f"sprawl:{len(sprawl)} nommage:{len(naming)} archivées:{len(arch_cards)}/{len(arch_cols)}")
+    print(f"Findings écrits : {out}")
+
+
+def _card_detail(mb, cid):
+    """Fetch /api/card/{id} avec cache disque (reprenable). 3 essais espacés."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    f = CACHE_DIR / f"card-{cid}.json"
+    if f.exists():
+        return json.loads(f.read_text())
+    for attempt in range(3):
+        try:
+            d = mb.get(f"/api/card/{cid}")
+        except Exception:
+            d = None
+        if d:
+            f.write_text(json.dumps(d, ensure_ascii=False))
+            return d
+        time.sleep(1.5 * (attempt + 1))
+    return None
+
+
+def cmd_deep(args):
+    mb = connect_resilient()
+    findings_file = _latest("audit-findings")
+    if not findings_file:
+        sys.exit("Aucun audit-findings : lancer `scan` d'abord.")
+    blob = json.loads(findings_file.read_text())
+
+    cards = _safe_get(mb, "/api/card/")
+    if args.limit:
+        cards = cards[:args.limit]
+    print(f"Passe profonde : fetch de {len(cards)} requêtes (cache {CACHE_DIR})...")
+    details = []
+    for i, c in enumerate(cards, 1):
+        d = _card_detail(mb, c["id"])
+        if d:
+            details.append(d)
+        if i % 200 == 0:
+            print(f"  {i}/{len(cards)}")
+
+    groups = audit_lib.classify_query_groups(details)
+    source_ids = audit_lib.build_source_ids(details)
+    unused = audit_lib.find_unused_cards(details, source_ids)
+
+    tpl_ids = set(blob["meta"].get("template_card_ids", []))
+    tpl_cards = [d for d in details if d["id"] in tpl_ids]
+    other_cards = [d for d in details if d["id"] not in tpl_ids]
+    drift = audit_lib.find_template_drift(tpl_cards, other_cards)
+
+    f = blob["findings"]
+    f["pure_dups"] = {"count": len(groups["pure_dups"]),
+                      "items": [[{"id": c["id"], "name": c.get("name"), "display": c.get("display")}
+                                 for c in g] for g in groups["pure_dups"]]}
+    f["variant_families"] = {"count": len(groups["variant_families"]),
+                             "items": [[{"id": c["id"], "name": c.get("name")} for c in g]
+                                       for g in groups["variant_families"]]}
+    f["unused_cards"] = {"count": len(unused),
+                         "items": [{"id": c["id"], "name": c.get("name")} for c in unused]}
+    f["template_drift"] = {"count": len(drift), "items": drift}
+    blob["meta"]["deep_done"] = True
+    findings_file.write_text(json.dumps(blob, indent=2, ensure_ascii=False))
+    print(f"  doublons:{len(groups['pure_dups'])} variantes:{len(groups['variant_families'])} "
+          f"inutilisées:{len(unused)} dérive:{len(drift)}")
+    print(f"Findings enrichis : {findings_file}")
+
+
+def cmd_report(args):
+    findings_file = _latest("audit-findings")
+    if not findings_file:
+        sys.exit("Aucun audit-findings : lancer `scan` d'abord.")
+    blob = json.loads(findings_file.read_text())
+    if not blob["meta"].get("deep_done"):
+        print("⚠️  passe profonde non exécutée — doublons/variantes/dérive seront à 0. "
+              "Lancer `deep` pour un rapport complet.")
+    md = render_report(blob["findings"],
+                       scanned_cards=blob["meta"].get("scanned_cards", 0),
+                       scanned_collections=blob["meta"].get("scanned_collections", 0),
+                       date=datetime.now().strftime("%Y-%m-%d"))
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    out = DOCS_DIR / f"audit-{datetime.now().strftime('%Y%m%d')}.md"
+    out.write_text(md)
+    print(f"Rapport écrit : {out}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("scan")
+    d = sub.add_parser("deep")
+    d.add_argument("--limit", type=int, default=0, help="ne traiter que les N premières cartes (test)")
+    sub.add_parser("report")
+    args = p.parse_args()
+    {"scan": cmd_scan, "deep": cmd_deep, "report": cmd_report}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -175,13 +175,33 @@ def cmd_deep(args):
     f["variant_families"] = {"count": len(groups["variant_families"]),
                              "items": [[{"id": c["id"], "name": c.get("name")} for c in g]
                                        for g in groups["variant_families"]]}
-    f["unused_cards"] = {"count": len(unused),
-                         "items": [{"id": c["id"], "name": c.get("name")} for c in unused]}
+    now_iso = datetime.now().strftime("%Y-%m-%d")
+    unused_items = [{
+        "id": c["id"], "name": c.get("name"),
+        "last_used_at": c.get("last_used_at"),
+        "view_count": c.get("view_count") or 0,
+        "days_since_used": audit_lib.days_since(c.get("last_used_at"), now_iso),
+        "stale": audit_lib.is_stale(c, now_iso),
+    } for c in unused]
+    # plus périmées d'abord : jamais utilisées (None) en tête, puis ancienneté, puis vues
+    unused_items.sort(key=lambda x: (-(x["days_since_used"] if x["days_since_used"] is not None else 10**9),
+                                      x["view_count"]))
+    stale_count = sum(1 for u in unused_items if u["stale"])
+    f["unused_cards"] = {"count": len(unused_items), "stale_count": stale_count, "items": unused_items}
+
+    # #11 perf : cartes les plus lentes (average_query_time en ms)
+    exp = [c for c in details if (c.get("average_query_time") or 0) >= 10000 and not c.get("archived")]
+    exp.sort(key=lambda c: -(c.get("average_query_time") or 0))
+    f["expensive_cards"] = {"count": len(exp),
+                            "items": [{"id": c["id"], "name": c.get("name"),
+                                       "avg_query_ms": round(c.get("average_query_time") or 0),
+                                       "view_count": c.get("view_count") or 0} for c in exp]}
+
     f["template_drift"] = {"count": len(drift), "items": drift}
     blob["meta"]["deep_done"] = True
     findings_file.write_text(json.dumps(blob, indent=2, ensure_ascii=False))
     print(f"  doublons:{len(groups['pure_dups'])} variantes:{len(groups['variant_families'])} "
-          f"inutilisées:{len(unused)} dérive:{len(drift)}")
+          f"inutilisées:{len(unused)} (périmées≥6mois:{stale_count}) lentes:{len(exp)} dérive:{len(drift)}")
     print(f"Findings enrichis : {findings_file}")
 
 

--- a/scripts/audit_brand_clause.py
+++ b/scripts/audit_brand_clause.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Audit LECTURE SEULE des clauses d'exclusion brand sur le sous-arbre 11673
+(+ nos cartes 13884/13885). Règle métier (user, 2026-06-11) : l'exclusion brand
+doit tester campaign_TYPE uniquement ; toute clause testant channel / category /
+network / product / name est FAUSSE.
+
+Sortie : migration/brand-clause-audit.json + résumé console.
+Usage : .venv/bin/python scripts/audit_brand_clause.py
+"""
+import json, re, sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from archive_collections import connect_resilient
+import conv_lib
+
+# toute condition « ... campaign_<col> ... NOT LIKE '%brand%' »
+RX = re.compile(r"campaign_(\w+)\s*,\s*''\s*\)\s*\)\s*NOT\s+LIKE\s*'%brand%'", re.I)
+
+def main():
+    mb = connect_resilient()
+    inv = json.loads((REPO / "migration" / "temporal-unit-inventory.json").read_text())
+    ids = sorted({c["id"] for c in inv["cards"]})
+    ids += [49095, 49096, 49097, 49098, 49100, 49101, 49102, 49103, 49104, 49105, 49106, 49107]
+    print("cartes à scanner:", len(ids))
+
+    def scan(cid):
+        try:
+            c = mb.get(f"/api/card/{cid}")
+            sql, _ = conv_lib.native_and_tags(c)
+            cols = sorted({m.group(1).lower() for m in RX.finditer(sql)})
+            return {"id": cid, "name": c.get("name"), "collection": c.get("collection_id"),
+                    "cols": cols, "archived": c.get("archived", False)}
+        except Exception as e:
+            return {"id": cid, "error": str(e)[:120]}
+
+    with ThreadPoolExecutor(8) as ex:
+        out = list(ex.map(scan, ids))
+
+    errors = [o for o in out if "error" in o]
+    with_brand = [o for o in out if o.get("cols")]
+    wrong = [o for o in with_brand if o["cols"] != ["type"]]
+    print(f"erreurs: {len(errors)} | avec clause brand: {len(with_brand)} | "
+          f"correctes (type seul): {len(with_brand) - len(wrong)} | FAUSSES: {len(wrong)}")
+    for combo, n in Counter(tuple(o["cols"]) for o in wrong).most_common():
+        print(f"  {n:5d} cartes testent {list(combo)}")
+    (REPO / "migration" / "brand-clause-audit.json").write_text(json.dumps(out, ensure_ascii=False))
+    print("audit sauvé: migration/brand-clause-audit.json")
+    print("nos cartes (>=49095) à corriger:", sorted(o["id"] for o in wrong if o["id"] >= 49095))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_extract_checks.py
+++ b/scripts/audit_extract_checks.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Extracteur de cards Metabase "check" -> backlog de portage dbt (audit engine, phase 2).
+
+Lecture seule. Pour chaque card Metabase d'une regle d'audit, on dump :
+  - le SQL natif (format MLv2 `dataset_query.stages[0].native`, fallback legacy `native.query`),
+  - les template-tags (params de scope/seuil),
+  - les colonnes de sortie (result_metadata) -> doit matcher audit_check/ratio/target/value,
+  - les tables sources (schema.table) reperees dans le SQL -> a mapper en ref() dbt.
+
+Sortie : un fichier .sql par card + un manifest.json + un BACKLOG.md (checklist de port).
+
+Sources d'ids :
+  --backlog <alert_cards.json>   lit les check_card_id / details_card_id du fichier de survey Airtable
+  --ids 11089,11090,11088        liste explicite d'ids de cards
+  --details                      inclut aussi les details_card_id du backlog
+
+Usage :
+  python3 scripts/audit_extract_checks.py --backlog ~/Downloads/audit-engine-redesign/metabase-cards/alert_cards.json
+  python3 scripts/audit_extract_checks.py --ids 11089,11088 --out /tmp/cards
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+
+DEFAULT_OUT = Path.home() / "Downloads" / "audit-engine-redesign" / "metabase-cards"
+
+
+def connect() -> Metabase_API:
+    """Connexion email/password (resiste a l'expiration de session)."""
+    e = _load_env()
+    missing = [k for k in ("METABASE_DOMAIN", "METABASE_EMAIL", "METABASE_PASSWORD") if not e.get(k)]
+    if missing:
+        sys.exit(f"Creds manquants dans .env : {', '.join(missing)}")
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def extract_native(dataset_query: dict) -> tuple[str, dict]:
+    """Renvoie (sql, template_tags) en gerant MLv2 (stages) et le format legacy."""
+    if not isinstance(dataset_query, dict):
+        return "", {}
+    # MLv2 / pMBQL : dataset_query.stages[0] = {"native": "<sql>", "template-tags": {...}}
+    stages = dataset_query.get("stages")
+    if isinstance(stages, list) and stages:
+        st = stages[0] or {}
+        sql = st.get("native") or ""
+        tags = st.get("template-tags") or {}
+        if sql:
+            return sql, tags
+    # Legacy : dataset_query.native = {"query": "<sql>", "template-tags": {...}}
+    native = dataset_query.get("native") or {}
+    return native.get("query") or "", native.get("template-tags") or {}
+
+
+_TABLE_RE = re.compile(r"(?is)\b(?:from|join)\s+([a-z_][\w$]*\.[a-z_][\w$]*)")
+
+
+def source_tables(sql: str) -> list[str]:
+    """Tables schema.table reperees apres FROM/JOIN (hors CTE), dedupliquees, ordonnees."""
+    seen: dict[str, None] = {}
+    for m in _TABLE_RE.findall(sql or ""):
+        seen.setdefault(m.lower(), None)
+    return list(seen)
+
+
+def slugify(name: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "_", (name or "").lower()).strip("_")
+    return s or "card"
+
+
+def fetch_card(mb: Metabase_API, card_id: int) -> dict | None:
+    try:
+        return mb.get(endpoint=f"/api/card/{card_id}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! card {card_id}: echec fetch ({exc})")
+        return None
+
+
+def tag_summary(tags: dict) -> list[dict]:
+    """Resume chaque template-tag : name, type, default, required, dimension (field-filter)."""
+    out = []
+    for name, t in (tags or {}).items():
+        t = t or {}
+        out.append({
+            "name": name,
+            "type": t.get("type"),                 # text | number | date | dimension
+            "default": t.get("default"),
+            "required": t.get("required", False),
+            "dimension": t.get("dimension"),       # ['field', <id>, ...] pour les field-filters
+        })
+    return sorted(out, key=lambda x: x["name"])
+
+
+def card_record(card: dict, meta: dict) -> dict:
+    sql, tags = extract_native(card.get("dataset_query") or {})
+    out_cols = [c.get("name") for c in (card.get("result_metadata") or []) if c.get("name")]
+    tag_details = tag_summary(tags)
+    return {
+        "card_id": card.get("id"),
+        "card_name": card.get("name"),
+        "archived": card.get("archived"),
+        "collection_id": card.get("collection_id"),
+        "database_id": card.get("database_id"),
+        "query_type": card.get("query_type"),
+        "output_columns": out_cols,
+        "template_tags": [t["name"] for t in tag_details],
+        "template_tag_details": tag_details,
+        "source_tables": source_tables(sql),
+        "sql_len": len(sql),
+        **meta,  # checkpoint_record_id, checkpoint_id, name (Airtable), platform, severity, role
+        "_sql": sql,
+    }
+
+
+def write_sql_file(out: Path, rec: dict) -> Path:
+    slug = slugify(rec.get("name") or rec.get("card_name") or "")
+    path = out / f"{rec['card_id']}__{slug}.sql"
+    tag_lines = [
+        f"--   {t['name']:<16} type={t.get('type')!s:<10} default={t.get('default')!r}"
+        + (f" dimension={t.get('dimension')}" if t.get("dimension") else "")
+        for t in (rec.get("template_tag_details") or [])
+    ]
+    header = [
+        f"-- Metabase card {rec['card_id']} : {rec.get('card_name')}",
+        f"-- Airtable check   : {rec.get('name')} [{rec.get('platform')}] severity={rec.get('severity')} role={rec.get('role')}",
+        f"-- checkpoint_record_id : {rec.get('checkpoint_record_id')}  (checkpoint_id={rec.get('checkpoint_id')})",
+        f"-- output columns  : {', '.join(rec.get('output_columns') or []) or '(n/a)'}",
+        f"-- source tables    : {', '.join(rec.get('source_tables') or []) or '(none parsed)'}",
+        "-- template tags (name / type / DEFAULT = threshold source for alerts) :",
+        *(tag_lines or ["--   (none)"]),
+        "-- " + "-" * 70,
+        "",
+    ]
+    path.write_text("\n".join(header) + (rec.get("_sql") or "") + "\n")
+    return path
+
+
+def load_targets(args) -> list[dict]:
+    """Renvoie une liste de {card_id, role, ...meta} a extraire."""
+    targets: list[dict] = []
+    if args.backlog:
+        data = json.loads(Path(args.backlog).expanduser().read_text())
+        for chk in data.get("checks", []):
+            base = {k: chk.get(k) for k in ("checkpoint_record_id", "checkpoint_id", "name", "platform", "severity")}
+            if chk.get("check_card_id"):
+                targets.append({"card_id": int(chk["check_card_id"]), "role": "check", **base})
+            if args.details and chk.get("details_card_id"):
+                targets.append({"card_id": int(chk["details_card_id"]), "role": "details", **base})
+    if args.ids:
+        for raw in args.ids.split(","):
+            raw = raw.strip()
+            if raw:
+                targets.append({"card_id": int(raw), "role": "check"})
+    # dedup par card_id (garde la 1re occurrence)
+    seen: dict[int, dict] = {}
+    for t in targets:
+        seen.setdefault(t["card_id"], t)
+    return list(seen.values())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--backlog", help="JSON de survey (alert_cards.json) : lit check_card_id / details_card_id")
+    ap.add_argument("--ids", help="Liste explicite d'ids de cards, separes par des virgules")
+    ap.add_argument("--details", action="store_true", help="Inclure aussi les details_card_id du backlog")
+    ap.add_argument("--out", default=str(DEFAULT_OUT), help=f"Dossier de sortie (def: {DEFAULT_OUT})")
+    args = ap.parse_args()
+
+    if not args.backlog and not args.ids:
+        ap.error("fournir --backlog et/ou --ids")
+
+    targets = load_targets(args)
+    if not targets:
+        sys.exit("Aucune card a extraire (check_card_id tous nuls ?).")
+
+    out = Path(args.out).expanduser()
+    out.mkdir(parents=True, exist_ok=True)
+
+    mb = connect()
+    print(f"Extraction de {len(targets)} card(s) -> {out}")
+
+    manifest: list[dict] = []
+    for t in sorted(targets, key=lambda x: x["card_id"]):
+        cid = t["card_id"]
+        card = fetch_card(mb, cid)
+        if card is None:
+            manifest.append({"card_id": cid, "role": t.get("role"), "error": "fetch_failed", **{k: v for k, v in t.items() if k != "card_id"}})
+            continue
+        rec = card_record(card, {k: v for k, v in t.items() if k != "card_id"})
+        path = write_sql_file(out, rec)
+        public = {k: v for k, v in rec.items() if k != "_sql"}
+        public["sql_file"] = path.name
+        manifest.append(public)
+        print(f"  ok card {cid:<6} role={t.get('role'):<7} cols={len(rec['output_columns'])} tags={len(rec['template_tags'])} -> {path.name}")
+
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+    _write_backlog_md(out, manifest)
+    print(f"\nManifest : {out / 'manifest.json'}")
+    print(f"Backlog  : {out / 'BACKLOG.md'}")
+    return 0
+
+
+def _write_backlog_md(out: Path, manifest: list[dict]) -> None:
+    lines = ["# Metabase check cards — port backlog", "", f"{len(manifest)} card(s) extracted.", ""]
+    lines.append("| card | role | platform | sev | output cols | template tags | source tables | airtable check |")
+    lines.append("|------|------|----------|-----|-------------|---------------|---------------|----------------|")
+    for m in manifest:
+        if m.get("error"):
+            lines.append(f"| {m['card_id']} | {m.get('role','')} | | | **{m['error']}** | | | {m.get('name','')} |")
+            continue
+        lines.append(
+            f"| {m['card_id']} | {m.get('role','')} | {m.get('platform','')} | {m.get('severity','')} "
+            f"| {', '.join(m.get('output_columns') or [])} | {', '.join(m.get('template_tags') or [])} "
+            f"| {', '.join(m.get('source_tables') or [])} | {m.get('name','')} |"
+        )
+    (out / "BACKLOG.md").write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_lib.py
+++ b/scripts/audit_lib.py
@@ -193,7 +193,10 @@ def find_empty_collections(collections, cards, dashboards):
     empty = []
     for col in collections:
         cid = col.get("id")
-        if _is_personal(col) or cid in occupied or cid in occupied_ancestors:
+        # exclut la racine Metabase ("Our analytics", id="root" non entier) et les perso
+        if not isinstance(cid, int) or _is_personal(col):
+            continue
+        if cid in occupied or cid in occupied_ancestors:
             continue
         empty.append({"id": cid, "name": col.get("name"), "location": col.get("location") or "/"})
     return empty

--- a/scripts/audit_lib.py
+++ b/scripts/audit_lib.py
@@ -193,8 +193,10 @@ def find_empty_collections(collections, cards, dashboards):
     empty = []
     for col in collections:
         cid = col.get("id")
-        # exclut la racine Metabase ("Our analytics", id="root" non entier) et les perso
-        if not isinstance(cid, int) or _is_personal(col):
+        # exclut : racine Metabase ("Our analytics", id non entier), perso, et les
+        # collections SYSTÈME (type non nul : 'library', 'library-data'… — la Metrics
+        # Library de Metabase, non archivable : "Cannot update properties on a Library collection").
+        if not isinstance(cid, int) or _is_personal(col) or col.get("type"):
             continue
         if cid in occupied or cid in occupied_ancestors:
             continue

--- a/scripts/audit_lib.py
+++ b/scripts/audit_lib.py
@@ -74,18 +74,31 @@ def query_fingerprint(card):
 def _output_selection(card):
     """Ce que la carte AFFICHE réellement — la clé des faux positifs.
 
-    Graphes : graph.metrics + graph.dimensions. Tables/pivots : colonnes activées.
+    Trois sources distinguent des variantes de vrais doublons :
+    - graphes : graph.metrics + graph.dimensions ;
+    - tables/pivots : colonnes activées ;
+    - défauts de paramètres (ex. `breakdown`=['device'|'age'|...]) : même SQL/viz
+      mais rendu différent par défaut (constaté en prod sur "Conversions by …").
     """
     vs = card.get("visualization_settings", {}) or {}
+    parts = {}
     metrics = vs.get("graph.metrics")
     dims = vs.get("graph.dimensions")
     if metrics or dims:
-        return json.dumps({"m": sorted(metrics or []), "d": sorted(dims or [])}, sort_keys=True)
-    cols = vs.get("table.columns")
-    if cols:
-        enabled = [c.get("name") for c in cols if isinstance(c, dict) and c.get("enabled", True)]
-        return json.dumps({"cols": enabled}, sort_keys=True)
-    return ""
+        # Donnée réelle parfois sale : la liste peut contenir des None -> on les
+        # écarte et on stringifie avant de trier (sorted() ne compare pas None à str).
+        parts["m"] = sorted(str(x) for x in (metrics or []) if x is not None)
+        parts["d"] = sorted(str(x) for x in (dims or []) if x is not None)
+    else:
+        cols = vs.get("table.columns")
+        if cols:
+            parts["cols"] = [c.get("name") for c in cols if isinstance(c, dict) and c.get("enabled", True)]
+    pdef = {p.get("slug"): p.get("default")
+            for p in (card.get("parameters") or [])
+            if p.get("default") is not None}
+    if pdef:
+        parts["p"] = pdef
+    return json.dumps(parts, sort_keys=True) if parts else ""
 
 
 def output_fingerprint(card):

--- a/scripts/audit_lib.py
+++ b/scripts/audit_lib.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Logique d'analyse de l'audit instance-wide (pur, testable, aucune I/O réseau).
+
+Empreintes de requête v2, détecteurs de patterns, scoring. Les fonctions opèrent
+sur des listes de dicts déjà récupérés par audit.py.
+
+Voir docs/superpowers/specs/2026-05-28-metabase-instance-audit-design.md
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from rename_lib import normalize_name  # noqa: E402  (réutilise la normalisation Phase 1.5)
+
+TEMPLATE_ROOT_ID = 215
+
+# Registre des patterns : scoring Impact/Risque/Effort + vague (cf. spec §6).
+PATTERNS = {
+    "empty_collections":    {"num": 1,  "family": "structurel", "impact": "H", "risk": "L", "effort": "L", "wave": 0},
+    "personal_sprawl":      {"num": 2,  "family": "structurel", "impact": "H", "risk": "H", "effort": "M", "wave": 2},
+    "dup_collection_names": {"num": 3,  "family": "structurel", "impact": "M", "risk": "M", "effort": "M", "wave": 2},
+    "junk_collections":     {"num": 4,  "family": "structurel", "impact": "M", "risk": "L", "effort": "L", "wave": 0},
+    "unused_cards":         {"num": 5,  "family": "gaspillage", "impact": "H", "risk": "L", "effort": "L", "wave": 1},
+    "pure_dups":            {"num": 6,  "family": "gaspillage", "impact": "H", "risk": "M", "effort": "M", "wave": 1},
+    "archived_backlog":     {"num": 7,  "family": "gaspillage", "impact": "M", "risk": "L", "effort": "L", "wave": 0},
+    "template_drift":       {"num": 8,  "family": "dry",        "impact": "H", "risk": "H", "effort": "H", "wave": 3},
+    "variant_families":     {"num": 9,  "family": "dry",        "impact": "M", "risk": "M", "effort": "H", "wave": 3},
+    "naming_issues":        {"num": 10, "family": "nommage",    "impact": "M", "risk": "L", "effort": "M", "wave": 1},
+    "expensive_cards":      {"num": 11, "family": "perf",       "impact": "M", "risk": "L", "effort": "M", "wave": 3},
+}
+
+
+# --- Empreintes v2 -----------------------------------------------------------
+
+def _legacy_query(card):
+    """Retourne le legacy_query (dict) ou None.
+
+    Via l'API, `dataset_query` (nouveau format) ressort souvent vide ;
+    `legacy_query` (string JSON) porte la requête classique fiable.
+    """
+    lq = card.get("legacy_query")
+    if isinstance(lq, str):
+        try:
+            lq = json.loads(lq)
+        except Exception:
+            lq = None
+    return lq if isinstance(lq, dict) and lq else None
+
+
+def query_fingerprint(card):
+    """Empreinte de la REQUÊTE seule (SQL/MBQL normalisé + base). Identité logique."""
+    lq = _legacy_query(card)
+    if lq is None:
+        dq = card.get("dataset_query", {}) or {}
+        return "ds|" + hashlib.md5(json.dumps(dq, sort_keys=True).encode()).hexdigest()
+    db = lq.get("database")
+    if lq.get("type") == "native":
+        sql = (lq.get("native", {}) or {}).get("query", "") or ""
+        norm = re.sub(r"\s+", " ", sql.strip().lower())
+        payload = f"native|{db}|{norm}"
+    else:
+        payload = f"mbql|{db}|" + json.dumps(lq.get("query", {}), sort_keys=True)
+    return hashlib.md5(payload.encode()).hexdigest()
+
+
+def _output_selection(card):
+    """Ce que la carte AFFICHE réellement — la clé des faux positifs.
+
+    Graphes : graph.metrics + graph.dimensions. Tables/pivots : colonnes activées.
+    """
+    vs = card.get("visualization_settings", {}) or {}
+    metrics = vs.get("graph.metrics")
+    dims = vs.get("graph.dimensions")
+    if metrics or dims:
+        return json.dumps({"m": sorted(metrics or []), "d": sorted(dims or [])}, sort_keys=True)
+    cols = vs.get("table.columns")
+    if cols:
+        enabled = [c.get("name") for c in cols if isinstance(c, dict) and c.get("enabled", True)]
+        return json.dumps({"cols": enabled}, sort_keys=True)
+    return ""
+
+
+def output_fingerprint(card):
+    """Empreinte FONCTIONNELLE : requête + display + sélection affichée.
+
+    Même output_fingerprint ⇒ rendu identique ⇒ vrai doublon (#6). Même
+    query_fingerprint mais output ≠ (ex. GSC clics/CTR/position) ⇒ variante (#9).
+    """
+    payload = f"{query_fingerprint(card)}|{card.get('display') or ''}|{_output_selection(card)}"
+    return hashlib.md5(payload.encode()).hexdigest()
+
+
+# --- Classification doublons / variantes -------------------------------------
+
+def classify_query_groups(cards):
+    """Classe les cartes partageant une même requête. Enrichit chaque carte de
+    'query_fp' et 'output_fp'. Retourne {pure_dups, variant_families, diff_viz}.
+    """
+    for c in cards:
+        c["query_fp"] = query_fingerprint(c)
+        c["output_fp"] = output_fingerprint(c)
+
+    by_q = defaultdict(list)
+    for c in cards:
+        by_q[c["query_fp"]].append(c)
+
+    pure_dups, variant_families, diff_viz = [], [], []
+    for _q, group in by_q.items():
+        if len(group) < 2:
+            continue
+        by_out = defaultdict(list)
+        for c in group:
+            by_out[c["output_fp"]].append(c)
+        for _out, sub in by_out.items():
+            if len(sub) >= 2:
+                pure_dups.append(sub)                 # #6 : rendu identique
+        displays = {c.get("display") or "" for c in group}
+        if len(by_out) >= 2 and len(displays) == 1:
+            variant_families.append(group)            # #9 : même viz, sélection ≠
+        if len(displays) >= 2:
+            diff_viz.append(group)                    # même logique, viz ≠
+    pure_dups.sort(key=len, reverse=True)
+    variant_families.sort(key=len, reverse=True)
+    return {"pure_dups": pure_dups, "variant_families": variant_families, "diff_viz": diff_viz}
+
+
+# --- Graphe de sources / cartes inutilisées ----------------------------------
+
+_CARD_SRC_RE = re.compile(r"card__(\d+)")
+
+
+def build_source_ids(card_details):
+    """Ids des cartes référencées comme SOURCE par une autre (`card__<id>`)."""
+    source_ids = set()
+    for d in card_details:
+        lq = d.get("legacy_query")
+        lq_blob = lq if isinstance(lq, str) else json.dumps(lq or {})
+        blob = json.dumps(d.get("dataset_query", {})) + lq_blob
+        for m in _CARD_SRC_RE.findall(blob):
+            source_ids.add(int(m))
+    return source_ids
+
+
+def find_unused_cards(cards, source_ids):
+    """Cartes 0 dashboard, non archivées, non utilisées comme source (règle 'hors sources')."""
+    return [c for c in cards
+            if c.get("dashboard_count", 0) == 0
+            and not c.get("archived")
+            and c["id"] not in source_ids]
+
+
+# --- Détecteurs de collections -----------------------------------------------
+
+def _is_personal(col):
+    return bool(col.get("personal_owner_id"))
+
+
+def find_empty_collections(collections, cards, dashboards):
+    """Collections non-perso sans carte/dashboard actif ET sans descendant occupé."""
+    occupied = {c.get("collection_id") for c in cards if not c.get("archived")}
+    occupied |= {d.get("collection_id") for d in dashboards if not d.get("archived")}
+    occupied.discard(None)
+
+    # ids de toutes les collections-ancêtres d'une collection occupée (via location)
+    occupied_ancestors = set()
+    for col in collections:
+        if col.get("id") in occupied:
+            for part in (col.get("location") or "/").strip("/").split("/"):
+                if part.isdigit():
+                    occupied_ancestors.add(int(part))
+
+    empty = []
+    for col in collections:
+        cid = col.get("id")
+        if _is_personal(col) or cid in occupied or cid in occupied_ancestors:
+            continue
+        empty.append({"id": cid, "name": col.get("name"), "location": col.get("location") or "/"})
+    return empty
+
+
+_JUNK_RE = re.compile(
+    r"\b(to ?sort|[àa] trier|test|tmp|temp|old|draft|brouillon|wip|backup|"
+    r"sauvegarde|copy|copie|untitled|sans titre|delete|supprimer)\b", re.I)
+
+
+def find_junk_collections(collections):
+    """Collections non-perso dont le nom évoque du fourre-tout / staging."""
+    out = []
+    for col in collections:
+        if _is_personal(col):
+            continue
+        name = col.get("name") or ""
+        if _JUNK_RE.search(name):
+            out.append({"id": col.get("id"), "name": name, "location": col.get("location") or "/"})
+    return out
+
+
+def find_duplicate_collection_names(collections):
+    """Noms de collections apparaissant plus d'une fois."""
+    names = defaultdict(list)
+    for col in collections:
+        nm = (col.get("name") or "").strip()
+        if nm:
+            names[nm].append({"id": col.get("id"),
+                              "location": col.get("location") or "/",
+                              "personal": _is_personal(col)})
+    return [{"name": nm, "count": len(entries), "entries": entries}
+            for nm, entries in names.items() if len(entries) > 1]
+
+
+# --- Sprawl perso / nommage --------------------------------------------------
+
+_CLIENT_PREFIX_RE = re.compile(r"^\s*(.+?)\s*\|\s*.+personal collection\s*$", re.I)
+
+
+def find_personal_sprawl(collections, cards):
+    """Collections personnelles préfixées d'un nom de client (travail client mal logé).
+
+    Retourne des groupes : [{client, count, collections:[...]}].
+    """
+    by_client = defaultdict(list)
+    for col in collections:
+        if not _is_personal(col):
+            continue
+        m = _CLIENT_PREFIX_RE.match(col.get("name") or "")
+        if m:
+            by_client[m.group(1).strip()].append({"id": col.get("id"), "name": col.get("name")})
+    return [{"client": k, "count": len(v), "collections": v} for k, v in sorted(by_client.items())]
+
+
+def find_naming_issues(cards, template_card_ids):
+    """Cartes hors template dont le nom n'est pas normalisé (cf. Phase 1.5)."""
+    out = []
+    for c in cards:
+        if c.get("archived") or c["id"] in template_card_ids:
+            continue
+        name = c.get("name") or ""
+        norm = normalize_name(name)
+        if norm and norm != name:
+            out.append({"id": c["id"], "name": name, "normalized": norm})
+    return out
+
+
+# --- Dérive template ---------------------------------------------------------
+
+def find_template_drift(template_cards, other_cards):
+    """Copies clientes divergentes : même nom normalisé qu'une carte template,
+    mais empreinte de requête différente.
+
+    Limite connue : appariement par NOM (rate les copies renommées) — l'audit
+    le signale dans le rapport.
+    """
+    tpl_by_name = {}
+    for c in template_cards:
+        tpl_by_name.setdefault(normalize_name(c.get("name") or ""), []).append(c)
+    drift = []
+    for c in other_cards:
+        matches = tpl_by_name.get(normalize_name(c.get("name") or ""))
+        if not matches:
+            continue
+        if query_fingerprint(c) != query_fingerprint(matches[0]):
+            drift.append({"id": c["id"], "name": c.get("name"),
+                          "collection_id": c.get("collection_id"),
+                          "template_id": matches[0]["id"]})
+    return drift
+
+
+# --- Scoring / agrégation ----------------------------------------------------
+
+def summarize_findings(findings):
+    """Joint le scoring (PATTERNS) à chaque finding et trie par vague puis compte décroissant.
+
+    findings : {pattern_key: {count, items}}. Retourne une liste de dicts plats.
+    """
+    out = []
+    for key, data in findings.items():
+        meta = PATTERNS.get(key, {})
+        out.append({"key": key, **meta, "count": data.get("count", 0), "items": data.get("items", [])})
+    out.sort(key=lambda f: (f.get("wave", 9), -f.get("count", 0)))
+    return out

--- a/scripts/audit_lib.py
+++ b/scripts/audit_lib.py
@@ -13,6 +13,7 @@ import json
 import re
 import sys
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -21,6 +22,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from rename_lib import normalize_name  # noqa: E402  (réutilise la normalisation Phase 1.5)
 
 TEMPLATE_ROOT_ID = 215
+STALE_DAYS = 180  # seuil "non utilisé depuis longtemps" (≈6 mois)
 
 # Registre des patterns : scoring Impact/Risque/Effort + vague (cf. spec §6).
 PATTERNS = {
@@ -170,6 +172,34 @@ def find_unused_cards(cards, source_ids):
             and c["id"] not in source_ids]
 
 
+# --- Signaux d'usage (last_used_at / view_count) -----------------------------
+
+def days_since(ts, now):
+    """Jours entre l'ISO `ts` et l'ISO `now` (passé explicitement = déterministe).
+
+    None si `ts` est vide ou illisible.
+    """
+    if not ts:
+        return None
+    try:
+        a = datetime.fromisoformat(str(ts).replace("Z", "")[:19]).date()
+        b = datetime.fromisoformat(str(now).replace("Z", "")[:19]).date()
+        return (b - a).days
+    except Exception:
+        return None
+
+
+def is_stale(card, now, stale_days=STALE_DAYS):
+    """Carte « dormante » : dernière utilisation il y a ≥ stale_days (≈ candidate au nettoyage).
+
+    Critère = récence seule. Le view_count n'entre PAS dans la décision (une carte
+    très vue mais dormante depuis 6 mois reste à reconsidérer) ; il est affiché
+    comme contexte dans le rapport. Récence inconnue (last_used_at absent) -> non flaggée.
+    """
+    d = days_since(card.get("last_used_at"), now)
+    return d is not None and d >= stale_days
+
+
 # --- Détecteurs de collections -----------------------------------------------
 
 def _is_personal(col):
@@ -301,6 +331,7 @@ def summarize_findings(findings):
     out = []
     for key, data in findings.items():
         meta = PATTERNS.get(key, {})
-        out.append({"key": key, **meta, "count": data.get("count", 0), "items": data.get("items", [])})
+        out.append({"key": key, **meta, "count": data.get("count", 0),
+                    "items": data.get("items", []), "stale_count": data.get("stale_count")})
     out.sort(key=lambda f: (f.get("wave", 9), -f.get("count", 0)))
     return out

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Rendu du rapport d'audit en markdown — digest COURT (détail exhaustif dans le JSON)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from audit_lib import summarize_findings  # noqa: E402
+
+MAX_EXAMPLES = 5
+WAVE_TITLES = {
+    0: "Vague 0 — Quick wins",
+    1: "Vague 1 — Automatisable",
+    2: "Vague 2 — Structurel",
+    3: "Vague 3 — DRY / dérive",
+}
+
+
+def _example_line(key, item):
+    if key in ("empty_collections", "junk_collections"):
+        return f"`{item.get('id')}` {item.get('name')}"
+    if key == "dup_collection_names":
+        return f"« {item.get('name')} » ×{item.get('count')}"
+    if key == "personal_sprawl":
+        return f"{item.get('client')} ×{item.get('count')}"
+    if key in ("unused_cards", "naming_issues", "template_drift"):
+        return f"#{item.get('id')} {item.get('name')}"
+    if key in ("pure_dups", "variant_families"):
+        return f"groupe de {len(item)} : " + ", ".join(f"#{c['id']}" for c in item[:4])
+    return str(item)[:80]
+
+
+def render_report(findings, *, scanned_cards=0, scanned_collections=0, date=""):
+    rows = summarize_findings(findings)
+    lines = [f"# Audit Metabase — {date}", "",
+             f"_{scanned_collections} collections · {scanned_cards} cartes scannées._", ""]
+    lines += ["## Résumé", "", "| # | Pattern | Compte | I/R/E | Vague |",
+              "|---|---------|--------|-------|-------|"]
+    for f in rows:
+        ire = f"{f.get('impact','?')}/{f.get('risk','?')}/{f.get('effort','?')}"
+        lines.append(f"| {f.get('num','?')} | {f['key']} | {f.get('count',0)} | {ire} | {f.get('wave','?')} |")
+    lines += ["", "## Backlog (quick-wins d'abord)", ""]
+    for wave in (0, 1, 2, 3):
+        wf = [f for f in rows if f.get("wave") == wave and f.get("count", 0) > 0]
+        if not wf:
+            continue
+        lines.append(f"### {WAVE_TITLES[wave]}")
+        for f in wf:
+            lines.append(f"- **{f['key']}** ({f.get('count',0)}) — {f.get('impact')}/{f.get('risk')}/{f.get('effort')}")
+            for item in f.get("items", [])[:MAX_EXAMPLES]:
+                lines.append(f"  - {_example_line(f['key'], item)}")
+            if f.get("count", 0) > MAX_EXAMPLES:
+                lines.append(f"  - … +{f['count'] - MAX_EXAMPLES} (détail dans le JSON)")
+        lines.append("")
+    return "\n".join(lines)

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -50,6 +50,12 @@ def render_report(findings, *, scanned_cards=0, scanned_collections=0, date=""):
         lines.append(f"### {WAVE_TITLES[wave]}")
         for f in wf:
             lines.append(f"- **{f['key']}** ({f.get('count',0)}) — {f.get('impact')}/{f.get('risk')}/{f.get('effort')}")
+            if f["key"] == "archived_backlog":
+                # 'count' est une somme (cartes + collections), pas une liste d'items
+                it = (f.get("items") or [{}])[0]
+                lines.append(f"  - {it.get('archived_collections', 0)} collections "
+                             f"+ {it.get('archived_cards', 0)} cartes archivées")
+                continue
             for item in f.get("items", [])[:MAX_EXAMPLES]:
                 lines.append(f"  - {_example_line(f['key'], item)}")
             if f.get("count", 0) > MAX_EXAMPLES:

--- a/scripts/audit_report.py
+++ b/scripts/audit_report.py
@@ -26,7 +26,13 @@ def _example_line(key, item):
         return f"« {item.get('name')} » ×{item.get('count')}"
     if key == "personal_sprawl":
         return f"{item.get('client')} ×{item.get('count')}"
-    if key in ("unused_cards", "naming_issues", "template_drift"):
+    if key == "unused_cards":
+        d = item.get("days_since_used")
+        rec = f"{d}j" if d is not None else "jamais"
+        return f"#{item.get('id')} {item.get('name')} (vu {rec}, {item.get('view_count', 0)} vues)"
+    if key == "expensive_cards":
+        return f"#{item.get('id')} {item.get('name')} ({item.get('avg_query_ms')} ms, {item.get('view_count', 0)} vues)"
+    if key in ("naming_issues", "template_drift"):
         return f"#{item.get('id')} {item.get('name')}"
     if key in ("pure_dups", "variant_families"):
         return f"groupe de {len(item)} : " + ", ".join(f"#{c['id']}" for c in item[:4])
@@ -49,7 +55,8 @@ def render_report(findings, *, scanned_cards=0, scanned_collections=0, date=""):
             continue
         lines.append(f"### {WAVE_TITLES[wave]}")
         for f in wf:
-            lines.append(f"- **{f['key']}** ({f.get('count',0)}) — {f.get('impact')}/{f.get('risk')}/{f.get('effort')}")
+            extra = f" · {f['stale_count']} périmées ≥6 mois" if f.get("stale_count") is not None else ""
+            lines.append(f"- **{f['key']}** ({f.get('count',0)}{extra}) — {f.get('impact')}/{f.get('risk')}/{f.get('effort')}")
             if f["key"] == "archived_backlog":
                 # 'count' est une somme (cartes + collections), pas une liste d'items
                 it = (f.get("items") or [{}])[0]

--- a/scripts/bascule_lib.py
+++ b/scripts/bascule_lib.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Logique pure de la BASCULE du filtre temps d'un dashboard :
+param 'Time period' (category -> tags dimension sur TIME_PERIODS.NAME, l'ancien trick)
+vers un param 'temporal-unit' (-> tags temporal-unit des cartes).
+
+Principe (validé avec l'utilisateur) : la bascule est PAR DASHBOARD et atomique —
+jamais deux filtres temps en état final. Pré-condition : toutes les cartes câblées
+au filtre temps doivent être prêtes (tag temporal-unit), via swap vers une carte de
+remplacement (11673 ou copie sandbox). Le param est remplacé SUR PLACE (même id),
+donc les parameter_mappings existants restent valides sans recâblage.
+
+Testé par tests/test_bascule_lib.py.
+"""
+
+TIME_TAG = "time_period"
+TIME_TARGET = ["dimension", ["template-tag", TIME_TAG]]
+TEMPORAL_UNITS = ["day", "week", "month", "quarter", "year"]
+
+
+def time_param_payload(tags, value):
+    """Paramètre d'exécution (POST /query) pour épingler la granularité d'une carte,
+    selon le mécanisme de SON tag time_period. None si pas pilotable (absent, ou
+    variable texte — l'ancien mécanisme cassé)."""
+    tag = (tags or {}).get(TIME_TAG) or {}
+    t = tag.get("type")
+    if t == "dimension":
+        return {"type": "category", "value": [value], "target": TIME_TARGET}
+    if t == "temporal-unit":
+        return {"type": "temporal-unit", "value": value, "target": TIME_TARGET}
+    return None
+
+
+def find_time_param(dashboard):
+    """L'ancien param 'Time period' (type category) du dashboard, sinon None."""
+    for p in dashboard.get("parameters") or []:
+        if p.get("type") != "category":
+            continue
+        if p.get("slug") == TIME_TAG or str(p.get("name", "")).strip().lower() == "time period":
+            return p
+    return None
+
+
+def build_temporal_unit_param(old_param):
+    """Nouveau param temporal-unit, MÊME id que l'ancien (les mappings survivent).
+    Défaut conservé (week sur les dashboards existants). L'ancien défaut category
+    est une LISTE (['week']) — temporal-unit attend une string."""
+    default = old_param.get("default")
+    if isinstance(default, (list, tuple)):
+        default = default[0] if default else None
+    return {
+        "id": old_param["id"],
+        "name": old_param.get("name") or "Time period",
+        "slug": old_param.get("slug") or TIME_TAG,
+        "type": "temporal-unit",
+        "sectionId": "temporal-unit",
+        "temporal_units": list(TEMPORAL_UNITS),
+        "default": default or "week",
+    }
+
+
+def _dcs(dashboard):
+    return dashboard.get("dashcards") or dashboard.get("ordered_cards") or []
+
+
+def bascule_plan(dashboard, tags_by_card, swaps=None):
+    """Classe chaque dashcard vis-à-vis du filtre temps. Pure (pas d'API).
+
+    tags_by_card : {card_id: template-tags dict} pour toutes les cartes du dashboard
+    swaps        : {old_card_id: new_card_id} résolutions déjà connues (registre) —
+                   le new_card_id doit figurer dans tags_by_card.
+
+    Retourne None si le dashboard n'a pas d'ancien param temps, sinon :
+      old_param / new_param,
+      swaps         {old->new} repris tels quels,
+      blockers      [{dashcard_id, card_id, reason}]  câblées non prêtes, non résolues,
+      dead_mappings [(dashcard_id, parameter_id)]     mapping temps vers carte sans tag,
+      to_wire       [(dashcard_id, card_id)]          cartes temporal-unit non câblées.
+    """
+    old_param = find_time_param(dashboard)
+    if not old_param:
+        return None
+    swaps = dict(swaps or {})
+    pid = old_param["id"]
+    blockers, dead, to_wire = [], [], []
+    for dc in _dcs(dashboard):
+        cid = dc.get("card_id")
+        if not cid:
+            continue
+        tags = tags_by_card.get(cid) or {}
+        tag_type = ((tags.get(TIME_TAG) or {}).get("type"))
+        wired = any(pm.get("parameter_id") == pid for pm in dc.get("parameter_mappings") or [])
+        if wired:
+            if tag_type == "temporal-unit":
+                continue  # déjà prête, mapping conservé
+            if tag_type is None:
+                dead.append((dc["id"], pid))
+            elif cid in swaps:
+                continue  # sera swappée vers une carte prête
+            else:
+                blockers.append({"dashcard_id": dc["id"], "card_id": cid,
+                                 "reason": f"tag time_period type={tag_type!r} sans remplacement"})
+        else:
+            if tag_type == "temporal-unit":
+                to_wire.append((dc["id"], cid))
+    return {"old_param": old_param, "new_param": build_temporal_unit_param(old_param),
+            "swaps": swaps, "blockers": blockers, "dead_mappings": dead, "to_wire": to_wire}
+
+
+def apply_bascule(dashboard, plan):
+    """(parameters, dashcards) prêts pour le PUT. Pure : ne modifie pas les entrées.
+    Refuse (ValueError) si le plan a encore des blockers."""
+    import json as _json
+    if plan["blockers"]:
+        raise ValueError(f"blockers non résolus: {plan['blockers']}")
+    pid = plan["old_param"]["id"]
+    dead = set(plan["dead_mappings"])
+    wire = dict(plan["to_wire"])
+    swaps = plan["swaps"]
+
+    params = [_json.loads(_json.dumps(p)) for p in dashboard.get("parameters") or []]
+    params = [plan["new_param"] if p.get("id") == pid else p for p in params]
+
+    dcs = []
+    for dc in _dcs(dashboard):
+        nd = _json.loads(_json.dumps(dc))
+        cid = nd.get("card_id")
+        if cid in swaps:
+            new_cid = swaps[cid]
+            nd["card_id"] = new_cid
+            for pm in nd.get("parameter_mappings") or []:
+                pm["card_id"] = new_cid
+        nd["parameter_mappings"] = [
+            pm for pm in nd.get("parameter_mappings") or []
+            if (nd["id"], pm.get("parameter_id")) not in dead
+        ]
+        if nd.get("id") in wire:
+            nd["parameter_mappings"].append(
+                {"parameter_id": pid, "card_id": wire[nd["id"]], "target": list(TIME_TARGET)})
+        dcs.append(nd)
+    return params, dcs

--- a/scripts/bascule_time_filter.py
+++ b/scripts/bascule_time_filter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Bascule le filtre temps d'un dashboard COPIE : param 'Time period' (category)
+-> param temporal-unit (MÊME id, donc les câblages survivent), après swap des
+cartes non prêtes.
+
+Pré-requis :
+- les tuiles CONVERSION câblées au filtre temps ont été swappées vers 11673
+  (migrate_dashboard_reuse.py --planned-temporal-unit --yes) ;
+- les cartes génériques non-conversion (Cost, Clicks, IS...) ont leur copie
+  temporal-unit en sandbox 13885, inscrite au REGISTRE migration/tu-generic-*.json.
+
+Garde-fous : par tuile swappée ici, valeurs avant (ancienne carte, granularité
+épinglée par field-filter) == après (nouvelle carte, temporal-unit) sur week ET
+month, non vides. Bascule atomique en un PUT (parameters + dashcards), snapshot
+avant, refus si le moindre blocker reste. Dashboards à onglets refusés.
+
+Usage :
+  python3 scripts/bascule_time_filter.py --copy 25567 --client "Pro Nutrition"        # dry-run
+  python3 scripts/bascule_time_filter.py --copy 25567 --client "Pro Nutrition" --yes
+"""
+import argparse, json, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+import conv_lib
+import bascule_lib
+from migrate_dashboard_full import connect, _dcs
+from migrate_dashboard_reuse import card_values_pinned
+
+
+def load_registry():
+    """{old_card_id: new_card_id} depuis migration/tu-generic-*.json (verified only)."""
+    reg = {}
+    for f in sorted((REPO / "migration").glob("tu-generic-*.json")):
+        d = json.loads(f.read_text())
+        if d.get("verified") and d.get("new_id"):
+            reg[int(d["old_id"])] = int(d["new_id"])
+    return reg
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copy", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--window", default="2026-05-01~2026-05-31")
+    ap.add_argument("--auto-prepare", action="store_true",
+                    help="convertit automatiquement le mécanisme temps des cartes bloquantes "
+                         "(copies temporal-unit sandbox) avant de basculer — couvre la traîne.")
+    ap.add_argument("--dry-prepare", action="store_true", help="auto-prepare en dry (ne crée pas les copies)")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+
+    dash = mb.get(f"/api/dashboard/{args.copy}")
+    if not isinstance(dash, dict):
+        sys.exit("dashboard inaccessible")
+
+    def build_plan():
+        registry = load_registry()
+        cards = {}
+        for dc in _dcs(dash):
+            cid = dc.get("card_id")
+            if cid and cid not in cards:
+                cards[cid] = mb.get(f"/api/card/{cid}")
+        tbc = {cid: conv_lib.native_and_tags(c)[1] for cid, c in cards.items()}
+        for old, new in registry.items():
+            if old in cards and new not in tbc:
+                tbc[new] = conv_lib.native_and_tags(mb.get(f"/api/card/{new}"))[1]
+        p = bascule_lib.bascule_plan(dash, tbc, swaps={o: n for o, n in registry.items() if o in cards})
+        return p, cards, tbc
+
+    plan, cards, tags_by_card = build_plan()
+    if plan is None:
+        sys.exit("Pas de param 'Time period' (category) sur ce dashboard — rien à basculer.")
+
+    # AUTO-PRÉPARATION : convertit le mécanisme temps de chaque carte bloquante (conversion
+    # ou non : Magento, tableaux multi-dim, charts orphelins) en copie temporal-unit, puis
+    # recalcule le plan. C'est l'option « propre » : couvre la traîne sans intervention.
+    unwire = set()  # (dashcard_id, card_id) à débrancher du filtre temps (granularité vestigiale)
+    if args.auto_prepare and plan["blockers"]:
+        from convert_generic_temporal import convert_card
+        print(f"Auto-préparation de {len(plan['blockers'])} carte(s) bloquante(s) :")
+        for b in list(plan["blockers"]):
+            cid = b["card_id"]
+            new_id = convert_card(mb, cid, args.client, args.window) if not args.dry_prepare else None
+            if new_id:
+                continue
+            # non convertible : si la carte a un filtre date séparé ET n'est pas un tableau
+            # « by date », sa granularité est vestigiale -> on la débranche du filtre temps.
+            tags = conv_lib.native_and_tags(cards[cid])[1]
+            bd = conv_lib.card_breakdown(cards[cid])
+            if "date" in tags and "date" not in bd:
+                unwire.add((b["dashcard_id"], cid))
+                print(f"  ↪ {cid} non convertible → DÉBRANCHÉE du filtre temps (granularité vestigiale, {bd})")
+            else:
+                print(f"  ⛔ {cid} non convertible ET time-driven → reste bloquant")
+        plan, cards, tags_by_card = build_plan()
+        # purge les blockers débranchés + ajoute-les au nettoyage de câblage
+        plan["blockers"] = [b for b in plan["blockers"] if (b["dashcard_id"], b["card_id"]) not in unwire]
+        _pid = plan["old_param"]["id"]
+        plan["dead_mappings"] += [(dcid, _pid) for dcid, cid in unwire]
+
+    # ne swapper que les cartes du dashboard réellement câblées sur l'ancien mécanisme
+    pid = plan["old_param"]["id"]
+    wired_dim = set()
+    for dc in _dcs(dash):
+        cid = dc.get("card_id")
+        if cid and any(pm.get("parameter_id") == pid for pm in dc.get("parameter_mappings") or []):
+            if ((tags_by_card.get(cid) or {}).get(bascule_lib.TIME_TAG) or {}).get("type") == "dimension":
+                wired_dim.add(cid)
+    plan["swaps"] = {o: n for o, n in plan["swaps"].items() if o in wired_dim}
+
+    print(f"Dashboard {args.copy} — plan de bascule :")
+    print(f"  param {pid} '{plan['old_param'].get('name')}' category -> temporal-unit (défaut "
+          f"{plan['new_param']['default']})")
+    # les copies temporal-unit du registre ont DÉJÀ été vérifiées par convert_card (baseline
+    # inline fiable, 4 granularités). La re-vérif ici utilise l'ancien field-filter (parfois
+    # cassé) -> on la garde en INFO mais on ne bloque QUE pour les swaps hors-registre.
+    verified_reg = set(load_registry().keys())
+    checks_ok = True
+    for old, new in sorted(plan["swaps"].items()):
+        name = (cards[old] or {}).get("name", "?")
+        ok_all = True
+        for g in ("week", "month"):
+            b = card_values_pinned(mb, old, args.client, args.window, g)
+            a = card_values_pinned(mb, new, args.client, args.window, g)
+            if not (bool(b) and b == a):
+                ok_all = False
+                if old not in verified_reg:
+                    print(f"  ⛔ swap {old}->{new} {name[:40]!r}: valeurs {g} "
+                          f"{'VIDES' if not b else 'différentes'} (avant {len(b)} / après {len(a)})")
+        if ok_all:
+            print(f"  swap {old} -> {new}  {name[:48]!r}  valeurs week+month identiques ✅")
+        elif old in verified_reg:
+            print(f"  swap {old} -> {new}  {name[:48]!r}  (vérifié à la conversion ✓, re-check skipé)")
+        checks_ok &= (ok_all or old in verified_reg)
+    for dcid, p in plan["dead_mappings"]:
+        print(f"  nettoyage câblage mort: dashcard {dcid}")
+    for dcid, cid in plan["to_wire"]:
+        print(f"  câblage ajouté: dashcard {dcid} -> carte {cid}")
+    if plan["blockers"]:
+        print("  ⛔ BLOCKERS (swap conversion/11673 à faire d'abord, ou carte sans remplacement):")
+        for b in plan["blockers"]:
+            nm = (cards.get(b['card_id']) or {}).get('name', '?')
+            print(f"     dashcard {b['dashcard_id']} carte {b['card_id']} {nm[:48]!r} — {b['reason']}")
+        sys.exit(1)
+    if not checks_ok:
+        sys.exit("⛔ vérifications de valeurs en échec — bascule refusée.")
+    if not args.yes:
+        print("(DRY-RUN — rien modifié.)")
+        return
+
+    snap_path = REPO / "migration" / f"bascule-snapshot-{args.copy}.json"
+    snap_path.write_text(json.dumps({"parameters": dash.get("parameters"),
+                                     "dashcards": _dcs(dash)}, ensure_ascii=False))
+    params, dcs = bascule_lib.apply_bascule(dash, plan)
+    put_body = {"parameters": params, "dashcards": dcs}
+    if dash.get("tabs"):  # PUT d'un dash à onglets DOIT inclure tabs (sinon 500)
+        put_body["tabs"] = dash["tabs"]
+    res = mb.put(f"/api/dashboard/{args.copy}", "raw", json=put_body)
+    if res.status_code != 200:
+        print(f"⛔ PUT ÉCHOUÉ: HTTP {res.status_code} — {res.text[:400]}")
+        sys.exit(1)
+    print(f"PUT {args.copy}: 200 OK (snapshot: {snap_path.name})")
+
+    # contrôles finaux
+    chk = mb.get(f"/api/dashboard/{args.copy}")
+    assert bascule_lib.find_time_param(chk) is None, "un param category 'Time period' subsiste !"
+    tu = [p for p in chk.get("parameters") or [] if p.get("type") == "temporal-unit"]
+    print(f"Param temporal-unit en place : {[p['id'] for p in tu]}")
+    residual = []
+    for dc in _dcs(chk):
+        cid = dc.get("card_id")
+        if not cid:
+            continue
+        t = conv_lib.native_and_tags(mb.get(f"/api/card/{cid}"))[1]
+        ttype = ((t.get(bascule_lib.TIME_TAG) or {}).get("type"))
+        wired = any(pm.get("parameter_id") == pid for pm in dc.get("parameter_mappings") or [])
+        # anomalie = une carte dimension ENCORE câblée au nouveau param (le param ne peut
+        # pas la piloter). Une dimension DÉBRANCHÉE (granularité vestigiale) est OK.
+        if ttype == "dimension" and wired:
+            residual.append((dc["id"], cid, "dimension encore câblée"))
+        if ttype == "temporal-unit" and not wired:
+            residual.append((dc["id"], cid, "temporal-unit non câblée"))
+    print(f"Anomalies résiduelles : {residual if residual else 'AUCUNE ✅'}")
+    if unwire:
+        print(f"Cartes débranchées du filtre temps (granularité vestigiale) : {sorted(c for _, c in unwire)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/batch_brand_fix.py
+++ b/scripts/batch_brand_fix.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Batch: applique la règle brand canonique (type LIKE + category=='brand' strict)
+à toutes les cartes 11673 portant une clause d'exclusion brand.
+
+Sécurité en couches :
+1. GATE STATIQUE (gratuit, 100% des cartes) : strip_brand_atoms(old)==strip_brand_atoms(new)
+   -> prouve que SEULE la clause brand change. Toute carte « dirty » est SAUTÉE.
+2. SNAPSHOT JSONL de chaque carte avant PUT (restaurable).
+3. RE-GET de chaque carte modifiée : le SQL persisté == SQL corrigé.
+4. ÉCHANTILLON stratifié exécuté avant/après :
+   - brand='yes' (défaut, clause inerte) : valeurs AVANT == APRÈS (gate dur) ;
+   - brand='no' : les 2 runs s'exécutent (SQL valide) ; on rapporte l'ampleur du changement.
+
+Usage :
+  .venv/bin/python scripts/batch_brand_fix.py            # dry-run (scan + gate + plan)
+  .venv/bin/python scripts/batch_brand_fix.py --yes      # applique
+"""
+import argparse, json, random, sys, threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from archive_collections import connect_resilient
+import conv_lib
+
+WINDOW = "2026-05-01~2026-05-31"
+BIG_TABLES = set(range(41335, 41355))  # tableaux génériques/custom (prod) = prioritaires à échantillonner
+_lock = threading.Lock()
+
+
+def _sql_of(card):
+    dq = card["dataset_query"]
+    st = dq["stages"][0] if "stages" in dq else dq["native"]
+    return st, ("native" if "stages" in dq else "query")
+
+
+def run_cells(mb, card, brand):
+    """Cellules numériques au format card_values, params: date épinglée + brand_included=brand."""
+    _, tags = conv_lib.native_and_tags(card)
+    params = []
+    if "date" in tags:
+        params.append({"type": "date/all-options", "value": WINDOW, "target": ["dimension", ["template-tag", "date"]]})
+    if "brand_included" in tags:
+        params.append({"type": "category", "value": [brand], "target": ["dimension", ["template-tag", "brand_included"]]})
+    r = mb.post(f"/api/card/{card['id']}/query", json={"parameters": params}, timeout=300)
+    if not isinstance(r, dict) or r.get("status") != "completed":
+        return None
+    cols = [str(x.get("name")) for x in r["data"]["cols"]]
+    return conv_lib.displayed_cells(cols, r["data"]["rows"], None)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--yes", action="store_true")
+    ap.add_argument("--sample", type=int, default=24)
+    args = ap.parse_args()
+    mb = connect_resilient()
+    ids = json.loads(Path("/tmp/brand_batch_ids.json").read_text())
+    print(f"cibles: {len(ids)} cartes")
+
+    # --- Phase 1 : scan + gate statique (parallèle, lecture seule) ---
+    def scan(cid):
+        try:
+            card = mb.get(f"/api/card/{cid}")
+            if card.get("archived"):
+                return {"id": cid, "klass": "archived"}
+            st, key = _sql_of(card)
+            sql = st[key]
+            fixed = conv_lib.fix_brand_clause(sql)
+            if fixed == sql:
+                return {"id": cid, "klass": "noop"}
+            if conv_lib.strip_brand_atoms(sql) != conv_lib.strip_brand_atoms(fixed):
+                return {"id": cid, "klass": "dirty", "name": card.get("name")}
+            return {"id": cid, "klass": "clean", "card": card, "fixed": fixed,
+                    "collection": card.get("collection_id"), "display": card.get("display")}
+        except Exception as e:
+            return {"id": cid, "klass": "error", "err": str(e)[:120]}
+
+    with ThreadPoolExecutor(8) as ex:
+        scanned = list(ex.map(scan, ids))
+    by = {}
+    for s in scanned:
+        by.setdefault(s["klass"], []).append(s)
+    clean = by.get("clean", [])
+    print(f"scan: clean={len(clean)} noop={len(by.get('noop',[]))} dirty={len(by.get('dirty',[]))} "
+          f"archived={len(by.get('archived',[]))} error={len(by.get('error',[]))}")
+    for d in by.get("dirty", []):
+        print(f"  DIRTY (sauté): {d['id']} {str(d.get('name'))[:60]}")
+    for e in by.get("error", []):
+        print(f"  ERROR: {e['id']} {e['err']}")
+    if not clean:
+        print("rien à appliquer."); return
+
+    # --- échantillon stratifié : tous les gros tableaux présents + tirage aléatoire ---
+    rnd = random.Random(12)
+    big = [c for c in clean if c["id"] in BIG_TABLES]
+    rest = [c for c in clean if c["id"] not in BIG_TABLES]
+    sample = big[:8] + rnd.sample(rest, min(args.sample, len(rest)))
+    sample_ids = {c["id"] for c in sample}
+    print(f"échantillon vérifié en exécution: {len(sample)} cartes (dont {len(big[:8])} gros tableaux)")
+
+    if not args.yes:
+        print("(DRY-RUN — scan + gate OK, rien modifié. Relancer avec --yes.)")
+        return
+
+    # --- before sur l'échantillon (avant tout PUT) ---
+    def before(c):
+        return c["id"], {"yes": run_cells(mb, c["card"], "yes"), "no": run_cells(mb, c["card"], "no")}
+    with ThreadPoolExecutor(8) as ex:
+        bef = dict(ex.map(before, sample))
+
+    # --- Phase 2 : PUT (parallèle) + snapshot JSONL ---
+    snap_path = REPO / "migration" / "snapshots" / "brand-batch-snapshots.jsonl"
+    snap = open(snap_path, "a")
+
+    def apply(c):
+        try:
+            card = c["card"]
+            st, key = _sql_of(card)
+            with _lock:
+                snap.write(json.dumps(card) + "\n"); snap.flush()
+            st[key] = c["fixed"]
+            resp = mb.put(f"/api/card/{c['id']}", "raw", json={"dataset_query": card["dataset_query"]})
+            return c["id"], (resp.status_code == 200), getattr(resp, "status_code", None)
+        except Exception as e:
+            return c["id"], False, str(e)[:120]
+
+    with ThreadPoolExecutor(8) as ex:
+        puts = list(ex.map(apply, clean))
+    snap.close()
+    ok = [p for p in puts if p[1]]
+    fail = [p for p in puts if not p[1]]
+    print(f"PUT: ok={len(ok)} fail={len(fail)}")
+    for f in fail[:10]:
+        print(f"  PUT FAIL {f[0]}: {f[2]}")
+
+    # --- Phase 3 : re-GET de contrôle (le SQL corrigé a-t-il persisté ?) ---
+    fixed_by_id = {c["id"]: c["fixed"] for c in clean}
+    ok_ids = {p[0] for p in ok}
+
+    def confirm(cid):
+        card = mb.get(f"/api/card/{cid}")
+        st, key = _sql_of(card)
+        return cid, (st[key] == fixed_by_id[cid])
+    with ThreadPoolExecutor(8) as ex:
+        confs = list(ex.map(confirm, ok_ids))
+    not_persisted = [c[0] for c in confs if not c[1]]
+    print(f"persistance SQL: {len(confs)-len(not_persisted)}/{len(confs)} OK"
+          + (f" — NON persistées: {not_persisted[:8]}" if not_persisted else ""))
+
+    # --- Phase 4 : after sur l'échantillon + comparaison ---
+    def after(c):
+        card = mb.get(f"/api/card/{c['id']}")
+        return c["id"], {"yes": run_cells(mb, card, "yes"), "no": run_cells(mb, card, "no")}
+    with ThreadPoolExecutor(8) as ex:
+        aft = dict(ex.map(after, sample))
+
+    default_changed, no_broken, no_changed, no_same = [], [], 0, 0
+    for cid in sample_ids:
+        b, a = bef[cid], aft[cid]
+        if b["yes"] is None or a["yes"] is None or a["yes"] != b["yes"]:
+            default_changed.append(cid)
+        if a["no"] is None:
+            no_broken.append(cid)
+        elif b["no"] != a["no"]:
+            no_changed += 1
+        else:
+            no_same += 1
+    print("\n=== ÉCHANTILLON ===")
+    print(f"  défaut (brand=yes) AVANT==APRÈS : {len(sample_ids)-len(default_changed)}/{len(sample_ids)}"
+          + (f"  ⛔ CHANGÉ: {default_changed}" if default_changed else "  ✅"))
+    print(f"  brand=no s'exécute : {len(sample_ids)-len(no_broken)}/{len(sample_ids)}"
+          + (f"  ⛔ CASSÉ: {no_broken}" if no_broken else "  ✅"))
+    print(f"  brand=no comportement: {no_changed} cartes changent (correctif visible), {no_same} inchangées")
+    verdict = not default_changed and not no_broken and not not_persisted and not fail
+    print(f"\n=> {'✅ BATCH SAIN' if verdict else '⚠️ ANOMALIES — inspecter ci-dessus'} "
+          f"({len(ok)} cartes corrigées, snapshots: {snap_path.name})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bilingual_24576.py
+++ b/scripts/bilingual_24576.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Rend bilingue (FR + EN) les cartes texte/heading d'un onglet du dashboard 24576.
+
+Piloté par une table CONTENT : {dashcard_id: {"text": <nouveau md>, "h": <hauteur>}}.
+Après modification des hauteurs, REFLOW automatique : décale le `row` des cartes
+situées sous une carte agrandie, sur le même onglet, du delta de hauteur.
+
+Headings : bilingue inline « FR · EN » (pas de changement de hauteur).
+Body : bloc FR puis `---` puis bloc EN (hauteur augmentée).
+
+Réversible (snapshot). Usage :
+  python3 scripts/bilingual_24576.py --tab accueil            # dry-run (montre reflow)
+  python3 scripts/bilingual_24576.py --tab accueil --yes      # applique + snapshot
+"""
+import argparse, json, sys, copy, requests
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+MIG = REPO / "migration"
+DASH = 24576
+TABS = {"accueil": 8020, "global": 7657, "seo": 7659, "sea": 7990}
+
+SEP = "\n\n---\n\n"
+
+CONTENT = {
+    # ---------- ACCUEIL (tab 8020) ----------
+    127507: {"text": "🏠 Accueil · Home", "h": 1},
+    127474: {"text": "💡 Lexique · Glossary", "h": 1},
+    127506: {"h": 7, "text": (
+        "- L'onglet **Global** permet de visualiser une vue d'ensemble de toutes les sources d'acquisition digitale de votre centre et leur impact sur les réservations.\n\n"
+        "- L'onglet **SEA / SMA** permet de suivre votre acquisition payante (Google Ads, Meta, TikTok). Si vous n'avez pas d'acquisition payante, il est normal de voir les métriques à 0.\n\n"
+        "- L'onglet **SEO** permet de comprendre comment votre centre est trouvé sur Google de manière naturelle, et si ce trafic génère des réservations."
+        + SEP +
+        "- The **Global** tab gives an overview of all your center's digital acquisition sources and their impact on bookings.\n\n"
+        "- The **SEA / SMA** tab tracks your paid acquisition (Google Ads, Meta, TikTok). If you don't run paid acquisition, it's normal to see the metrics at 0.\n\n"
+        "- The **SEO** tab explains how your center is found on Google organically, and whether that traffic generates bookings."
+    )},
+    127473: {"h": 31, "text": (
+        "**Canaux d'acquisition**\n\n"
+        "- **SEO** : recherche Google naturelle.\n\n"
+        "- **SEA** : publicités Google Ads.\n\n"
+        "- **SMA** : publicités sur les réseaux sociaux (Meta, TikTok…).\n\n\n"
+        "**Plateformes**\n\n"
+        "- **Meta** : Regroupe les publicités diffusées sur **Facebook**, **Instagram**, **Messenger** et le **Réseau d'audience Meta** (sites et applications partenaires).\n\n"
+        "- **Google** : Regroupe les publicités diffusées sur le **moteur de recherche Google**, **YouTube**, **Gmail**, **Google Maps** et le **Réseau Display Google** (bannières sur des millions de sites et applications partenaires).\n\n"
+        "> [Vidéo explicative : différences entre Meta et Google](https://www.youtube.com/watch?v=Cp5nkhRyhe4) (jusqu'à la moitié)\n\n\n"
+        "**Métriques**\n\n"
+        "- **Coûts** : Budget dépensé sur la campagne et les actions marketing Google, YouTube, Instagram, Facebook (hors frais de gestion).\n\n"
+        "- **Impressions** : Nombre de fois qu'une publicité est affichée sur l'écran d'un utilisateur. Une même personne peut générer plusieurs impressions si elle voit la publicité plusieurs fois.\n\n"
+        "- **Clics** : Nombre de fois qu'un utilisateur clique sur une publicité ou un lien pour accéder à votre site. Un même utilisateur peut générer plusieurs clics.\n\n"
+        "- **Visites** : Nombre total de sessions ouvertes sur votre site, toutes sources confondues (SEO, SEA, SMA, accès direct, etc.). Une session correspond à une période d'activité continue d'un utilisateur sur le site.\n\n"
+        "- **Nouveaux visiteurs** : Personnes qui découvrent votre centre pour la première fois.\n\n"
+        "- **Conversion** : Une action concrète réalisée par un visiteur (réservation, formulaire, appel).\n\n"
+        "- **Taux de conversion** : Pourcentage de visites ayant abouti à une action concrète (réservation, formulaire, appel). Calculé en divisant le nombre de conversions par le nombre total de visites.\n\n"
+        "- **Réservations** : Nombre de réservations confirmées en ligne.\n\n"
+        "- **Contacts** : Nombre de personnes ayant affiché vos coordonnées ou envoyé un formulaire de contact."
+        + SEP +
+        "**Acquisition channels**\n\n"
+        "- **SEO**: organic Google search.\n\n"
+        "- **SEA**: Google Ads paid advertising.\n\n"
+        "- **SMA**: paid advertising on social networks (Meta, TikTok…).\n\n\n"
+        "**Platforms**\n\n"
+        "- **Meta**: Covers ads shown on **Facebook**, **Instagram**, **Messenger** and the **Meta Audience Network** (partner sites and apps).\n\n"
+        "- **Google**: Covers ads shown on **Google Search**, **YouTube**, **Gmail**, **Google Maps** and the **Google Display Network** (banners across millions of partner sites and apps).\n\n"
+        "> [Explainer video: differences between Meta and Google](https://www.youtube.com/watch?v=Cp5nkhRyhe4) (up to the halfway point)\n\n\n"
+        "**Metrics**\n\n"
+        "- **Costs**: Budget spent on the campaign and on Google, YouTube, Instagram and Facebook marketing actions (excluding management fees).\n\n"
+        "- **Impressions**: Number of times an ad is displayed on a user's screen. The same person can generate several impressions if they see the ad multiple times.\n\n"
+        "- **Clicks**: Number of times a user clicks on an ad or a link to reach your site. The same user can generate several clicks.\n\n"
+        "- **Visits**: Total number of sessions opened on your site, all sources combined (SEO, SEA, SMA, direct access, etc.). A session is a period of continuous activity by a user on the site.\n\n"
+        "- **New visitors**: People discovering your center for the first time.\n\n"
+        "- **Conversion**: A concrete action taken by a visitor (booking, form, call).\n\n"
+        "- **Conversion rate**: Percentage of visits that led to a concrete action (booking, form, call). Calculated by dividing the number of conversions by the total number of visits.\n\n"
+        "- **Bookings**: Number of bookings confirmed online.\n\n"
+        "- **Contacts**: Number of people who viewed your contact details or submitted a contact form."
+    )},
+}
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tab", required=True, choices=list(TABS))
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    tab_id = TABS[args.tab]
+
+    mb = connect()
+    d = mb.get(f"/api/dashboard/{DASH}")
+    dcs = copy.deepcopy(d.get("dashcards") or [])
+    by_id = {dc["id"]: dc for dc in dcs}
+
+    # cibles présentes sur cet onglet
+    targets = {cid: c for cid, c in CONTENT.items() if cid in by_id and by_id[cid].get("dashboard_tab_id") == tab_id}
+    if not targets:
+        sys.exit(f"Aucune cible CONTENT sur l'onglet {args.tab} ({tab_id}).")
+
+    # 1) calcul des deltas de hauteur (boundary = bas de la carte, en coords d'origine)
+    orig_row = {dc["id"]: dc.get("row") for dc in dcs}
+    deltas = []  # (boundary_row, delta)
+    for cid, spec in targets.items():
+        dc = by_id[cid]
+        old_h = dc.get("size_y")
+        if spec["h"] != old_h:
+            deltas.append((dc.get("row") + old_h - 1, spec["h"] - old_h))
+
+    # 2) appliquer texte + hauteur
+    for cid, spec in targets.items():
+        dc = by_id[cid]
+        dc["visualization_settings"]["text"] = spec["text"]
+        dc["size_y"] = spec["h"]
+
+    # 3) reflow : pour chaque carte de l'onglet, somme des deltas dont la boundary
+    #    est < à sa row d'origine (donc située au-dessus). Calcul sur coords figées.
+    for dc in dcs:
+        if dc.get("dashboard_tab_id") != tab_id:
+            continue
+        shift = sum(delta for b, delta in deltas if b < orig_row[dc["id"]])
+        dc["row"] += shift
+
+    print(f"Onglet {args.tab}: {len(targets)} carte(s) bilingue(s), deltas={deltas}")
+    for cid in targets:
+        dc = by_id[cid]
+        print(f"  id={cid} row={dc['row']} h={dc['size_y']} | {dc['visualization_settings']['text'][:45]!r}")
+
+    if not args.yes:
+        print("\n(DRY-RUN — aucune modification.)")
+        return
+
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"bilingual-snapshot-{DASH}-{args.tab}-{ts}.json").write_text(
+        json.dumps({"dashboard": DASH, "dashcards": d.get("dashcards")}, ensure_ascii=False, indent=2))
+    payload = {"dashcards": dcs}
+    if d.get("tabs"):
+        payload["tabs"] = d["tabs"]
+    r = requests.put(mb.domain + f"/api/dashboard/{DASH}", headers=mb.header, auth=mb.auth, json=payload, timeout=120)
+    print(f"PUT: {r.status_code}")
+    r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_antipattern_tasks.py
+++ b/scripts/build_antipattern_tasks.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Explose les candidats anti-patterns en fichiers .sql par tâche + index.json.
+
+Chaque agent du workflow lit UN fichier .sql (petit) et rend un verdict.
+Index = métadonnées légères (sans SQL) passées en `args` au workflow.
+"""
+from __future__ import annotations
+
+import glob
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TASK_DIR = REPO_ROOT / "migration" / "antipattern-tasks"
+
+
+def fmt_dashboards(dl):
+    if not dl:
+        return "AUCUN dashboard"
+    return ", ".join(f'{d["name"]}(#{d["id"]})' for d in dl)
+
+
+def main():
+    cand_path = sorted(glob.glob(str(REPO_ROOT / "migration" / "sql-antipattern-candidates-*.json")))[-1]
+    blob = json.load(open(cand_path))
+    TASK_DIR.mkdir(parents=True, exist_ok=True)
+    # clean stale task files
+    for f in TASK_DIR.glob("*.sql"):
+        f.unlink()
+
+    index = []
+    for c in blob["a_candidates"]:
+        path = TASK_DIR / f'A-{c["id"]}.sql'
+        header = (
+            f'-- ANTI-PATTERN A (JOIN kp__* sans language/zone)\n'
+            f'-- CARD #{c["id"]}: {c["name"]}\n'
+            f'-- Collection: {c.get("collection_name")} (id {c.get("collection_id")})\n'
+            f'-- Dashboards: {fmt_dashboards(c.get("dashboards"))}\n'
+            f'-- Flags: has_join={c["has_join"]} mentions_airtable_record_id={c["mentions_airtable_record_id"]} '
+            f'kp_tables={",".join(c["kp_tables"])}\n'
+            f'-- view_count={c.get("view_count")} updated_at={c.get("updated_at")}\n'
+            f'-- ============================== SQL ==============================\n'
+        )
+        path.write_text(header + c["sql"])
+        index.append({"task_id": f'A-{c["id"]}', "antipattern": "A", "card_id": c["id"],
+                      "name": c["name"], "path": str(path),
+                      "has_join": c["has_join"],
+                      "mentions_airtable_record_id": c["mentions_airtable_record_id"],
+                      "kp_tables": c["kp_tables"],
+                      "dashboards": [d["id"] for d in (c.get("dashboards") or [])]})
+
+    for c in blob["b_candidates"]:
+        path = TASK_DIR / f'B-{c["id"]}.sql'
+        header = (
+            f'-- ANTI-PATTERN B (\\. et meta-chars echappes d un seul backslash dans REGEXP Snowflake)\n'
+            f'-- CARD #{c["id"]}: {c["name"]}\n'
+            f'-- Collection: {c.get("collection_name")} (id {c.get("collection_id")})\n'
+            f'-- Dashboards: {fmt_dashboards(c.get("dashboards"))}\n'
+            f'-- Flags: regex_funcs={",".join(c["regex_funcs"])} escaped_metachars={" ".join(c["escaped_metachars"])}\n'
+            f'-- view_count={c.get("view_count")} updated_at={c.get("updated_at")}\n'
+            f'-- ============================== SQL ==============================\n'
+        )
+        path.write_text(header + c["sql"])
+        index.append({"task_id": f'B-{c["id"]}', "antipattern": "B", "card_id": c["id"],
+                      "name": c["name"], "path": str(path),
+                      "regex_funcs": c["regex_funcs"],
+                      "escaped_metachars": c["escaped_metachars"],
+                      "dashboards": [d["id"] for d in (c.get("dashboards") or [])]})
+
+    idx_path = TASK_DIR / "index.json"
+    idx_path.write_text(json.dumps(index, indent=2, ensure_ascii=False))
+    print(f"{len(index)} tâches écrites dans {TASK_DIR}")
+    print(f"  A: {sum(1 for t in index if t['antipattern']=='A')}  "
+          f"B: {sum(1 for t in index if t['antipattern']=='B')}")
+    print(f"Index: {idx_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_new_conv_index.py
+++ b/scripts/build_new_conv_index.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Indexe l'arbre des nouvelles conversions -> {(NEW_COL, shape) -> [card_id]} (JSON-encodé).
+Par défaut depuis l'audit-cache (rapide) ; --live parcourt la collection 11673.
+Une carte « pure nouvelle » (référence des colonnes nouvelles, aucune ancienne) est indexée
+sous CHAQUE colonne nouvelle qu'elle somme, avec sa forme (display, metric_kind, breakdown) —
+ce qui fait résoudre aussi les métriques dérivées (CAC/COS/CR/ROAS) par colonne+forme.
+Usage:
+  python3 scripts/build_new_conv_index.py            # depuis le cache
+  python3 scripts/build_new_conv_index.py --live --root 11673
+"""
+import argparse, glob, json, sys
+from collections import defaultdict
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+import conv_lib
+
+def _index_card(card, index):
+    if card.get("archived"):
+        return
+    sql, _ = conv_lib.native_and_tags(card)
+    if not sql:
+        return
+    new = conv_lib.new_conversion_columns(sql)
+    if not new or conv_lib.old_conversion_columns(sql):
+        return  # pure-new cards only
+    bd = conv_lib.card_breakdown(card)
+    src = conv_lib.conversion_source(sql)
+    entry = {"id": card["id"], "source": src, "display": card.get("display"),
+             "kpis": list(conv_lib.kpi_signature(card)), "brand": conv_lib.brand_excluded(card)}
+    for col in new:
+        index[json.dumps([col, list(bd)])].append(entry)
+
+def from_cache():
+    index = defaultdict(list)
+    n = 0
+    for fp in glob.glob(str(REPO / "migration" / "audit-cache" / "card-*.json")):
+        try:
+            card = json.load(open(fp))
+        except Exception:
+            continue
+        n += 1
+        _index_card(card, index)
+    return index, n
+
+def from_live(root):
+    from spark_metabase_api import Metabase_API
+    from reorg_phase1 import _load_env
+    e = _load_env()
+    mb = Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+    ids = []
+    def walk(cid):
+        r = mb.get(f"/api/collection/{cid}/items")
+        for it in (r.get("data") if isinstance(r, dict) else r) or []:
+            if it.get("model") == "collection":
+                walk(it["id"])
+            elif it.get("model") == "card":
+                ids.append(it["id"])
+    walk(root)
+    index = defaultdict(list)
+    for cid in ids:
+        c = mb.get(f"/api/card/{cid}")
+        if isinstance(c, dict):
+            _index_card(c, index)
+    return index, len(ids)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--live", action="store_true")
+    ap.add_argument("--root", type=int, default=11673)
+    ap.add_argument("--out", default=None, help="chemin de sortie (défaut: migration/conv-new-index.json)")
+    args = ap.parse_args()
+    index, n = (from_live(args.root) if args.live else from_cache())
+    out = Path(args.out) if args.out else REPO / "migration" / "conv-new-index.json"
+    out.write_text(json.dumps(index, ensure_ascii=False, indent=2))
+    multi = sum(1 for v in index.values() if len(v) > 1)
+    print(f"{n} cards scanned -> {len(index)} (col,shape) keys ({multi} ambiguous/multi) -> {out}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_seo_dashboard.py
+++ b/scripts/build_seo_dashboard.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Vue Snapshot + Dashboard dédié 'Suivi mensuel des mots-clés SEO | Manucurist'.
+Assemble : Snapshot (table, mois courant) + Grille positions (#48634) + filtres Gamme/Catégorie.
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; SERP_COLLECTION=4809; MODEL_ID=48633; GRID_ID=48634; HTTP_TIMEOUT=300
+SNAP_NAME="SEO — Snapshot mots-clés (mois courant) | Manucurist"
+DASH_NAME="Suivi mensuel des mots-clés SEO | Manucurist"
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+def main():
+    mb=connect(); print("connected")
+    # 1) Snapshot card (MBQL table sur le modèle, mois courant)
+    snap_q={"database":DB,"type":"query","query":{
+        "source-table":f"card__{MODEL_ID}",
+        "fields":[fr("GAMME","type/Text"),fr("CATEGORIE","type/Text"),fr("KEYWORD","type/Text"),
+                  fr("POSITION","type/Float"),fr("SEARCH_VOLUME","type/Float"),fr("CLICKS","type/Float")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),"current","month"],
+        "order-by":[["asc",fr("GAMME","type/Text")],["asc",fr("POSITION","type/Float")]]}}
+    snap_viz={"column_settings":{
+        json.dumps(["name","KEYWORD"]):{"column_title":"Mot-clé"},
+        json.dumps(["name","GAMME"]):{"column_title":"Gamme"},
+        json.dumps(["name","CATEGORIE"]):{"column_title":"Catégorie"},
+        json.dumps(["name","POSITION"]):{"column_title":"Position"},
+        json.dumps(["name","SEARCH_VOLUME"]):{"column_title":"Volume rech."},
+        json.dumps(["name","CLICKS"]):{"column_title":"Clics GSC"}},
+        "table.column_formatting":[{"columns":["POSITION"],"type":"range","colors":["#84BB4C","#ED6E6E"],
+            "min_type":"custom","min_value":1,"max_type":"custom","max_value":50}]}
+    snap_pl={"name":SNAP_NAME,"collection_id":SERP_COLLECTION,"dataset_query":snap_q,"display":"table",
+             "visualization_settings":snap_viz,"description":"Snapshot mois courant : position/volume/clics par mot-clé (gamme/catégorie). Source modèle #48633. Vue A du gsheet."}
+    existing=None
+    for it in mb.get(f"/api/collection/{SERP_COLLECTION}/items?limit=2000").get("data",[]):
+        if it.get("model")=="card" and it.get("name")==SNAP_NAME: existing=it.get("id"); break
+    if existing:
+        mb.put(f"/api/card/{existing}","raw",json=snap_pl,timeout=HTTP_TIMEOUT); SNAP=existing; print("snapshot maj #",SNAP)
+    else:
+        b=mb.post("/api/card","raw",json=snap_pl,timeout=HTTP_TIMEOUT).json()
+        SNAP=b.get("id"); print("snapshot créé #",SNAP)
+    jr=mb.post("/api/dataset","raw",json=snap_q,timeout=HTTP_TIMEOUT).json()
+    if not jr.get("error"):
+        mb.put(f"/api/card/{SNAP}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+        print("  snapshot lignes:", len(jr["data"]["rows"]))
+
+    # 2) Dashboard
+    existing_d=None
+    for it in mb.get(f"/api/collection/{SERP_COLLECTION}/items?limit=2000").get("data",[]):
+        if it.get("model")=="dashboard" and it.get("name")==DASH_NAME: existing_d=it.get("id"); break
+    if existing_d:
+        DID=existing_d; print("dashboard existant #",DID)
+    else:
+        bd=mb.post("/api/dashboard","raw",json={"name":DASH_NAME,"collection_id":SERP_COLLECTION,
+            "description":"Suivi mensuel SEO des 15 mots-clés stratégiques Manucurist (gsheet). Position (DataForSEO/GSC) + Volume + Clics GSC, par gamme. V1."},timeout=HTTP_TIMEOUT).json()
+        DID=bd.get("id"); print("dashboard créé #",DID)
+
+    P_GAMME={"id":"gamme01","name":"Gamme","slug":"gamme","type":"string/=","sectionId":"string"}
+    P_CAT={"id":"categ01","name":"Catégorie","slug":"categorie","type":"string/=","sectionId":"string"}
+    def maps(card_id):
+        return [{"parameter_id":"gamme01","card_id":card_id,"target":["dimension",fr("GAMME","type/Text")]},
+                {"parameter_id":"categ01","card_id":card_id,"target":["dimension",fr("CATEGORIE","type/Text")]}]
+    dashcards=[
+      {"id":-1,"card_id":SNAP,"row":0,"col":0,"size_x":12,"size_y":8,"series":[],"parameter_mappings":maps(SNAP),"visualization_settings":{}},
+      {"id":-2,"card_id":GRID_ID,"row":8,"col":0,"size_x":24,"size_y":10,"series":[],"parameter_mappings":maps(GRID_ID),"visualization_settings":{}},
+    ]
+    r=mb.put(f"/api/dashboard/{DID}","raw",json={"parameters":[P_GAMME,P_CAT],"dashcards":dashcards},timeout=HTTP_TIMEOUT)
+    body=r.json() if hasattr(r,"json") else r
+    ndc=len(body.get("dashcards",[])) if isinstance(body,dict) else "?"
+    print("  PUT dashboard status:",getattr(r,"status_code","?"),"| dashcards:",ndc)
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> SNAPSHOT #{SNAP} | DASHBOARD #{DID}: {dom}/dashboard/{DID}")
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_dashboard_v2.py
+++ b/scripts/build_seo_dashboard_v2.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Assemblage V2 du dashboard #25137 'Suivi mensuel des mots-clés SEO | Manucurist'.
+
+Usage: python3 scripts/build_seo_dashboard_v2.py <PAGES_MODEL_ID>
+
+- maj snapshot #48635 : table mois M-1 (marché, kw, position, ΔM-1, Δ6M, volume, clics)
+- maj grille #48634   : pivot [marché, kw] × mois → position (MLv2)
+- crée pivot pages    : [marché, gabarit] × mois → clics (MLv2)
+- crée table Δ gabarit: mois M-1, Δ6M% + tendance
+- PUT dashboard : filtres Marché + Marque/Hors Marque (dropdowns), 4 tuiles pleine largeur
+"""
+from __future__ import annotations
+import json, sys, time, uuid
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; COLL=13752; KW_MODEL=48633; GRID_ID=48634; SNAP_ID=48635; DASH_ID=25137; HTTP_TIMEOUT=480
+PAGES_MODEL=int(sys.argv[1]) if len(sys.argv)>1 else None
+u=lambda: str(uuid.uuid4())
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+def fl(name,bt,extra=None):
+    o={"base-type":bt,"lib/uuid":u()}
+    if extra:o.update(extra)
+    return ["field",o,name]
+def cs(name,opts): return {json.dumps(["name",name]):opts}
+def dec0(title): return {"column_title":title,"number_style":"decimal","decimals":0}
+
+def upsert_card(mb,name,payload):
+    existing=None
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")=="card" and it.get("name")==name: existing=it.get("id"); break
+    if existing:
+        mb.put(f"/api/card/{existing}","raw",json=payload,timeout=HTTP_TIMEOUT); return existing,"maj"
+    b=mb.post("/api/card","raw",json=payload,timeout=HTTP_TIMEOUT).json()
+    return b.get("id"),"créé"
+
+def set_meta(mb,cid,query_legacy):
+    jr=mb.post("/api/dataset","raw",json=query_legacy,timeout=HTTP_TIMEOUT).json()
+    if jr.get("error"): print(f"  meta #{cid} ERR:",str(jr["error"])[:200]); return None
+    mb.put(f"/api/card/{cid}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+    return jr
+
+def main():
+    if not PAGES_MODEL: sys.exit("PAGES_MODEL_ID requis en argument")
+    mb=connect(); print("connected")
+
+    # ---- 1) SNAPSHOT (#48635) : table M-1 ----
+    snap_q={"database":DB,"type":"query","query":{
+        "source-table":f"card__{KW_MODEL}",
+        "fields":[fr("MARCHE","type/Text"),fr("KEYWORD","type/Text"),fr("POSITION","type/Float"),
+                  fr("DELTA_M1","type/Float"),fr("DELTA_6M","type/Float"),
+                  fr("SEARCH_VOLUME","type/Float"),fr("CLICKS","type/Float")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),-1,"month"],
+        "order-by":[["asc",fr("MARCHE","type/Text")],["asc",fr("POSITION","type/Float")]]}}
+    snap_viz={"column_settings":{
+        **cs("MARCHE",{"column_title":"Marché"}), **cs("KEYWORD",{"column_title":"Mot-clé"}),
+        **cs("POSITION",dec0("Position")), **cs("DELTA_M1",dec0("Δ vs M-1")),
+        **cs("DELTA_6M",dec0("Δ 6 mois")), **cs("SEARCH_VOLUME",dec0("Volume rech.")),
+        **cs("CLICKS",dec0("Clics GSC"))},
+        "table.column_formatting":[
+          {"columns":["POSITION"],"type":"range","colors":["#84BB4C","#ED6E6E"],"min_type":"custom","min_value":1,"max_type":"custom","max_value":100},
+          {"columns":["DELTA_M1","DELTA_6M"],"type":"range","colors":["#ED6E6E","#FFFFFF","#84BB4C"],"min_type":"custom","min_value":-10,"max_type":"custom","max_value":10}]}
+    r=mb.put(f"/api/card/{SNAP_ID}","raw",json={"dataset_query":snap_q,"display":"table",
+        "visualization_settings":snap_viz,
+        "description":"V2 — snapshot dernier mois complet : position (100=non classé), Δ vs M-1, Δ 6 mois (+=gagné), volume, clics, par marché."},timeout=HTTP_TIMEOUT)
+    print("snapshot #%s:"%SNAP_ID, getattr(r,"status_code","?"))
+    jr=set_meta(mb,SNAP_ID,snap_q)
+    if jr: print("  lignes:",len(jr["data"]["rows"]))
+
+    # ---- 2) GRILLE POSITIONS (#48634) : pivot [marché, kw] × mois (MLv2) ----
+    grid_dq={"database":DB,"lib/type":"mbql/query","stages":[{
+        "lib/type":"mbql.stage/mbql","source-card":KW_MODEL,
+        "aggregation":[["avg",{"lib/uuid":u()}, fl("POSITION","type/Float")]],
+        "breakout":[ fl("MARCHE","type/Text"), fl("KEYWORD","type/Text"),
+                     fl("MONTH_DATE","type/Date",{"temporal-unit":"month"}) ]}]}
+    grid_viz={"pivot_table.column_split":{
+            "rows":[fr("MARCHE","type/Text"),fr("KEYWORD","type/Text")],
+            "columns":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})],
+            "values":[["aggregation",0]]},
+        "column_settings":{**cs("MARCHE",{"column_title":"Marché"}),**cs("KEYWORD",{"column_title":"Mot-clé"}),
+                           **cs("avg",{"number_style":"decimal","decimals":0})},
+        "table.column_formatting":[{"columns":["avg"],"type":"range","colors":["#84BB4C","#ED6E6E"],
+            "min_type":"custom","min_value":1,"max_type":"custom","max_value":100}]}
+    r=mb.put(f"/api/card/{GRID_ID}","raw",json={"dataset_query":grid_dq,"display":"pivot",
+        "visualization_settings":grid_viz,"name":"SEO — Positions mois par mois (grille) | Manucurist",
+        "description":"V2 — pivot [marché, mot-clé] × mois → position (100=non classé). Source modèle #48633."},timeout=HTTP_TIMEOUT)
+    print("grille #%s:"%GRID_ID, getattr(r,"status_code","?"))
+    grid_legacy={"database":DB,"type":"query","query":{"source-table":f"card__{KW_MODEL}",
+        "aggregation":[["avg",fr("POSITION","type/Float")]],
+        "breakout":[fr("MARCHE","type/Text"),fr("KEYWORD","type/Text"),
+                    fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})]}}
+    set_meta(mb,GRID_ID,grid_legacy)
+
+    # ---- 3) PIVOT PAGES : [marché, gabarit] × mois → clics (MLv2) ----
+    pages_dq={"database":DB,"lib/type":"mbql/query","stages":[{
+        "lib/type":"mbql.stage/mbql","source-card":PAGES_MODEL,
+        "aggregation":[["sum",{"lib/uuid":u()}, fl("CLICKS","type/Number")]],
+        "breakout":[ fl("MARCHE","type/Text"), fl("GABARIT","type/Text"),
+                     fl("MONTH_DATE","type/Date",{"temporal-unit":"month"}) ]}]}
+    pages_viz={"pivot_table.column_split":{
+            "rows":[fr("MARCHE","type/Text"),fr("GABARIT","type/Text")],
+            "columns":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})],
+            "values":[["aggregation",0]]},
+        "column_settings":{**cs("MARCHE",{"column_title":"Marché"}),**cs("GABARIT",{"column_title":"Gabarit"}),
+                           **cs("sum",{"number_style":"decimal","decimals":0})},
+        "table.column_formatting":[{"columns":["sum"],"type":"range","colors":["#FFFFFF","#509EE3"]}]}
+    PAGES_PIVOT,how=upsert_card(mb,"SEO — Clics par gabarit de page, mois par mois | Manucurist",{
+        "name":"SEO — Clics par gabarit de page, mois par mois | Manucurist","collection_id":COLL,
+        "dataset_query":pages_dq,"display":"pivot","visualization_settings":pages_viz,
+        "description":"V2 — pivot [marché, gabarit] × mois → clics GSC (granularité requête, échantillonné). Filtrable Marque/Hors Marque. Source modèle pages."})
+    print(f"pivot pages {how} #",PAGES_PIVOT)
+    pages_legacy={"database":DB,"type":"query","query":{"source-table":f"card__{PAGES_MODEL}",
+        "aggregation":[["sum",fr("CLICKS","type/Number")]],
+        "breakout":[fr("MARCHE","type/Text"),fr("GABARIT","type/Text"),
+                    fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})]}}
+    set_meta(mb,PAGES_PIVOT,pages_legacy)
+
+    # ---- 4) TABLE Δ GABARIT (M-1) ----
+    delta_q={"database":DB,"type":"query","query":{
+        "source-table":f"card__{PAGES_MODEL}",
+        "fields":[fr("MARCHE","type/Text"),fr("GABARIT","type/Text"),fr("MARQUE","type/Text"),
+                  fr("CLICKS","type/Number"),fr("DELTA_6M_PCT","type/Number"),fr("TENDANCE","type/Text")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),-1,"month"],
+        "order-by":[["asc",fr("MARCHE","type/Text")],["asc",fr("GABARIT","type/Text")],["asc",fr("MARQUE","type/Text")]]}}
+    delta_viz={"column_settings":{
+        **cs("MARCHE",{"column_title":"Marché"}),**cs("GABARIT",{"column_title":"Gabarit"}),
+        **cs("MARQUE",{"column_title":"Marque / Hors Marque"}),**cs("CLICKS",dec0("Clics (M-1)")),
+        **cs("DELTA_6M_PCT",{"column_title":"Δ 6 mois %","number_style":"decimal","decimals":1,"suffix":" %"}),
+        **cs("TENDANCE",{"column_title":"Tendance"})}}
+    DELTA_ID,how=upsert_card(mb,"SEO — Δ 6 mois par gabarit | Manucurist",{
+        "name":"SEO — Δ 6 mois par gabarit | Manucurist","collection_id":COLL,
+        "dataset_query":delta_q,"display":"table","visualization_settings":delta_viz,
+        "description":"V2 — dernier mois complet : clics, Δ 6 mois % et tendance par marché × gabarit × marque."})
+    print(f"table Δ {how} #",DELTA_ID)
+    set_meta(mb,DELTA_ID,delta_q)
+
+    # ---- 5) DASHBOARD ----
+    P_MARCHE={"id":"marche01","name":"Marché","slug":"marche","type":"string/=","sectionId":"string",
+        "values_query_type":"list","values_source_type":"static-list",
+        "values_source_config":{"values":["FR","US","UK","AUTRES"]}}
+    P_MARQUE={"id":"marque01","name":"Marque / Hors Marque","slug":"marque","type":"string/=","sectionId":"string",
+        "values_query_type":"list","values_source_type":"static-list",
+        "values_source_config":{"values":["Marque","Hors Marque"]}}
+    def m_marche(cid): return {"parameter_id":"marche01","card_id":cid,"target":["dimension",fr("MARCHE","type/Text")]}
+    def m_marque(cid): return {"parameter_id":"marque01","card_id":cid,"target":["dimension",fr("MARQUE","type/Text")]}
+    dashcards=[
+      {"id":-1,"card_id":SNAP_ID,"row":0,"col":0,"size_x":24,"size_y":9,"series":[],
+       "parameter_mappings":[m_marche(SNAP_ID)],
+       "visualization_settings":{"card.title":"Snapshot du dernier mois — position · Δ · volume · clics"}},
+      {"id":-2,"card_id":GRID_ID,"row":9,"col":0,"size_x":24,"size_y":11,"series":[],
+       "parameter_mappings":[m_marche(GRID_ID)],
+       "visualization_settings":{"card.title":"Positions mois par mois (100 = non classé)"}},
+      {"id":-3,"card_id":PAGES_PIVOT,"row":20,"col":0,"size_x":24,"size_y":9,"series":[],
+       "parameter_mappings":[m_marche(PAGES_PIVOT),m_marque(PAGES_PIVOT)],
+       "visualization_settings":{"card.title":"Clics par gabarit de page (Blog / Collections / Produits), mois par mois"}},
+      {"id":-4,"card_id":DELTA_ID,"row":29,"col":0,"size_x":24,"size_y":8,"series":[],
+       "parameter_mappings":[m_marche(DELTA_ID),m_marque(DELTA_ID)],
+       "visualization_settings":{"card.title":"Δ 6 mois par gabarit — gagne-t-on du trafic ?"}},
+    ]
+    r=mb.put(f"/api/dashboard/{DASH_ID}","raw",json={
+        "parameters":[P_MARCHE,P_MARQUE],"dashcards":dashcards,
+        "description":"V2 (gsheet Thibaut). 32 mots-clés stratégiques par marché (14 US + 18 FR) : position/Δ/volume/clics + clics par gabarit de page, filtres Marché & Marque/Hors Marque."},timeout=HTTP_TIMEOUT)
+    bb=r.json() if hasattr(r,"json") else r
+    print("dashboard:",getattr(r,"status_code","?"),"| dashcards:",len(bb.get("dashcards",[])) if isinstance(bb,dict) else "?")
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> DASHBOARD V2: {dom}/dashboard/{DASH_ID}")
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_dashboard_v3.py
+++ b/scripts/build_seo_dashboard_v3.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Dashboard V3 — #25137 'Suivi mensuel des mots-clés SEO | Manucurist'.
+Snapshot enrichi (15 col), 7 filtres, tuile saisonnalité + lien template #13489, sections.
+"""
+from __future__ import annotations
+import json, sys, time, urllib.parse as ulib
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; COLL=13752; DASH=25137; HTTP_TIMEOUT=480
+KW_MODEL=48633; GRID=48634; SNAP=48635; PAGES_PIVOT=49063; DELTA=49064; SAIS_PIVOT=49426
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+def cs(name,opts): return {json.dumps(["name",name]):opts}
+def dec0(t): return {"column_title":t,"number_style":"decimal","decimals":0}
+
+def main():
+    mb=connect(); print("connected")
+    # ---- Snapshot V3 (#48635) ----
+    snap_q={"database":DB,"type":"query","query":{
+        "source-table":f"card__{KW_MODEL}",
+        "fields":[fr("MARCHE","type/Text"),fr("GAMME","type/Text"),fr("CATEGORIE","type/Text"),fr("KEYWORD","type/Text"),
+                  fr("POSITION","type/Float"),fr("DELTA_M1","type/Float"),fr("DELTA_M3","type/Float"),
+                  fr("SEARCH_VOLUME","type/Float"),fr("POTENTIEL_TRAFIC","type/Float"),
+                  fr("CLICKS","type/Float"),fr("CLICKS_FR","type/Float"),fr("CLICKS_UK","type/Float"),
+                  fr("CLICKS_US","type/Float"),fr("CLICKS_AUTRES","type/Float"),fr("URL_POSITIONNEE","type/Text")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),-1,"month"],
+        "order-by":[["asc",fr("MARCHE","type/Text")],["asc",fr("GAMME","type/Text")],["asc",fr("POSITION","type/Float")]]}}
+    snap_viz={"column_settings":{
+        **cs("MARCHE",{"column_title":"Marché"}),**cs("GAMME",{"column_title":"Gamme"}),**cs("CATEGORIE",{"column_title":"Catégorie"}),
+        **cs("KEYWORD",{"column_title":"Mot-clé"}),**cs("POSITION",dec0("Position")),
+        **cs("DELTA_M1",dec0("Δ M-1")),**cs("DELTA_M3",dec0("Δ M-3")),
+        **cs("SEARCH_VOLUME",dec0("Volume rech.")),**cs("POTENTIEL_TRAFIC",dec0("Potentiel trafic")),
+        **cs("CLICKS",dec0("Clics GSC")),**cs("CLICKS_FR",dec0("FR")),**cs("CLICKS_UK",dec0("UK")),
+        **cs("CLICKS_US",dec0("US")),**cs("CLICKS_AUTRES",dec0("Autres")),
+        **cs("URL_POSITIONNEE",{"column_title":"URL positionnée","view_as":"link"})},
+        "table.column_formatting":[
+          {"columns":["POSITION"],"type":"range","colors":["#84BB4C","#ED6E6E"],"min_type":"custom","min_value":1,"max_type":"custom","max_value":100},
+          {"columns":["DELTA_M1","DELTA_M3"],"type":"range","colors":["#ED6E6E","#FFFFFF","#84BB4C"],"min_type":"custom","min_value":-10,"max_type":"custom","max_value":10}]}
+    print("snapshot V3:", getattr(mb.put(f"/api/card/{SNAP}","raw",json={"dataset_query":snap_q,"display":"table",
+        "visualization_settings":snap_viz,
+        "description":"V3 — snapshot dernier mois complet: marché/gamme/catégorie/mot-clé, position+Δ M-1/M-3, volume, potentiel trafic (vol×CTR), clics GSC + split FR/UK/US/Autres, URL positionnée."},timeout=HTTP_TIMEOUT),"status_code","?"))
+    jr=mb.post("/api/dataset","raw",json=snap_q,timeout=HTTP_TIMEOUT).json()
+    if not jr.get("error"): mb.put(f"/api/card/{SNAP}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+
+    # ---- Filtres ----
+    def DD(values): return {"values_query_type":"list","values_source_type":"static-list","values_source_config":{"values":values}}
+    P=[
+      {"id":"marche01","name":"Marché","slug":"marche","type":"string/=","sectionId":"string", **DD(["FR","US","UK","AUTRES"])},
+      {"id":"gamme01","name":"Gamme","slug":"gamme","type":"string/=","sectionId":"string", **DD(["Gel Polish","Nail Polish","Nailcare"])},
+      {"id":"categ01","name":"Catégorie","slug":"categorie","type":"string/=","sectionId":"string", **DD(["Transactionnel","Générique","Clean / Engagement","Produit","Informationnel"])},
+      {"id":"marque01","name":"Marque / Hors Marque","slug":"marque","type":"string/=","sectionId":"string", **DD(["Marque","Hors Marque"])},
+      {"id":"pat01","name":"Mot-clé (contient)","slug":"pattern_keyword","type":"string/contains","sectionId":"string"},
+      {"id":"exact01","name":"Mot-clé (exact)","slug":"exact_keyword","type":"string/=","sectionId":"string"},
+      {"id":"date01","name":"Période","slug":"date","type":"date/all-options","sectionId":"date","default":"past6months"},
+    ]
+    def m(pid,cid,field): return {"parameter_id":pid,"card_id":cid,"target":["dimension",field]}
+    KW=fr("KEYWORD","type/Text"); MAR=fr("MARCHE","type/Text"); GAM=fr("GAMME","type/Text")
+    CAT=fr("CATEGORIE","type/Text"); MQ=fr("MARQUE","type/Text"); MO=fr("MONTH_DATE","type/Date")
+    def kw_maps(cid,with_date=False,with_cat=True):
+        l=[m("marche01",cid,MAR),m("gamme01",cid,GAM),m("pat01",cid,KW),m("exact01",cid,KW)]
+        if with_cat: l.append(m("categ01",cid,CAT))
+        if with_date: l.append(m("date01",cid,MO))
+        return l
+    def page_maps(cid):
+        return [m("marche01",cid,MAR),m("marque01",cid,MQ),m("date01",cid,MO)]
+
+    def txt(t): return {"text":t,"virtual_card":{"name":None,"display":"text","visualization_settings":{},"dataset_query":{},"archived":False}}
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    def tmpl(corpus): return f"{dom}/dashboard/13489?client=Manucurist&corpus_name={ulib.quote(corpus)}&date=past48months"
+    sais_link=("### 🗓️ Saisonnalité\nVolumes de recherche par mois. Vue détaillée **48 mois** (template #13489) — choisis le marché : "
+               f"**[🇺🇸 US]({tmpl('Corpus transactionnel US')})**  ·  "
+               f"**[🇫🇷 FR]({tmpl('Corpus transactionnel FR - Mots clés stratégiques')})**")
+    dashcards=[
+      {"id":-1,"card_id":None,"row":0,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],"visualization_settings":txt("## 📊 Vision par mots-clés")},
+      {"id":-2,"card_id":SNAP,"row":1,"col":0,"size_x":24,"size_y":9,"series":[],"parameter_mappings":kw_maps(SNAP),
+       "visualization_settings":{"card.title":"Snapshot du dernier mois — position · Δ · volume · potentiel · clics (+ géo) · URL"}},
+      {"id":-3,"card_id":GRID,"row":10,"col":0,"size_x":24,"size_y":11,"series":[],"parameter_mappings":kw_maps(GRID,with_date=True),
+       "visualization_settings":{"card.title":"Positions mois par mois (100 = non classé)"}},
+      {"id":-4,"card_id":None,"row":21,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],"visualization_settings":txt(sais_link)},
+      {"id":-5,"card_id":SAIS_PIVOT,"row":22,"col":0,"size_x":24,"size_y":9,"series":[],
+       "parameter_mappings":[m("marche01",SAIS_PIVOT,MAR),m("gamme01",SAIS_PIVOT,GAM),m("pat01",SAIS_PIVOT,KW),m("exact01",SAIS_PIVOT,KW),m("date01",SAIS_PIVOT,MO)],
+       "visualization_settings":{"card.title":"Saisonnalité — volume de recherche par mois (24 mois)"}},
+      {"id":-6,"card_id":None,"row":31,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],"visualization_settings":txt("## 📄 Vision par pages")},
+      {"id":-7,"card_id":PAGES_PIVOT,"row":32,"col":0,"size_x":24,"size_y":9,"series":[],"parameter_mappings":page_maps(PAGES_PIVOT),
+       "visualization_settings":{"card.title":"Clics par gabarit de page (Blog / Collections / Produits), mois par mois"}},
+      {"id":-8,"card_id":DELTA,"row":41,"col":0,"size_x":24,"size_y":8,"series":[],"parameter_mappings":page_maps(DELTA),
+       "visualization_settings":{"card.title":"Δ 6 mois par gabarit — gagne-t-on du trafic ?"}},
+    ]
+    r=mb.put(f"/api/dashboard/{DASH}","raw",json={"parameters":P,"dashcards":dashcards,
+        "description":"V3 (gsheet Thibaut juin). 34 mots-clés stratégiques (16 US + 18 FR) par marché : position/Δ/volume/potentiel trafic/clics + split géo + URL positionnée ; saisonnalité ; clics par gabarit de page. Filtres : Marché, Gamme, Catégorie, Marque/Hors Marque, Mot-clé (contient/exact), Période."},timeout=HTTP_TIMEOUT)
+    bb=r.json() if hasattr(r,"json") else r
+    print("dashboard:",getattr(r,"status_code","?"),"| dashcards:",len(bb.get("dashcards",[])) if isinstance(bb,dict) else "?",
+          "| filtres:",[p.get("slug") for p in (bb.get("parameters") or [])] if isinstance(bb,dict) else "?")
+    print(f"\n>>> DASHBOARD V3: {dom}/dashboard/{DASH}")
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_global_dashboard.py
+++ b/scripts/build_seo_global_dashboard.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Phase 1 — NOUVEAU dashboard global de suivi mots-clés stratégiques | Manucurist.
+- bloc synthèse = snapshot #48635 (kw + volume + position + Δ + clics, dernier mois complet)
+- tableau détaillé inversé = #49557 (mois × kw × Rank/Impr/Clics)
+- filtres : Marché (FR/US, défaut FR), Gamme, Catégorie, Mot-clé (contient/exact), Période (6 mois)
+- le toggle Marché filtre synthèse + détail.
+Crée/maj le dashboard dans la collection Manucurist #13752 (idempotent par nom)."""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; COLL=13752; HTTP_TIMEOUT=300
+SNAP=48635; INV=49557
+DASH_NAME="Suivi mots-clés stratégiques (global) | Manucurist"
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+
+def find_dash(mb):
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")=="dashboard" and it.get("name")==DASH_NAME:
+            return it["id"]
+    return None
+
+def main():
+    mb=connect(); print("connected",flush=True)
+    did=find_dash(mb)
+    if not did:
+        b=mb.post("/api/dashboard","raw",json={"name":DASH_NAME,"collection_id":COLL,
+            "description":"Suivi mensuel des mots-clés stratégiques. Synthèse (kw+volume+position) + tableau inversé (mois × kw × Rank/Impr/Clics) pour lire l'évolution et corréler ranking/impressions/clics. Toggle Marché FR/US."}).json()
+        did=b.get("id"); print("dashboard créé #",did,flush=True)
+    else:
+        print("dashboard existant #",did,flush=True)
+
+    def DD(values): return {"values_query_type":"list","values_source_type":"static-list","values_source_config":{"values":values}}
+    P=[
+      {"id":"marche01","name":"Marché","slug":"marche","type":"string/=","sectionId":"string","default":"FR", **DD(["FR","US"])},
+      {"id":"gamme01","name":"Gamme","slug":"gamme","type":"string/=","sectionId":"string", **DD(["Gel Polish","Nail Polish","Nailcare"])},
+      {"id":"categ01","name":"Catégorie","slug":"categorie","type":"string/=","sectionId":"string", **DD(["Transactionnel","Générique","Clean / Engagement","Produit","Informationnel"])},
+      {"id":"pat01","name":"Mot-clé (contient)","slug":"pattern_keyword","type":"string/contains","sectionId":"string"},
+      {"id":"exact01","name":"Mot-clé (exact)","slug":"exact_keyword","type":"string/=","sectionId":"string"},
+      {"id":"date01","name":"Période","slug":"date","type":"date/all-options","sectionId":"date","default":"past6months"},
+    ]
+    KW=fr("KEYWORD","type/Text"); MAR=fr("MARCHE","type/Text"); GAM=fr("GAMME","type/Text"); CAT=fr("CATEGORIE","type/Text"); MO=fr("MONTH_DATE","type/Date")
+    def m(pid,cid,field): return {"parameter_id":pid,"card_id":cid,"target":["dimension",field]}
+    snap_maps=[m("marche01",SNAP,MAR),m("gamme01",SNAP,GAM),m("categ01",SNAP,CAT),m("pat01",SNAP,KW),m("exact01",SNAP,KW)]
+    inv_maps=[m("marche01",INV,MAR),m("gamme01",INV,GAM),m("categ01",INV,CAT),m("pat01",INV,KW),m("exact01",INV,KW),m("date01",INV,MO)]
+    def txt(t): return {"text":t,"virtual_card":{"name":None,"display":"text","visualization_settings":{},"dataset_query":{},"archived":False},
+        "text.align_vertical":"middle","text.align_horizontal":"left","dashcard.background":False}
+    dashcards=[
+      {"id":-1,"card_id":None,"row":0,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],
+       "visualization_settings":txt("## 📈 Synthèse — sur quel mot-clé monter ?\nMot-clé · volume de recherche · position (dernier mois complet). Filtrable par marché.")},
+      {"id":-2,"card_id":SNAP,"row":1,"col":0,"size_x":24,"size_y":9,"series":[],"parameter_mappings":snap_maps,
+       "visualization_settings":{"card.title":"Synthèse — mot-clé · volume · position · clics (dernier mois complet)"}},
+      {"id":-3,"card_id":None,"row":10,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],
+       "visualization_settings":txt("## 📊 Détail inversé — évolution par mot-clé\nMois en lignes, mot-clé en colonnes ; sous chaque kw **Rank · Impressions · Clics**. Rank en heatmap (vert = bon) — lu de haut en bas = trajectoire. Scroll horizontal pour parcourir les mots-clés.")},
+      {"id":-4,"card_id":INV,"row":11,"col":0,"size_x":24,"size_y":12,"series":[],"parameter_mappings":inv_maps,
+       "visualization_settings":{"card.title":"Évolution Rank · Impressions · Clics par mot-clé (mois en lignes)"}},
+    ]
+    body={"parameters":P,"dashcards":dashcards}
+    r=mb.put(f"/api/dashboard/{did}","raw",json=body,timeout=HTTP_TIMEOUT)
+    bb=r.json() if hasattr(r,"json") else r
+    print("dashboard PUT:",getattr(r,"status_code","?"),"| dashcards:",len(bb.get("dashcards",[])) if isinstance(bb,dict) else "?",
+          "| filtres:",[p.get("slug") for p in (bb.get("parameters") or [])] if isinstance(bb,dict) else "?",flush=True)
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> DASHBOARD #{did} : {dom}/dashboard/{did}",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_grid.py
+++ b/scripts/build_seo_grid.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Vue 'Positions mois par mois' (pivot MBQL) sur le modèle #48633.
+Lignes = mot-clé, colonnes = mois, valeur = position (DataForSEO/GSC). Couleur 1=vert.
+Stocké MLv2 (évite la redirection ad-hoc). Démo bakée sur Manucurist (le modèle est déjà Manucurist).
+"""
+from __future__ import annotations
+import json, sys, time, uuid, collections
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; SERP_COLLECTION=4809; MODEL_ID=48633; HTTP_TIMEOUT=300
+NAME="SEO — Positions mois par mois (grille) | Manucurist"
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+u=lambda: str(uuid.uuid4())
+def main():
+    mb=connect(); print("connected")
+    def fld(name,bt,extra=None):
+        o={"base-type":bt,"lib/uuid":u()}
+        if extra:o.update(extra)
+        return ["field",o,name]
+    dq={"database":DB,"lib/type":"mbql/query","stages":[{
+        "lib/type":"mbql.stage/mbql","source-card":MODEL_ID,
+        "aggregation":[["avg",{"lib/uuid":u()}, fld("POSITION","type/Float")]],
+        "breakout":[ fld("KEYWORD","type/Text"), fld("MONTH_DATE","type/Date",{"temporal-unit":"month"}) ]}]}
+    def sref(name,bt,extra=None):
+        o={"base-type":bt}
+        if extra:o.update(extra)
+        return ["field",name,o]
+    viz={"pivot_table.column_split":{
+            "rows":[sref("KEYWORD","type/Text")],
+            "columns":[sref("MONTH_DATE","type/Date",{"temporal-unit":"month"})],
+            "values":[["aggregation",0]]},
+         "column_settings":{json.dumps(["name","KEYWORD"]):{"column_title":"Mot-clé"}},
+         "table.column_formatting":[{"columns":["avg"],"type":"range","colors":["#84BB4C","#ED6E6E"],
+            "min_type":"custom","min_value":1,"max_type":"custom","max_value":50}]}
+    pl={"name":NAME,"collection_id":SERP_COLLECTION,"dataset_query":dq,"display":"pivot",
+        "visualization_settings":viz,
+        "description":"Grille mensuelle des positions (mots-clés × mois). Source modèle #48633. Vert = bonne position. Vue C du gsheet."}
+    # update-or-create
+    existing=None
+    for it in mb.get(f"/api/collection/{SERP_COLLECTION}/items?limit=2000").get("data",[]):
+        if it.get("model")=="card" and it.get("name")==NAME: existing=it.get("id"); break
+    if existing:
+        mb.put(f"/api/card/{existing}","raw",json=pl,timeout=HTTP_TIMEOUT); PID=existing; print("maj #",PID)
+    else:
+        b=mb.post("/api/card","raw",json=pl,timeout=HTTP_TIMEOUT).json()
+        if not b.get("id"): print("ÉCHEC:",str(b)[:500]); sys.exit(1)
+        PID=b["id"]; print("créé #",PID)
+    # result_metadata via legacy équivalent + rendu
+    legacy={"database":DB,"type":"query","query":{"source-table":f"card__{MODEL_ID}",
+        "aggregation":[["avg",["field","POSITION",{"base-type":"type/Float"}]]],
+        "breakout":[["field","KEYWORD",{"base-type":"type/Text"}],
+                    ["field","MONTH_DATE",{"base-type":"type/Date","temporal-unit":"month"}]]}}
+    jr=mb.post("/api/dataset","raw",json=legacy,timeout=HTTP_TIMEOUT).json()
+    if not jr.get("error"):
+        mb.put(f"/api/card/{PID}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+        cols=[c["name"] for c in jr["data"]["cols"]]; rows=jr["data"]["rows"]
+        ki=cols.index("KEYWORD"); mi=[i for i,c in enumerate(cols) if "MONTH" in c.upper()][0]; vi=len(cols)-1
+        g=collections.defaultdict(dict); months=set()
+        for r in rows:
+            m=str(r[mi])[:7]; g[r[ki]][m]=r[vi]; months.add(m)
+        months=sorted(months)[-6:]
+        print(f"\nGRILLE positions — {len(g)} mots-clés × {len(months)} derniers mois\n")
+        print("MOT-CLÉ".ljust(24)+" "+" ".join(x[2:] for x in months))
+        for kw in sorted(g):
+            print(kw[:23].ljust(24)+" "+" ".join((str(int(round(g[kw][m]))) if g[kw].get(m) is not None else ".").rjust(7) for m in months))
+    # vérif moteur pivot
+    jp=mb.post("/api/dataset/pivot","raw",json=legacy,timeout=HTTP_TIMEOUT).json()
+    print("\n/api/dataset/pivot:", "OK "+str(len(jp["data"]["rows"]))+" lignes" if jp.get("data") else str(jp)[:150])
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> GRILLE #{PID}: {dom}/question/{PID}")
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_inverted.py
+++ b/scripts/build_seo_inverted.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Phase 1 — tuile 'suivi inversé' Manucurist : MOIS en lignes × MOT-CLÉ en colonnes × [Rank, Impr, Clics].
+Pivot MBQL (MLv2) sur le modèle #48633. Heatmap sur le Rank (1 vert -> 100 rouge).
+Crée/maj la carte dans la collection Manucurist #13752. Imprime les noms de colonnes du résultat
+(pour vérifier le mapping des agrégations avant de figer le formatage)."""
+from __future__ import annotations
+import json, sys, time, uuid
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; COLL=13752; MODEL=48633; HTTP_TIMEOUT=480
+CARD_NAME="SEO — Suivi inversé : Rank · Impr · Clics × mois (mots-clés en colonnes) | Manucurist"
+u=lambda: str(uuid.uuid4())
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def fl(name,bt,extra=None):
+    o={"base-type":bt,"lib/uuid":u()}
+    if extra:o.update(extra)
+    return ["field",o,name]
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+
+def upsert(mb,name,payload):
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")=="card" and it.get("name")==name:
+            mb.put(f"/api/card/{it['id']}","raw",json=payload,timeout=HTTP_TIMEOUT); return it["id"],"maj"
+    b=mb.post("/api/card","raw",json=payload,timeout=HTTP_TIMEOUT).json(); return b.get("id"),"créé"
+
+def main():
+    mb=connect(); print("connected",flush=True)
+    dq={"database":DB,"lib/type":"mbql/query","stages":[{
+        "lib/type":"mbql.stage/mbql","source-card":MODEL,
+        "aggregation":[
+            ["sum",{"lib/uuid":u()}, fl("SEARCH_VOLUME","type/Number")],
+            ["avg",{"lib/uuid":u()}, fl("POSITION","type/Number")],
+            ["sum",{"lib/uuid":u()}, fl("IMPRESSIONS","type/Number")],
+            ["sum",{"lib/uuid":u()}, fl("CLICKS","type/Number")]],
+        "breakout":[ fl("MONTH_DATE","type/Date",{"temporal-unit":"month"}), fl("KEYWORD","type/Text") ]}]}
+    viz={"pivot_table.column_split":{
+            "rows":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})],
+            "columns":[fr("KEYWORD","type/Text")],
+            "values":[["aggregation",0],["aggregation",1],["aggregation",2],["aggregation",3]]},
+        "pivot.show_row_totals":False,"pivot.show_column_totals":False,
+        "column_settings":{
+            json.dumps(["name","MONTH_DATE"]):{"column_title":"Mois"},
+            json.dumps(["name","KEYWORD"]):{"column_title":"Mot-clé"},
+            json.dumps(["name","sum"]):{"column_title":"Volume","number_style":"decimal","decimals":0},
+            json.dumps(["name","avg"]):{"column_title":"Rank","number_style":"decimal","decimals":0},
+            json.dumps(["name","sum_2"]):{"column_title":"Impressions","number_style":"decimal","decimals":0},
+            json.dumps(["name","sum_3"]):{"column_title":"Clics","number_style":"decimal","decimals":0}},
+        "table.column_formatting":[
+            {"columns":["avg"],"type":"range","colors":["#84BB4C","#ED6E6E"],
+             "min_type":"custom","min_value":1,"max_type":"custom","max_value":100}]}
+    CID,how=upsert(mb,CARD_NAME,{"name":CARD_NAME,"collection_id":COLL,
+        "dataset_query":dq,"display":"pivot","visualization_settings":viz,
+        "description":"Suivi inversé : mois en lignes, mots-clés en colonnes ; sous chaque kw Volume (kp, ~constant car dernier connu) / Rank (avg POSITION, heatmap 1→100) / Impressions / Clics (GSC, échantillonné). Filtrable Marché/Gamme/Catégorie/Mot-clé/Période. Source modèle #48633."})
+    print(f"card {how} #{CID}",flush=True)
+    legacy={"database":DB,"type":"query","query":{"source-table":f"card__{MODEL}",
+        "aggregation":[["sum",fr("SEARCH_VOLUME","type/Number")],["avg",fr("POSITION","type/Number")],["sum",fr("IMPRESSIONS","type/Number")],["sum",fr("CLICKS","type/Number")]],
+        "breakout":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"}),fr("KEYWORD","type/Text")]}}
+    jr=mb.post("/api/dataset","raw",json=legacy,timeout=HTTP_TIMEOUT).json()
+    if jr.get("error"):
+        print("ERR run:",str(jr["error"])[:400],flush=True)
+    else:
+        cols=jr["data"]["cols"]; rows=jr["data"]["rows"]
+        print("COLS:", [(c.get("name"),c.get("display_name")) for c in cols],flush=True)
+        print("nb lignes (mois×kw):",len(rows),flush=True)
+        mb.put(f"/api/card/{CID}","raw",json={"result_metadata":cols},timeout=120)
+        print("result_metadata posé",flush=True)
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> CARD #{CID} : {dom}/question/{CID}",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_monitoring.py
+++ b/scripts/build_seo_monitoring.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Modèle consolidé V1 — SEO Keyword Monitoring | Manucurist.
+
+15 mots-clés curatés (gsheet) × mois × [Position (SERP), Volume (KP), Clics+Impr (GSC)],
++ gamme + catégorie. Zone US (mots-clés EN). 13 mois. Mapping kw→gamme→catégorie en dur (V1).
+Valide un snapshot avant de créer le modèle.
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; SERP_COLLECTION=4809; HTTP_TIMEOUT=300; ZONE="United States"
+
+# 15 mots-clés curatés (du gsheet) : (keyword_lower, gamme, categorie)
+KW=[("gel polish kit","Gel Polish","Transactionnel"),
+    ("gel polish","Gel Polish","Générique"),
+    ("non toxic gel polish","Gel Polish","Clean / Engagement"),
+    ("gel nail polish","Gel Polish","Générique"),
+    ("led gel polish","Gel Polish","Produit"),
+    ("nail polish kit","Nail Polish","Transactionnel"),
+    ("non toxic nail polish","Nail Polish","Clean / Engagement"),
+    ("vegan nail polish","Nail Polish","Clean / Engagement"),
+    ("natural nail polish","Nail Polish","Clean / Engagement"),
+    ("nail polish","Nail Polish","Générique"),
+    ("nail care","Nailcare","Générique"),
+    ("cuticle oil","Nailcare","Produit"),
+    ("nail strengthener","Nailcare","Produit"),
+    ("base & top coat","Nailcare","Produit"),
+    ("nail treatment","Nailcare","Informationnel")]
+
+def vlist():
+    return ",\n    ".join("('%s','%s','%s')"%(k.replace("'","''"),g,c) for k,g,c in KW)
+INLIST=",".join("'%s'"%k for k,_,_ in KW)
+
+MODEL_SQL=f"""
+WITH kw_map AS (
+  SELECT * FROM (VALUES
+    {vlist()}
+  ) AS t(keyword, gamme, categorie)
+),
+months AS (
+  SELECT DISTINCT DATE_TRUNC('month', date) AS month_date
+  FROM utils.calendar
+  WHERE date >= DATEADD('month', -13, CURRENT_DATE) AND date <= CURRENT_DATE
+),
+gcd AS (
+  SELECT serp_requests.client_id, serp_requests.corpus_name,
+         LOWER(serp__keyword_metrics.keyword) AS keyword,
+         serp__keyword_metrics.url, serp__keyword_metrics.request_date,
+         serp_requests.domain AS client_domain,
+         CASE WHEN serp__keyword_metrics.type='featured_snippet' AND serp__keyword_metrics.rank_group=1 THEN 0
+              ELSE serp__keyword_metrics.rank_absolute END AS rank_absolute
+  FROM utils.clients
+    JOIN google_serp.serp_requests ON google_serp.serp_requests.client_id = utils.clients.id
+    JOIN google_serp.serp_history ON (serp_history.keyword=serp_requests.keyword AND serp_history.language=serp_requests.language AND serp_history.zone=serp_requests.zone)
+    JOIN google_serp.serp__keyword_metrics ON (serp__keyword_metrics.keyword=serp_history.keyword AND serp__keyword_metrics.language=serp_history.language AND serp__keyword_metrics.zone=serp_history.zone)
+  WHERE utils.clients.name='Manucurist' AND serp_requests.zone='{ZONE}'
+    AND LOWER(serp_requests.keyword) IN ({INLIST})
+    AND serp__keyword_metrics.request_date >= DATEADD('month', -13, CURRENT_DATE)
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY serp_requests.client_id, serp_requests.corpus_name, serp_history.keyword, serp_history.language, serp_history.zone, serp__keyword_metrics.url, serp__keyword_metrics.request_date ORDER BY rank_absolute) = 1
+),
+client_pos AS (
+  SELECT keyword, request_date, rank_absolute
+  FROM gcd WHERE url ILIKE '%' || client_domain || '%'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY keyword, request_date ORDER BY rank_absolute) = 1
+),
+pos AS (
+  SELECT keyword, DATE_TRUNC('month', request_date) AS month_date, AVG(rank_absolute) AS position
+  FROM client_pos GROUP BY 1,2
+),
+gsc_pos AS (
+  SELECT LOWER(keyword) AS keyword, DATE_TRUNC('month', date) AS month_date,
+         SUM(position * impressions) / NULLIF(SUM(impressions), 0) AS gsc_position
+  FROM google_search_console.gsc__site_keyword_daily_metrics
+  WHERE client_name='Manucurist' AND LOWER(keyword) IN ({INLIST})
+  GROUP BY 1,2
+),
+vol AS (  -- dernier volume connu par mot-clé (kp lague ~2 mois)
+  SELECT keyword, search_volume FROM (
+    SELECT LOWER(keyword) AS keyword,
+           COALESCE(adjusted_avg_searches, avg_monthly_searches) AS search_volume,
+           ROW_NUMBER() OVER (PARTITION BY LOWER(keyword) ORDER BY month DESC) AS rn
+    FROM google_keyword_planner.kp__keyword_monthly_metrics
+    WHERE zone='{ZONE}' AND LOWER(keyword) IN ({INLIST})
+  ) WHERE rn=1
+),
+clk AS (
+  SELECT LOWER(keyword) AS keyword, DATE_TRUNC('month', date) AS month_date,
+         SUM(clicks) AS clicks, SUM(impressions) AS impressions
+  FROM google_search_console.gsc__site_keyword_daily_metrics
+  WHERE client_name='Manucurist' AND LOWER(keyword) IN ({INLIST})
+  GROUP BY 1,2
+)
+SELECT
+  m.month_date,
+  k.gamme, k.categorie, k.keyword,
+  COALESCE(pos.position, gsc_pos.gsc_position) AS position,
+  pos.position        AS position_serp,
+  gsc_pos.gsc_position AS position_gsc,
+  vol.search_volume   AS search_volume,
+  clk.clicks          AS clicks,
+  clk.impressions     AS impressions
+FROM kw_map k
+  CROSS JOIN months m
+  LEFT JOIN pos ON pos.keyword=k.keyword AND pos.month_date=m.month_date
+  LEFT JOIN gsc_pos ON gsc_pos.keyword=k.keyword AND gsc_pos.month_date=m.month_date
+  LEFT JOIN vol ON vol.keyword=k.keyword
+  LEFT JOIN clk ON clk.keyword=k.keyword AND clk.month_date=m.month_date
+ORDER BY k.gamme, k.keyword, m.month_date DESC
+"""
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql):
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=HTTP_TIMEOUT)
+    j=r.json()
+    if j.get("error"): return None,str(j["error"])
+    d=j["data"]; return {"cols":d["cols"],"rows":d["rows"]},None
+
+def main():
+    mb=connect(); print("connected")
+    res,err=run(mb, MODEL_SQL)
+    if err: print("ÉCHEC SQL modèle:",err[:500]); sys.exit(1)
+    cols=[c["name"] for c in res["cols"]]; rows=res["rows"]
+    print(f"modèle: {len(rows)} lignes, cols={cols}")
+    # snapshot dernier mois
+    ci={n:i for i,n in enumerate(cols)}
+    months=sorted({r[ci["MONTH_DATE"]] for r in rows}, reverse=True)
+    last=months[0] if months else None
+    print(f"\nSNAPSHOT {str(last)[:7]} (15 kw) :")
+    print("  GAMME        CATÉGORIE          MOT-CLÉ                POS   VOL    CLICS")
+    snap=[r for r in rows if r[ci["MONTH_DATE"]]==last]
+    for r in sorted(snap, key=lambda r:(r[ci["GAMME"]], r[ci["KEYWORD"]])):
+        pos=r[ci["POSITION"]]; vol=r[ci["SEARCH_VOLUME"]]; clk=r[ci["CLICKS"]]
+        print(f"  {str(r[ci['GAMME']]):12} {str(r[ci['CATEGORIE']]):18} {r[ci['KEYWORD']][:22]:22} "
+              f"{('%.0f'%pos if pos is not None else '.'):>4} {('%.0f'%vol if vol is not None else '.'):>6} {('%.0f'%clk if clk is not None else '.'):>6}")
+    nkw=len({r[ci["KEYWORD"]] for r in snap})
+    haspos=sum(1 for r in snap if r[ci["POSITION"]] is not None)
+    print(f"\n  {nkw}/15 mots-clés, {haspos} avec position ce mois")
+    if nkw<15 or haspos<5:
+        print("  ⚠️ snapshot incomplet — on NE crée pas, à investiguer."); sys.exit(1)
+
+    NAME="SEO Keyword Monitoring — Manucurist (model)"
+    DESC=("V1 livrable suivi mots-clés SEO Manucurist (gsheet). 15 kw curatés × mois × "
+          "Position (COALESCE SERP DataForSEO / GSC) / Volume (KP, dernier connu) / Clics+Impr (GSC), "
+          "+ gamme/catégorie + position_serp & position_gsc séparées. Zone US. Mapping kw→gamme→catégorie en dur (V1).")
+    pl={"name":NAME,"type":"model","collection_id":SERP_COLLECTION,
+        "dataset_query":{"database":DB,"type":"native","native":{"query":MODEL_SQL}},
+        "display":"table","visualization_settings":{},"description":DESC}
+    existing=None
+    for it in mb.get(f"/api/collection/{SERP_COLLECTION}/items?limit=2000").get("data",[]):
+        if it.get("model")=="dataset" and it.get("name")==NAME: existing=it.get("id"); break
+    if existing:
+        mb.put(f"/api/card/{existing}","raw",json=pl,timeout=HTTP_TIMEOUT); MID=existing
+        print(f"  modèle mis à jour #{MID}")
+    else:
+        b=mb.post("/api/card","raw",json=pl,timeout=HTTP_TIMEOUT).json()
+        if not b.get("id"): print("ÉCHEC create:",str(b)[:400]); sys.exit(1)
+        MID=b["id"]; print(f"  modèle créé #{MID}")
+    rm,_=run(mb, f"SELECT * FROM ({MODEL_SQL}) LIMIT 50")
+    if rm: mb.put(f"/api/card/{MID}","raw",json={"result_metadata":rm["cols"]},timeout=120)
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> MODÈLE V1 #{MID}: {dom}/model/{MID}")
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_monitoring_v2.py
+++ b/scripts/build_seo_monitoring_v2.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Modèle mots-clés V2 — SEO Keyword Monitoring | Manucurist (gsheet V2).
+
+14 kw US + 18 kw FR × mois (13) × :
+- position : SERP DataForSEO par zone (FR→France, US→United States), repli GSC
+  (position pondérée impressions, depuis page_keyword) ; affichage convention
+  gsheet : 100 = non classé (LEAST/COALESCE)
+- volume   : kp par zone, dernier connu
+- clics    : GSC page_keyword, attribués au MARCHÉ DU SITE via l'URL
+  (www=FR, us.=US, uk.=UK, locales www/{en,es,...}=AUTRES)
+- Δ vs M-1 et Δ 6 mois (LAG sur position affichée ; + = positions gagnées)
+
+Met à jour le modèle #48633 EN PLACE. Valide un snapshot avant le PUT.
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; MODEL_ID=48633; HTTP_TIMEOUT=480
+
+US=['gel polish kit','gel polish','non toxic gel polish','gel nail polish','nail polish kit',
+ 'non toxic nail polish','vegan nail polish','natural nail polish','nail polish','nail care',
+ 'cuticle oil','nail strengthener','base coat','top coat','nail treatment']
+FR=['vernis semi permanent','french manucure','kit vernis semi permanent','kit manucure',
+ 'vernis a ongle','top coat','lampe uv ongles','base coat','soin des ongles',
+ 'kit manucure semi permanent','dissolvant vernis semi permanent','vernis amer',
+ 'vernis durcisseur','kit semi permanent','dissolvant semi permanent','couleur vernis',
+ 'huile cuticule','vernis naturel']
+def esc(k): return k.replace("'","''")
+VALUES=",\n    ".join([f"('{esc(k)}','US')" for k in US]+[f"('{esc(k)}','FR')" for k in FR])
+ALL_IN=",".join(f"'{esc(k)}'" for k in US+FR)
+
+MODEL_SQL=f"""
+WITH kw_map AS (
+  SELECT t.keyword, t.marche,
+         CASE t.marche WHEN 'FR' THEN 'France' WHEN 'US' THEN 'United States' END AS zone
+  FROM (VALUES
+    {VALUES}
+  ) AS t(keyword, marche)
+),
+months AS (
+  SELECT DISTINCT DATE_TRUNC('month', date) AS month_date
+  FROM utils.calendar
+  WHERE date >= DATEADD('month', -13, CURRENT_DATE) AND date <= CURRENT_DATE
+),
+gcd AS (
+  SELECT serp_requests.zone AS zone,
+         LOWER(serp__keyword_metrics.keyword) AS keyword,
+         serp__keyword_metrics.url, serp__keyword_metrics.request_date,
+         serp_requests.domain AS client_domain,
+         CASE WHEN serp__keyword_metrics.type='featured_snippet' AND serp__keyword_metrics.rank_group=1 THEN 0
+              ELSE serp__keyword_metrics.rank_absolute END AS rank_absolute
+  FROM utils.clients
+    JOIN google_serp.serp_requests ON google_serp.serp_requests.client_id = utils.clients.id
+    JOIN google_serp.serp_history ON (serp_history.keyword=serp_requests.keyword AND serp_history.language=serp_requests.language AND serp_history.zone=serp_requests.zone)
+    JOIN google_serp.serp__keyword_metrics ON (serp__keyword_metrics.keyword=serp_history.keyword AND serp__keyword_metrics.language=serp_history.language AND serp__keyword_metrics.zone=serp_history.zone)
+  WHERE utils.clients.name='Manucurist'
+    AND serp_requests.zone IN ('France','United States')
+    AND LOWER(serp_requests.keyword) IN ({ALL_IN})
+    AND serp__keyword_metrics.request_date >= DATEADD('month', -13, CURRENT_DATE)
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY serp_requests.client_id, serp_requests.corpus_name, serp_history.keyword, serp_history.language, serp_history.zone, serp__keyword_metrics.url, serp__keyword_metrics.request_date ORDER BY rank_absolute) = 1
+),
+client_pos AS (
+  SELECT zone, keyword, request_date, rank_absolute
+  FROM gcd WHERE url ILIKE '%' || client_domain || '%'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY zone, keyword, request_date ORDER BY rank_absolute) = 1
+),
+pos AS (
+  SELECT zone, keyword, DATE_TRUNC('month', request_date) AS month_date, AVG(rank_absolute) AS position
+  FROM client_pos GROUP BY 1,2,3
+),
+vol AS (
+  SELECT zone, keyword, search_volume FROM (
+    SELECT zone, LOWER(keyword) AS keyword,
+           COALESCE(adjusted_avg_searches, avg_monthly_searches) AS search_volume,
+           ROW_NUMBER() OVER (PARTITION BY zone, LOWER(keyword) ORDER BY month DESC) AS rn
+    FROM google_keyword_planner.kp__keyword_monthly_metrics
+    WHERE zone IN ('France','United States') AND LOWER(keyword) IN ({ALL_IN})
+  ) WHERE rn=1
+),
+gsc AS (
+  SELECT LOWER(keyword) AS keyword,
+    CASE WHEN page ILIKE 'https://us.manucurist.com%' THEN 'US'
+         WHEN page ILIKE 'https://uk.manucurist.com%' THEN 'UK'
+         WHEN REGEXP_LIKE(page, 'https://www[.]manucurist[.]com/(en|es|it|de|nl|el|pt)(/.*)?') THEN 'AUTRES'
+         WHEN page ILIKE 'https://www.manucurist.com%' THEN 'FR'
+         ELSE 'AUTRES' END AS marche,
+    DATE_TRUNC('month', date) AS month_date,
+    SUM(clicks) AS clicks, SUM(impressions) AS impressions,
+    SUM(position*impressions)/NULLIF(SUM(impressions),0) AS gsc_position
+  FROM google_search_console.gsc__page_keyword_daily_metrics
+  WHERE client_name='Manucurist' AND LOWER(keyword) IN ({ALL_IN})
+    AND date >= DATEADD('month', -13, CURRENT_DATE)
+  GROUP BY 1,2,3
+),
+assembled AS (
+  SELECT
+    m.month_date, k.marche, k.keyword,
+    LEAST(COALESCE(pos.position, g.gsc_position, 100), 100) AS position,
+    pos.position      AS position_serp,
+    g.gsc_position    AS position_gsc,
+    vol.search_volume AS search_volume,
+    g.clicks          AS clicks,
+    g.impressions     AS impressions
+  FROM kw_map k
+    CROSS JOIN months m
+    LEFT JOIN pos ON pos.zone=k.zone AND pos.keyword=k.keyword AND pos.month_date=m.month_date
+    LEFT JOIN gsc g ON g.marche=k.marche AND g.keyword=k.keyword AND g.month_date=m.month_date
+    LEFT JOIN vol ON vol.zone=k.zone AND vol.keyword=k.keyword
+)
+SELECT a.*,
+  LAG(position)   OVER (PARTITION BY marche, keyword ORDER BY month_date) - position AS delta_m1,
+  LAG(position,6) OVER (PARTITION BY marche, keyword ORDER BY month_date) - position AS delta_6m
+FROM assembled a
+ORDER BY marche, keyword, month_date DESC
+"""
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql):
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=HTTP_TIMEOUT)
+    j=r.json()
+    if j.get("error"): return None,str(j["error"])
+    d=j["data"]; return {"cols":d["cols"],"rows":d["rows"]},None
+
+def main():
+    mb=connect(); print("connected")
+    res,err=run(mb, MODEL_SQL)
+    if err: print("ÉCHEC SQL:",err[:600]); sys.exit(1)
+    cols=[c["name"] for c in res["cols"]]; rows=res["rows"]
+    ci={n:i for i,n in enumerate(cols)}
+    print(f"modèle: {len(rows)} lignes (attendu 33 kw × 14 mois = 462), cols={cols}")
+    months=sorted({r[ci["MONTH_DATE"]] for r in rows})
+    # snapshot mois précédent (données complètes)
+    prev=months[-2] if len(months)>=2 else months[-1]
+    snap=[r for r in rows if r[ci["MONTH_DATE"]]==prev]
+    print(f"\nSNAPSHOT {str(prev)[:7]} :")
+    print("  M  MOT-CLÉ                          POS  ΔM-1  Δ6M    VOL   CLICS")
+    ok_pos=ok_vol=ok_clk=0
+    for r in sorted(snap, key=lambda r:(r[ci["MARCHE"]], r[ci["POSITION"]] if r[ci["POSITION"]] is not None else 999)):
+        p=r[ci["POSITION"]]; d1=r[ci["DELTA_M1"]]; d6=r[ci["DELTA_6M"]]
+        v=r[ci["SEARCH_VOLUME"]]; cl=r[ci["CLICKS"]]
+        if p is not None and p<100: ok_pos+=1
+        if v: ok_vol+=1
+        if cl is not None: ok_clk+=1
+        fmt=lambda x,w: (('%+d'%x) if isinstance(x,(int,float)) and x==x else '.').rjust(w) if x is not None else '.'.rjust(w)
+        print(f"  {r[ci['MARCHE']]:3} {r[ci['KEYWORD']][:32]:32} {('%.0f'%p if p is not None else '.'):>4} {fmt(d1,5)} {fmt(d6,5)} {('%.0f'%v if v else '.'):>6} {('%.0f'%cl if cl is not None else '.'):>6}")
+    print(f"\n  {len(snap)} lignes | positions<100: {ok_pos} | volumes: {ok_vol} | clics non-null: {ok_clk}")
+    if len(snap)!=33 or ok_vol<31:
+        print("  ⚠️ incomplet — PAS de PUT."); sys.exit(1)
+
+    DESC=("V2 (gsheet Thibaut 2026-06 ; base & top coat US scindé en base coat + top coat sur demande Thibaut). "
+          "15 kw US + 18 kw FR × mois × position (SERP zone, repli GSC ; "
+          "100 = non classé) / volume (kp zone, dernier connu) / clics GSC par marché du site (URL : www=FR, us.=US, uk.=UK) "
+          "+ Δ vs M-1 et Δ 6 mois (+ = positions gagnées). NB: pays du chercheur non ingéré (country='other') → marché = section du site.")
+    r=mb.put(f"/api/card/{MODEL_ID}","raw",json={
+        "name":"SEO Keyword Monitoring — Manucurist (model)",
+        "dataset_query":{"database":DB,"type":"native","native":{"query":MODEL_SQL}},
+        "description":DESC},timeout=HTTP_TIMEOUT)
+    print("PUT modèle:",getattr(r,"status_code","?"))
+    rm,_=run(mb, f"SELECT * FROM ({MODEL_SQL}) LIMIT 40")
+    if rm: print("PUT metadata:",getattr(mb.put(f"/api/card/{MODEL_ID}","raw",json={"result_metadata":rm["cols"]},timeout=120),"status_code","?"))
+    print(f"\n>>> MODÈLE V2 #{MODEL_ID} mis à jour")
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_monitoring_v3.py
+++ b/scripts/build_seo_monitoring_v3.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Modèle mots-clés V3 — SEO Keyword Monitoring | Manucurist (gsheet V3).
+
+Ajoute vs V2 : Gamme, Catégorie, URL positionnée, Potentiel de trafic (vol×CTR position),
+Δ vs M-3, clics TOTAUX + split géo (Trafic FR/UK/US/Autres), Δ clics vs M-1.
+16 kw US + 18 kw FR. Mapping gamme/catégorie : US = gsheet ; FR = proposition (à valider).
+Met à jour #48633 en place. Valide un snapshot avant PUT.
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; MODEL_ID=48633; HTTP_TIMEOUT=600
+
+# (keyword, gamme, categorie)
+US=[("gel polish kit","Gel Polish","Transactionnel"),
+    ("gel polish","Gel Polish","Générique"),
+    ("non toxic gel polish","Gel Polish","Clean / Engagement"),
+    ("gel nail polish","Gel Polish","Générique"),
+    ("led gel polish","Gel Polish","Produit"),
+    ("nail polish kit","Nail Polish","Transactionnel"),
+    ("non toxic nail polish","Nail Polish","Clean / Engagement"),
+    ("vegan nail polish","Nail Polish","Clean / Engagement"),
+    ("natural nail polish","Nail Polish","Clean / Engagement"),
+    ("nail polish","Nail Polish","Générique"),
+    ("nail care","Nailcare","Générique"),
+    ("cuticle oil","Nailcare","Produit"),
+    ("nail strengthener","Nailcare","Produit"),
+    ("base coat","Nailcare","Produit"),
+    ("top coat","Nailcare","Produit"),
+    ("nail treatment","Nailcare","Informationnel")]
+# FR : mapping proposé (à valider avec Thibaut)
+FR=[("vernis semi permanent","Gel Polish","Générique"),
+    ("french manucure","Nail Polish","Générique"),
+    ("kit vernis semi permanent","Gel Polish","Transactionnel"),
+    ("kit manucure","Nailcare","Transactionnel"),
+    ("vernis a ongle","Nail Polish","Générique"),
+    ("top coat","Nailcare","Produit"),
+    ("lampe uv ongles","Gel Polish","Produit"),
+    ("base coat","Nailcare","Produit"),
+    ("soin des ongles","Nailcare","Générique"),
+    ("kit manucure semi permanent","Gel Polish","Transactionnel"),
+    ("dissolvant vernis semi permanent","Gel Polish","Produit"),
+    ("vernis amer","Nailcare","Produit"),
+    ("vernis durcisseur","Nailcare","Produit"),
+    ("kit semi permanent","Gel Polish","Transactionnel"),
+    ("dissolvant semi permanent","Gel Polish","Produit"),
+    ("couleur vernis","Nail Polish","Générique"),
+    ("huile cuticule","Nailcare","Produit"),
+    ("vernis naturel","Nail Polish","Clean / Engagement")]
+def esc(s): return s.replace("'","''")
+VALUES=",\n    ".join([f"('{esc(k)}','US','{g}','{c}')" for k,g,c in US]
+                     +[f"('{esc(k)}','FR','{g}','{c}')" for k,g,c in FR])
+ALL_IN=",".join(sorted({f"'{esc(k)}'" for k,_,_ in US+FR}))
+
+# CASE marché (section de site) réutilisé pour les clics géo
+def market_case(col="page"):
+    return (f"CASE WHEN {col} ILIKE 'https://us.manucurist.com%' THEN 'US' "
+            f"WHEN {col} ILIKE 'https://uk.manucurist.com%' THEN 'UK' "
+            f"WHEN REGEXP_LIKE({col},'https://www[.]manucurist[.]com/(en|es|it|de|nl|el|pt)(/.*)?') THEN 'AUTRES' "
+            f"WHEN {col} ILIKE 'https://www.manucurist.com%' THEN 'FR' ELSE 'AUTRES' END")
+
+MODEL_SQL=f"""
+WITH kw_map AS (
+  SELECT * FROM (VALUES
+    {VALUES}
+  ) AS t(keyword, marche, gamme, categorie)
+),
+zone_map AS (
+  SELECT keyword, marche, gamme, categorie,
+         CASE marche WHEN 'FR' THEN 'France' WHEN 'US' THEN 'United States' END AS zone
+  FROM kw_map
+),
+months AS (
+  SELECT DISTINCT DATE_TRUNC('month', date) AS month_date
+  FROM utils.calendar
+  WHERE date >= DATEADD('month', -13, CURRENT_DATE) AND date <= CURRENT_DATE
+),
+gcd AS (
+  SELECT serp_requests.zone AS zone,
+         LOWER(serp__keyword_metrics.keyword) AS keyword,
+         serp__keyword_metrics.url AS url, serp__keyword_metrics.request_date,
+         serp_requests.domain AS client_domain,
+         CASE WHEN serp__keyword_metrics.type='featured_snippet' AND serp__keyword_metrics.rank_group=1 THEN 0
+              ELSE serp__keyword_metrics.rank_absolute END AS rank_absolute
+  FROM utils.clients
+    JOIN google_serp.serp_requests ON google_serp.serp_requests.client_id = utils.clients.id
+    JOIN google_serp.serp_history ON (serp_history.keyword=serp_requests.keyword AND serp_history.language=serp_requests.language AND serp_history.zone=serp_requests.zone)
+    JOIN google_serp.serp__keyword_metrics ON (serp__keyword_metrics.keyword=serp_history.keyword AND serp__keyword_metrics.language=serp_history.language AND serp__keyword_metrics.zone=serp_history.zone)
+  WHERE utils.clients.name='Manucurist'
+    AND serp_requests.zone IN ('France','United States')
+    AND LOWER(serp_requests.keyword) IN ({ALL_IN})
+    AND serp__keyword_metrics.request_date >= DATEADD('month', -13, CURRENT_DATE)
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY serp_requests.client_id, serp_requests.corpus_name, serp_history.keyword, serp_history.language, serp_history.zone, serp__keyword_metrics.url, serp__keyword_metrics.request_date ORDER BY rank_absolute) = 1
+),
+client_pos AS (
+  SELECT zone, keyword, request_date, rank_absolute, REGEXP_REPLACE(url,'[?].*$','') AS url
+  FROM gcd WHERE url ILIKE '%' || client_domain || '%'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY zone, keyword, request_date ORDER BY rank_absolute) = 1
+),
+pos AS (
+  SELECT zone, keyword, DATE_TRUNC('month', request_date) AS month_date, AVG(rank_absolute) AS position
+  FROM client_pos GROUP BY 1,2,3
+),
+url_pos AS (
+  SELECT zone, keyword, url FROM (
+    SELECT zone, keyword, url,
+           ROW_NUMBER() OVER (PARTITION BY zone, keyword ORDER BY request_date DESC, rank_absolute) rn
+    FROM client_pos
+  ) WHERE rn=1
+),
+vol AS (
+  SELECT zone, keyword, search_volume FROM (
+    SELECT zone, LOWER(keyword) AS keyword,
+           COALESCE(adjusted_avg_searches, avg_monthly_searches) AS search_volume,
+           ROW_NUMBER() OVER (PARTITION BY zone, LOWER(keyword) ORDER BY month DESC) AS rn
+    FROM google_keyword_planner.kp__keyword_monthly_metrics
+    WHERE zone IN ('France','United States') AND LOWER(keyword) IN ({ALL_IN})
+  ) WHERE rn=1
+),
+gsc AS (
+  SELECT LOWER(keyword) AS keyword, DATE_TRUNC('month', date) AS month_date,
+    SUM(clicks) AS clicks, SUM(impressions) AS impressions,
+    SUM(position*impressions)/NULLIF(SUM(impressions),0) AS gsc_position,
+    SUM(CASE WHEN {market_case()}='FR' THEN clicks ELSE 0 END) AS clicks_fr,
+    SUM(CASE WHEN {market_case()}='UK' THEN clicks ELSE 0 END) AS clicks_uk,
+    SUM(CASE WHEN {market_case()}='US' THEN clicks ELSE 0 END) AS clicks_us,
+    SUM(CASE WHEN {market_case()}='AUTRES' THEN clicks ELSE 0 END) AS clicks_autres
+  FROM google_search_console.gsc__page_keyword_daily_metrics
+  WHERE client_name='Manucurist' AND LOWER(keyword) IN ({ALL_IN})
+    AND date >= DATEADD('month', -13, CURRENT_DATE)
+  GROUP BY 1,2
+),
+assembled AS (
+  SELECT
+    m.month_date, z.marche, z.gamme, z.categorie, z.keyword,
+    up.url AS url_positionnee,
+    LEAST(COALESCE(pos.position, g.gsc_position, 100), 100) AS position,
+    pos.position AS position_serp, g.gsc_position AS position_gsc,
+    vol.search_volume AS search_volume,
+    g.clicks AS clicks, g.impressions AS impressions,
+    COALESCE(g.clicks_fr,0) AS clicks_fr, COALESCE(g.clicks_uk,0) AS clicks_uk,
+    COALESCE(g.clicks_us,0) AS clicks_us, COALESCE(g.clicks_autres,0) AS clicks_autres
+  FROM zone_map z
+    CROSS JOIN months m
+    LEFT JOIN pos ON pos.zone=z.zone AND pos.keyword=z.keyword AND pos.month_date=m.month_date
+    LEFT JOIN gsc g ON g.keyword=z.keyword AND g.month_date=m.month_date
+    LEFT JOIN vol ON vol.zone=z.zone AND vol.keyword=z.keyword
+    LEFT JOIN url_pos up ON up.zone=z.zone AND up.keyword=z.keyword
+),
+withctr AS (
+  SELECT a.*,
+    ROUND(a.search_volume * COALESCE(ctr.ctr_medium,0)) AS potentiel_trafic
+  FROM assembled a
+    LEFT JOIN metabase_filters.serp_ctr_scenarios ctr
+      ON ctr.name='Default' AND ctr.position = LEAST(GREATEST(ROUND(a.position),0),100)
+)
+SELECT w.*,
+  LAG(position)   OVER (PARTITION BY marche, keyword ORDER BY month_date) - position AS delta_m1,
+  LAG(position,3) OVER (PARTITION BY marche, keyword ORDER BY month_date) - position AS delta_m3,
+  clicks - LAG(clicks) OVER (PARTITION BY marche, keyword ORDER BY month_date)        AS delta_clicks_m1
+FROM withctr w
+ORDER BY marche, gamme, keyword, month_date DESC
+"""
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql):
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=HTTP_TIMEOUT)
+    j=r.json()
+    if j.get("error"): return None,str(j["error"])
+    d=j["data"]; return {"cols":d["cols"],"rows":d["rows"]},None
+
+def main():
+    mb=connect(); print("connected")
+    nkw=len(US)+len(FR)
+    res,err=run(mb, MODEL_SQL)
+    if err: print("ÉCHEC SQL:",err[:700]); sys.exit(1)
+    cols=[c["name"] for c in res["cols"]]; rows=res["rows"]; ci={n:i for i,n in enumerate(cols)}
+    print(f"modèle: {len(rows)} lignes (attendu {nkw}×14≈{nkw*14}), cols={cols}")
+    months=sorted({r[ci["MONTH_DATE"]] for r in rows})
+    prev=months[-2] if len(months)>=2 else months[-1]
+    snap=[r for r in rows if r[ci["MONTH_DATE"]]==prev]
+    print(f"\nSNAPSHOT {str(prev)[:7]} (extrait) :")
+    print("  M  GAMME       MOT-CLÉ                    POS POT.TRAF VOL   CLICS  FR/UK/US/AU         URL")
+    okurl=okpot=okgeo=0
+    for r in sorted(snap, key=lambda r:(r[ci["MARCHE"]], r[ci["POSITION"]] if r[ci["POSITION"]] is not None else 999))[:12]:
+        u=r[ci["URL_POSITIONNEE"]]; pot=r[ci["POTENTIEL_TRAFIC"]]
+        geo=f"{int(r[ci['CLICKS_FR']] or 0)}/{int(r[ci['CLICKS_UK']] or 0)}/{int(r[ci['CLICKS_US']] or 0)}/{int(r[ci['CLICKS_AUTRES']] or 0)}"
+        print(f"  {r[ci['MARCHE']]:2} {str(r[ci['GAMME']]):11} {r[ci['KEYWORD']][:24]:24} "
+              f"{('%.0f'%r[ci['POSITION']]):>3} {('%.0f'%pot if pot is not None else '.'):>7} "
+              f"{('%.0f'%r[ci['SEARCH_VOLUME']] if r[ci['SEARCH_VOLUME']] else '.'):>6} "
+              f"{('%.0f'%r[ci['CLICKS']] if r[ci['CLICKS']] is not None else '.'):>5}  {geo:16} {str(u)[:38] if u else '—'}")
+    for r in snap:
+        if r[ci["URL_POSITIONNEE"]]: okurl+=1
+        if r[ci["POTENTIEL_TRAFIC"]] is not None: okpot+=1
+        if (r[ci["CLICKS_FR"]] or r[ci["CLICKS_UK"]] or r[ci["CLICKS_US"]] or r[ci["CLICKS_AUTRES"]]): okgeo+=1
+    print(f"\n  {len(snap)} lignes | URL pos.: {okurl} | potentiel calc.: {okpot} | géo non-nul: {okgeo}")
+    if len(snap)!=nkw or okpot<nkw-2:
+        print("  ⚠️ incomplet — PAS de PUT."); sys.exit(1)
+
+    DESC=("V3 (gsheet Thibaut juin). 16 kw US + 18 kw FR × mois × Gamme/Catégorie (US=gsheet, FR=proposé à valider) / "
+          "position (SERP zone, repli GSC ; 100=non classé) / URL positionnée (SERP) / Volume (kp) / "
+          "Potentiel de trafic (volume×CTR position, scénario Default) / Clics GSC TOTAUX + split géo FR/UK/US/Autres (section de site) / "
+          "Δ M-1, Δ M-3 (positions), Δ clics M-1.")
+    r=mb.put(f"/api/card/{MODEL_ID}","raw",json={
+        "name":"SEO Keyword Monitoring — Manucurist (model)",
+        "dataset_query":{"database":DB,"type":"native","native":{"query":MODEL_SQL}},
+        "description":DESC},timeout=HTTP_TIMEOUT)
+    print("PUT modèle:",getattr(r,"status_code","?"))
+    rm,_=run(mb, f"SELECT * FROM ({MODEL_SQL}) LIMIT 40")
+    if rm: print("PUT metadata:",getattr(mb.put(f"/api/card/{MODEL_ID}","raw",json={"result_metadata":rm["cols"]},timeout=120),"status_code","?"))
+    print(f"\n>>> MODÈLE V3 #{MODEL_ID} mis à jour ({nkw} kw)")
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_pages_model.py
+++ b/scripts/build_seo_pages_model.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Modèle pages V2 — clics par gabarit × marché × Marque/Hors Marque | Manucurist.
+
+Source unique : gsc__page_keyword_daily_metrics (27M lignes, hist. 2024-02→).
+- marché   : section du site via URL (www=FR, us.=US, uk.=UK, locales www/xx=AUTRES)
+- gabarit  : /blogs/=Blog, /collections/=Collections, /products/=Produits, sinon Autres pages
+- marque   : requête contenant un radical de gsc__brand_keywords → 'Marque', sinon 'Hors Marque'
+- mois × clics/impressions + Δ 6 mois % et tendance (LAG par marché×gabarit×marque)
+
+⚠️ granularité requête GSC = échantillonnée (requêtes anonymisées exclues) →
+les totaux sont < clics réels de la page ; cohérent en tendance.
+Crée ou met à jour le modèle. Valide avant PUT.
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; HTTP_TIMEOUT=480
+NAME="SEO Pages Monitoring — Manucurist (model)"
+
+MODEL_SQL="""
+WITH brand_pat AS (
+  SELECT DISTINCT LOWER(keyword) AS pat
+  FROM google_search_console.gsc__brand_keywords
+  WHERE client_name='Manucurist'
+),
+base AS (
+  SELECT
+    DATE_TRUNC('month', date) AS month_date,
+    CASE WHEN page ILIKE 'https://us.manucurist.com%' THEN 'US'
+         WHEN page ILIKE 'https://uk.manucurist.com%' THEN 'UK'
+         WHEN REGEXP_LIKE(page, 'https://www[.]manucurist[.]com/(en|es|it|de|nl|el|pt)(/.*)?') THEN 'AUTRES'
+         WHEN page ILIKE 'https://www.manucurist.com%' THEN 'FR'
+         ELSE 'AUTRES' END AS marche,
+    CASE WHEN page ILIKE '%/blogs/%' THEN 'Blog'
+         WHEN page ILIKE '%/collections/%' THEN 'Collections'
+         WHEN page ILIKE '%/products/%' THEN 'Produits'
+         ELSE 'Autres pages' END AS gabarit,
+    LOWER(keyword) AS keyword,
+    clicks, impressions
+  FROM google_search_console.gsc__page_keyword_daily_metrics
+  WHERE client_name='Manucurist'
+    AND date >= DATEADD('month', -14, CURRENT_DATE)
+),
+kw_flag AS (
+  SELECT k.keyword,
+         CASE WHEN COUNT(b.pat) > 0 THEN 'Marque' ELSE 'Hors Marque' END AS marque
+  FROM (SELECT DISTINCT keyword FROM base) k
+  LEFT JOIN brand_pat b ON k.keyword LIKE '%' || b.pat || '%'
+  GROUP BY k.keyword
+),
+agg AS (
+  SELECT b.month_date, b.marche, b.gabarit, f.marque,
+         SUM(b.clicks) AS clicks, SUM(b.impressions) AS impressions
+  FROM base b JOIN kw_flag f ON f.keyword=b.keyword
+  GROUP BY 1,2,3,4
+)
+SELECT a.*,
+  ROUND(100.0 * (clicks - LAG(clicks,6) OVER (PARTITION BY marche, gabarit, marque ORDER BY month_date))
+        / NULLIF(LAG(clicks,6) OVER (PARTITION BY marche, gabarit, marque ORDER BY month_date), 0), 1) AS delta_6m_pct,
+  CASE
+    WHEN LAG(clicks,6) OVER (PARTITION BY marche, gabarit, marque ORDER BY month_date) IS NULL THEN NULL
+    WHEN clicks >= 1.05 * LAG(clicks,6) OVER (PARTITION BY marche, gabarit, marque ORDER BY month_date) THEN '↗ on gagne'
+    WHEN clicks <= 0.95 * LAG(clicks,6) OVER (PARTITION BY marche, gabarit, marque ORDER BY month_date) THEN '↘ on recule'
+    ELSE '→ stable'
+  END AS tendance
+FROM agg a
+ORDER BY marche, gabarit, marque, month_date DESC
+"""
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql):
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=HTTP_TIMEOUT)
+    j=r.json()
+    if j.get("error"): return None,str(j["error"])
+    d=j["data"]; return {"cols":d["cols"],"rows":d["rows"]},None
+
+def main():
+    mb=connect(); print("connected")
+    res,err=run(mb, MODEL_SQL)
+    if err: print("ÉCHEC SQL:",err[:600]); sys.exit(1)
+    cols=[c["name"] for c in res["cols"]]; rows=res["rows"]
+    ci={n:i for i,n in enumerate(cols)}
+    print(f"modèle pages: {len(rows)} lignes, cols={cols}")
+    months=sorted({r[ci["MONTH_DATE"]] for r in rows})
+    prev=months[-2] if len(months)>=2 else months[-1]
+    snap=[r for r in rows if r[ci["MONTH_DATE"]]==prev and r[ci["MARCHE"]] in ('FR','US','UK')
+          and r[ci["GABARIT"]]!='Autres pages']
+    print(f"\nSNAPSHOT {str(prev)[:7]} (FR/US/UK, hors 'Autres pages') :")
+    print("  MARCHÉ GABARIT      MARQUE       CLICS    Δ6M%   TENDANCE")
+    for r in sorted(snap, key=lambda r:(r[ci["MARCHE"]], r[ci["GABARIT"]], r[ci["MARQUE"]])):
+        print(f"  {r[ci['MARCHE']]:6} {r[ci['GABARIT']]:12} {r[ci['MARQUE']]:12} "
+              f"{('%.0f'%r[ci['CLICKS']] if r[ci['CLICKS']] is not None else '.'):>7} "
+              f"{(str(r[ci['DELTA_6M_PCT']]) if r[ci['DELTA_6M_PCT']] is not None else '.'):>7}  {r[ci['TENDANCE']] or '.'}")
+    if not snap: print("  ⚠️ vide — PAS de création."); sys.exit(1)
+
+    pl={"name":NAME,"type":"model","collection_id":13752,
+        "dataset_query":{"database":DB,"type":"native","native":{"query":MODEL_SQL}},
+        "display":"table","visualization_settings":{},
+        "description":("V2. Clics GSC par gabarit (Blog/Collections/Produits via URL) × marché du site "
+        "(www=FR, us.=US, uk.=UK) × Marque/Hors Marque (radicaux gsc__brand_keywords) × mois, + Δ 6 mois % et tendance. "
+        "Source: gsc__page_keyword_daily (granularité requête → totaux échantillonnés GSC).")}
+    existing=None
+    for it in mb.get("/api/collection/13752/items?limit=2000").get("data",[]):
+        if it.get("model")=="dataset" and it.get("name")==NAME: existing=it.get("id"); break
+    if existing:
+        mb.put(f"/api/card/{existing}","raw",json=pl,timeout=HTTP_TIMEOUT); MID=existing; print("modèle pages maj #",MID)
+    else:
+        b=mb.post("/api/card","raw",json=pl,timeout=HTTP_TIMEOUT).json()
+        if not b.get("id"): print("ÉCHEC create:",str(b)[:400]); sys.exit(1)
+        MID=b["id"]; print("modèle pages créé #",MID)
+    rm,_=run(mb, f"SELECT * FROM ({MODEL_SQL}) LIMIT 40")
+    if rm: mb.put(f"/api/card/{MID}","raw",json={"result_metadata":rm["cols"]},timeout=120)
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> MODÈLE PAGES #{MID}: {dom}/model/{MID}")
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_polish.py
+++ b/scripts/build_seo_polish.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Finitions V1 dashboard SEO Manucurist :
+- déplace dashboard #25137 + cartes (#48633/#48634/#48635) dans la collection Manucurist
+- filtres en dropdown (listes statiques Gamme/Catégorie)
+- positions à 0 décimale (snapshot + grille)
+- tri du snapshot (Gamme, Position)
+- titres de tuiles propres + layout pleine largeur (vire le blanc)
+"""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; MODEL_ID=48633; GRID_ID=48634; SNAP_ID=48635; DASH_ID=25137; HTTP_TIMEOUT=300
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+def main():
+    mb=connect(); print("connected")
+    # 0) collection Manucurist
+    colls=mb.get("/api/collection")
+    cands=[c for c in colls if (c.get("name") or"").strip().lower()=="manucurist" and not c.get("archived")]
+    if not cands:
+        cands=[c for c in colls if "manucurist" in (c.get("name") or"").lower() and not c.get("archived")]
+    print("collections Manucurist:", [(c["id"],c["name"]) for c in cands][:8])
+    COLL = cands[0]["id"] if cands else None
+    print("collection cible:", COLL)
+
+    # 1) snapshot : viz décimales/titres + tri + collection
+    snap_q={"database":DB,"type":"query","query":{
+        "source-table":f"card__{MODEL_ID}",
+        "fields":[fr("GAMME","type/Text"),fr("CATEGORIE","type/Text"),fr("KEYWORD","type/Text"),
+                  fr("POSITION","type/Float"),fr("SEARCH_VOLUME","type/Float"),fr("CLICKS","type/Float")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),"current","month"],
+        "order-by":[["asc",fr("GAMME","type/Text")],["asc",fr("POSITION","type/Float")]]}}
+    snap_viz={"column_settings":{
+        json.dumps(["name","KEYWORD"]):{"column_title":"Mot-clé"},
+        json.dumps(["name","GAMME"]):{"column_title":"Gamme"},
+        json.dumps(["name","CATEGORIE"]):{"column_title":"Catégorie"},
+        json.dumps(["name","POSITION"]):{"column_title":"Position","number_style":"decimal","decimals":0},
+        json.dumps(["name","SEARCH_VOLUME"]):{"column_title":"Volume rech.","number_style":"decimal","decimals":0},
+        json.dumps(["name","CLICKS"]):{"column_title":"Clics GSC","number_style":"decimal","decimals":0}},
+        "table.column_formatting":[{"columns":["POSITION"],"type":"range","colors":["#84BB4C","#ED6E6E"],"min_type":"custom","min_value":1,"max_type":"custom","max_value":50}]}
+    payload={"dataset_query":snap_q,"visualization_settings":snap_viz}
+    if COLL: payload["collection_id"]=COLL
+    print("snapshot:", getattr(mb.put(f"/api/card/{SNAP_ID}","raw",json=payload,timeout=HTTP_TIMEOUT),"status_code","?"))
+
+    # 2) grille : décimales 0 sur la valeur 'avg' (ne PAS toucher dataset_query MLv2)
+    d=mb.get(f"/api/card/{GRID_ID}")
+    gviz=dict(d.get("visualization_settings") or {})
+    cs=dict(gviz.get("column_settings") or {})
+    cs[json.dumps(["name","avg"])]={"number_style":"decimal","decimals":0}
+    gviz["column_settings"]=cs
+    payload={"visualization_settings":gviz}
+    if COLL: payload["collection_id"]=COLL
+    print("grille:", getattr(mb.put(f"/api/card/{GRID_ID}","raw",json=payload,timeout=HTTP_TIMEOUT),"status_code","?"))
+
+    # 3) modèle -> collection
+    if COLL: print("modèle:", getattr(mb.put(f"/api/card/{MODEL_ID}","raw",json={"collection_id":COLL},timeout=120),"status_code","?"))
+
+    # 4) dashboard : collection + dropdowns + layout pleine largeur + titres propres
+    P_GAMME={"id":"gamme01","name":"Gamme","slug":"gamme","type":"string/=","sectionId":"string",
+        "values_query_type":"list","values_source_type":"static-list",
+        "values_source_config":{"values":["Gel Polish","Nail Polish","Nailcare"]}}
+    P_CAT={"id":"categ01","name":"Catégorie","slug":"categorie","type":"string/=","sectionId":"string",
+        "values_query_type":"list","values_source_type":"static-list",
+        "values_source_config":{"values":["Transactionnel","Générique","Clean / Engagement","Produit","Informationnel"]}}
+    def maps(card_id):
+        return [{"parameter_id":"gamme01","card_id":card_id,"target":["dimension",fr("GAMME","type/Text")]},
+                {"parameter_id":"categ01","card_id":card_id,"target":["dimension",fr("CATEGORIE","type/Text")]}]
+    dashcards=[
+      {"id":-1,"card_id":SNAP_ID,"row":0,"col":0,"size_x":24,"size_y":8,"series":[],
+       "parameter_mappings":maps(SNAP_ID),"visualization_settings":{"card.title":"Snapshot du mois — position · volume · clics"}},
+      {"id":-2,"card_id":GRID_ID,"row":8,"col":0,"size_x":24,"size_y":11,"series":[],
+       "parameter_mappings":maps(GRID_ID),"visualization_settings":{"card.title":"Positions mois par mois"}},
+    ]
+    body={"parameters":[P_GAMME,P_CAT],"dashcards":dashcards}
+    if COLL: body["collection_id"]=COLL
+    r=mb.put(f"/api/dashboard/{DASH_ID}","raw",json=body,timeout=HTTP_TIMEOUT)
+    bb=r.json() if hasattr(r,"json") else r
+    print("dashboard:", getattr(r,"status_code","?"), "| dashcards:", len(bb.get("dashcards",[])) if isinstance(bb,dict) else "?",
+          "| params dropdown:", [p.get("values_query_type") for p in (bb.get("parameters") or [])] if isinstance(bb,dict) else "?")
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> {dom}/dashboard/{DASH_ID}")
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_saisonnalite.py
+++ b/scripts/build_seo_saisonnalite.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Saisonnalité — volume de recherche historique par mot-clé | Manucurist.
+Modèle kp (34 kw, 24 mois, par marché/gamme) + carte pivot [marché,kw] × mois × volume.
+"""
+from __future__ import annotations
+import json, sys, time, uuid
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+import build_seo_monitoring_v3 as V3
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; COLL=13752; HTTP_TIMEOUT=480
+MODEL_NAME="SEO Saisonnalité — Manucurist (model)"
+PIVOT_NAME="SEO — Saisonnalité (volume de recherche / mois) | Manucurist"
+u=lambda: str(uuid.uuid4())
+
+MODEL_SQL=f"""
+WITH kw_map AS (
+  SELECT * FROM (VALUES
+    {V3.VALUES}
+  ) AS t(keyword, marche, gamme, categorie)
+),
+zone_map AS (
+  SELECT keyword, marche, gamme,
+         CASE marche WHEN 'FR' THEN 'France' WHEN 'US' THEN 'United States' END AS zone
+  FROM kw_map
+),
+base AS (
+  SELECT z.marche, z.gamme, z.keyword, TO_DATE(km.month||'-01','YYYY-MM-DD') AS month_date,
+         COALESCE(km.adjusted_avg_searches, km.avg_monthly_searches, 0) AS search_volume
+  FROM zone_map z
+    JOIN google_keyword_planner.kp__keyword_monthly_metrics km
+      ON LOWER(km.keyword)=z.keyword AND km.zone=z.zone
+  WHERE km.month >= TO_CHAR(DATEADD('month', -24, CURRENT_DATE),'YYYY-MM')
+)
+SELECT marche, gamme, keyword, month_date, search_volume
+FROM base
+QUALIFY ROW_NUMBER() OVER (PARTITION BY marche, keyword, month_date ORDER BY search_volume DESC) = 1
+ORDER BY marche, keyword, month_date DESC
+"""
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql):
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=HTTP_TIMEOUT)
+    j=r.json()
+    if j.get("error"): return None,str(j["error"])
+    d=j["data"]; return {"cols":d["cols"],"rows":d["rows"]},None
+
+def upsert(mb,name,model,payload):
+    kind="dataset" if model else "card"
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")==kind and it.get("name")==name:
+            mb.put(f"/api/card/{it['id']}","raw",json=payload,timeout=HTTP_TIMEOUT); return it["id"],"maj"
+    b=mb.post("/api/card","raw",json=payload,timeout=HTTP_TIMEOUT).json(); return b.get("id"),"créé"
+
+def main():
+    mb=connect(); print("connected")
+    res,err=run(mb, MODEL_SQL)
+    if err: print("ÉCHEC SQL:",err[:600]); sys.exit(1)
+    cols=[c["name"] for c in res["cols"]]; rows=res["rows"]
+    nkw=len({r[cols.index("KEYWORD")] for r in rows}); nmo=len({r[cols.index("MONTH_DATE")] for r in rows})
+    print(f"modèle saisonnalité: {len(rows)} lignes, {nkw} kw, {nmo} mois")
+    if nkw<25: print("⚠️ trop peu de kw — stop"); sys.exit(1)
+
+    MID,how=upsert(mb,MODEL_NAME,True,{"name":MODEL_NAME,"type":"model","collection_id":COLL,
+        "dataset_query":{"database":DB,"type":"native","native":{"query":MODEL_SQL}},
+        "display":"table","visualization_settings":{},
+        "description":"Saisonnalité : volume de recherche mensuel (kp) par mot-clé, 24 mois, par marché/gamme. Voir aussi le template #13489 (48 mois)."})
+    print(f"modèle {how} #{MID}")
+    rm,_=run(mb, f"SELECT * FROM ({MODEL_SQL}) LIMIT 30")
+    if rm: mb.put(f"/api/card/{MID}","raw",json={"result_metadata":rm["cols"]},timeout=120)
+
+    def fl(name,bt,extra=None):
+        o={"base-type":bt,"lib/uuid":u()}
+        if extra:o.update(extra)
+        return ["field",o,name]
+    def fr(name,bt,extra=None):
+        o={"base-type":bt}
+        if extra:o.update(extra)
+        return ["field",name,o]
+    dq={"database":DB,"lib/type":"mbql/query","stages":[{
+        "lib/type":"mbql.stage/mbql","source-card":MID,
+        "aggregation":[["sum",{"lib/uuid":u()}, fl("SEARCH_VOLUME","type/Number")]],
+        "breakout":[ fl("MARCHE","type/Text"), fl("KEYWORD","type/Text"),
+                     fl("MONTH_DATE","type/Date",{"temporal-unit":"month"}) ]}]}
+    viz={"pivot_table.column_split":{
+            "rows":[fr("MARCHE","type/Text"),fr("KEYWORD","type/Text")],
+            "columns":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})],
+            "values":[["aggregation",0]]},
+        "pivot.show_row_totals":False,"pivot.show_column_totals":False,
+        "column_settings":{json.dumps(["name","sum"]):{"number_style":"decimal","decimals":0}},
+        "table.column_formatting":[{"columns":["sum"],"type":"range","colors":["#FFFFFF","#88BF4D"]}]}
+    PID,how=upsert(mb,PIVOT_NAME,False,{"name":PIVOT_NAME,"collection_id":COLL,
+        "dataset_query":dq,"display":"pivot","visualization_settings":viz,
+        "description":"Saisonnalité : volume de recherche par mot-clé × mois (24 mois). Source modèle saisonnalité. Filtrable par marché/gamme/mot-clé."})
+    print(f"pivot {how} #{PID}")
+    legacy={"database":DB,"type":"query","query":{"source-table":f"card__{MID}",
+        "aggregation":[["sum",fr("SEARCH_VOLUME","type/Number")]],
+        "breakout":[fr("MARCHE","type/Text"),fr("KEYWORD","type/Text"),fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})]}}
+    jr=mb.post("/api/dataset","raw",json=legacy,timeout=HTTP_TIMEOUT).json()
+    if not jr.get("error"): mb.put(f"/api/card/{PID}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+    print(f"\n>>> SAISONNALITÉ model #{MID} | pivot #{PID}")
+
+if __name__=="__main__":
+    main()

--- a/scripts/conv_lib.py
+++ b/scripts/conv_lib.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Logique pure de la migration de conversions (ancien positionnel -> nouveau nommé).
+Aucune I/O réseau. Voir docs/superpowers/specs/2026-06-03-conversion-migration-design.md."""
+from __future__ import annotations
+import json, re
+from collections import defaultdict
+
+# --- Column inventory (authoritative, Snowflake information_schema 2026-06-03) ---
+OLD_COUNT = ["CONVERSIONS"] + [f"CONVERSIONS_{n}" for n in range(1, 20)]
+OLD_VALUE = ["CONVERSION_VALUE"] + [f"CONVERSION_{n}_VALUE" for n in range(1, 20)]
+OLD_COLS = set(OLD_COUNT) | set(OLD_VALUE)
+
+CUSTOM_COUNT = {n: f"CUSTOM_CONVERSIONS_{n}" for n in range(1, 16)}
+CUSTOM_VALUE = {n: f"CUSTOM_CONVERSIONS_{n}_VALUE" for n in range(1, 16)}
+NAMED_COL = {
+    "Purchases": ("PURCHASES", "PURCHASES_VALUE"),
+    "Add to cart": ("ADD_TO_CARTS_NEW", "ADD_TO_CARTS_VALUE_NEW"),
+    "Initiate checkouts": ("INITIATE_CHECKOUTS", "INITIATE_CHECKOUTS_VALUE"),
+    "Content views OR View Item": ("CONTENT_VIEWS", None),
+    "Sign ups": ("SIGN_UPS", None),
+    "Leads": ("LEADS", "LEADS_VALUE"),
+    "Marketing Qualified Leads": ("MARKETING_QUALIFIED_LEADS", "MARKETING_QUALIFIED_LEADS_VALUE"),
+    "Sales Qualified Leads": ("SALES_QUALIFIED_LEADS", "SALES_QUALIFIED_LEADS_VALUE"),
+    "Offline sales": ("OFFLINE_SALES", "OFFLINE_SALES_VALUE"),
+    "App installs": ("APP_INSTALLS_NEW", "APP_INSTALL_VALUE"),
+    "Search visits (combo organic + sea custom conv meta)": ("SEARCH_VISITS_COMBO", None),
+    "Organic search visits (custom conv meta)": ("ORGANIC_SEARCH_VISITS", None),
+    "Paid search visits (custom conv meta)": ("PAID_SEARCH_VISITS", None),
+}
+NEW_COLS = set()
+for n in range(1, 16):
+    NEW_COLS |= {CUSTOM_COUNT[n], CUSTOM_VALUE[n]}
+for _c, _v in NAMED_COL.values():
+    NEW_COLS.add(_c)
+    if _v:
+        NEW_COLS.add(_v)
+
+def _rx(cols):
+    return re.compile(r"(?<![A-Z0-9_])(" + "|".join(sorted(cols, key=len, reverse=True)) + r")(?![A-Z0-9_])")
+_OLD_RX, _NEW_RX = _rx(OLD_COLS), _rx(NEW_COLS)
+
+_SQL_LITERAL_RX = re.compile(r"'(?:[^']|'')*'")
+
+def _mask_literals(text):
+    """Neutralise les littéraux SQL '...' (détection/substitution ne doivent jamais y toucher:
+    WHERE event = 'conversions_1' est une VALEUR, pas une colonne)."""
+    parts = []
+    def _repl(m):
+        parts.append(m.group(0))
+        return f"\x00L{len(parts) - 1}\x00"
+    return _SQL_LITERAL_RX.sub(_repl, text), parts
+
+def _unmask_literals(text, parts):
+    for i, p in enumerate(parts):
+        text = text.replace(f"\x00L{i}\x00", p)
+    return text
+
+def native_and_tags(card):
+    """(sql, template-tags dict) — tolère natif legacy, stages pMBQL, et legacy_query."""
+    dq = card.get("dataset_query") or {}
+    if dq.get("type") == "native":
+        n = dq.get("native") or {}
+        return n.get("query") or "", (n.get("template-tags") or {})
+    for st in dq.get("stages") or []:
+        if st.get("lib/type") == "mbql.stage/native":
+            return st.get("native") or "", (st.get("template-tags") or {})
+    lq = card.get("legacy_query")
+    if isinstance(lq, str):
+        try:
+            lq = json.loads(lq)
+        except Exception:
+            lq = {}
+        if isinstance(lq, dict) and lq.get("type") == "native":
+            n = lq.get("native") or {}
+            return n.get("query") or "", (n.get("template-tags") or {})
+    return "", {}
+
+def old_conversion_columns(sql):
+    masked, _ = _mask_literals(sql or "")
+    return set(_OLD_RX.findall(masked.upper()))
+
+def new_conversion_columns(sql):
+    masked, _ = _mask_literals(sql or "")
+    return set(_NEW_RX.findall(masked.upper()))
+
+# Tables that actually hold conversion metrics (the "platform/source"); a swap is only
+# valid between cards reading the SAME source table (e.g. a GA4 card must not become a
+# campaign_daily_metrics card even if the conversion mapping matches).
+METRIC_TABLES = {
+    # schema `global` = ads platforms (Google/Meta/TikTok Ads…), several granularities
+    "global.campaign_daily_metrics", "global.campaign_daily_metrics_per_device",
+    "global.campaign_daily_geographical_metrics", "global.campaign_breakdown_daily_metrics",
+    "global.campaign_daily_url_metrics", "global.search_adgroup_daily_metrics",
+    "global.social_ad_daily_metrics", "global.social_adset_daily_metrics",
+    # schema `analytics` = GA4 / analytics
+    "analytics.google__analytics_metrics", "analytics.google__analytics_per_device",
+    "analytics.google__analytics_per_landing_page", "analytics.google__analytics_per_location",
+    "analytics.google__analytics_url_groups", "analytics.google__analytics_accounts",
+    # misc
+    "google.google__keyword_metrics",
+}
+# Source family (ads / analytics / crm) — a swap must stay within the same exact table,
+# but the family is useful for reporting/coverage.
+def source_family(table):
+    if not table:
+        return None
+    schema = table.split(".", 1)[0]
+    return {"global": "ads", "analytics": "analytics", "google": "ads"}.get(schema, schema)
+_FROMJOIN_RX = re.compile(r"(?:\bfrom|\bjoin)\s+([a-z0-9_]+\.[a-z0-9_]+)(?:\s+(?:as\s+)?([a-z0-9_]+))?")
+_SQL_KW = {"on", "where", "left", "right", "inner", "outer", "full", "cross", "join",
+           "group", "order", "as", "using", "and", "or", "select", "with"}
+
+def conversion_source(sql):
+    """The metric source table the card's conversion column comes from, or None.
+    Deterministic: resolves table aliases (FROM t AS a -> a.col), prefers the table the
+    conversion column is qualified to; campaign_daily_metrics wins remaining ties, then
+    alphabetical order (never set-iteration order)."""
+    low = (sql or "").lower()
+    qual, present = {}, []
+    for t, a in _FROMJOIN_RX.findall(low):
+        if t in METRIC_TABLES:
+            if t not in present:
+                present.append(t)
+            qual[t] = t
+            qual[t.split(".", 1)[1]] = t
+            if a and a not in _SQL_KW:
+                qual[a] = t
+    if not present:
+        return None
+    if len(present) == 1:
+        return present[0]
+    for m in re.finditer(r"([a-z0-9_\.]+)\.([a-z0-9_]+)", low):
+        if m.group(2).upper() in OLD_COLS or m.group(2).upper() in NEW_COLS:
+            t = qual.get(m.group(1)) or qual.get(m.group(1).split(".")[-1])
+            if t:
+                return t
+    if "global.campaign_daily_metrics" in present:
+        return "global.campaign_daily_metrics"
+    return sorted(present)[0]
+
+def has_opaque_refs(sql):
+    """True si le SQL référence un snippet ({{snippet: ...}}) ou une carte source ({{#123}}) :
+    leur contenu est invisible ici et peut cacher des colonnes de conversion."""
+    low = (sql or "").lower()
+    return bool(re.search(r"\{\{\s*snippet\s*:", low) or re.search(r"\{\{\s*#\d+", low))
+
+def tag_field_map(card):
+    """{template-tag name -> field ref} des field-filters de la carte. Réfs par id
+    (recherche en profondeur, dernier entier) ou par NOM ('name:<champ>')."""
+    _, tags = native_and_tags(card)
+    out = {}
+    for name, d in (tags or {}).items():
+        dim = (d or {}).get("dimension")
+        if not isinstance(dim, list):
+            continue
+        ints, strs = [], []
+        stack = [dim]
+        while stack:
+            x = stack.pop(0)
+            if isinstance(x, list):
+                stack = list(x) + stack
+            elif isinstance(x, int):
+                ints.append(x)
+            elif isinstance(x, str) and x not in ("field", "field-id", "dimension", "template-tag"):
+                strs.append(x)
+        if ints:
+            out[name] = ints[-1]
+        elif strs:
+            out[name] = f"name:{strs[0]}"
+    return out
+
+def tag_rename_map(old_card, new_card):
+    """{old_tag -> new_tag} for filters renamed between cards but pointing to the SAME
+    Snowflake field (e.g. 'location' -> 'campaign_location'). Lets a swap re-wire a filter
+    whose template-tag name changed, instead of breaking it."""
+    o, n = tag_field_map(old_card), tag_field_map(new_card)
+    by_field = {}
+    for name, fid in n.items():
+        by_field.setdefault(fid, name)
+    return {name: by_field[fid] for name, fid in o.items() if name not in n and fid in by_field}
+
+def incompatible_wired_tags(old_card, new_card, wired_tags, renames=None):
+    """Tags câblés au dashboard dont le TYPE change entre l'ancienne et la nouvelle carte
+    (ex. time_period: 'dimension' -> 'temporal-unit'): le paramètre du dashboard ne peut
+    plus les piloter, le filtre meurt silencieusement -> swap à refuser.
+    Retourne {tag: (type_ancien, type_nouveau)}."""
+    renames = renames or {}
+    _, ot = native_and_tags(old_card)
+    _, nt = native_and_tags(new_card)
+    bad = {}
+    for t in wired_tags:
+        o, n = ot.get(t), nt.get(renames.get(t, t))
+        if o and n and o.get("type") != n.get("type"):
+            bad[t] = (o.get("type"), n.get("type"))
+    return bad
+
+# --- Type-axis (Airtable slot -> new named) ---
+TYPE_TO_SLOT = {"Main conversion": 0}
+_ORD = ["1st", "2nd", "3rd"] + [f"{n}th" for n in range(4, 20)]
+for _i, _o in enumerate(_ORD, start=1):
+    TYPE_TO_SLOT[f"{_o} conversion"] = _i
+
+UNMAPPED = "__UNMAPPED__"
+CONFLICT = "__CONFLICT__"
+
+def slot_old_columns(slot):
+    if slot == 0:
+        return ("CONVERSIONS", "CONVERSION_VALUE")
+    return (f"CONVERSIONS_{slot}", f"CONVERSION_{slot}_VALUE")
+
+def new_type_columns(new_type):
+    m = re.match(r"Custom (\d+)$", new_type or "")
+    if m:
+        n = int(m.group(1))
+        return (CUSTOM_COUNT.get(n), CUSTOM_VALUE.get(n))
+    return NAMED_COL.get(new_type, (None, None))
+
+def _slot_of(col):
+    if col in ("CONVERSIONS", "CONVERSION_VALUE"):
+        return 0
+    m = re.search(r"(\d+)", col)
+    return int(m.group(1)) if m else None
+
+def substitution_map(old_cols, client_mapping):
+    """For each OLD conversion column the card uses, the NEW column to substitute it with,
+    via the client's slot->new_type. Returns (sub_map, unmapped_cols). A column whose slot
+    has no usable mapping (absent / UNMAPPED / CONFLICT) is left in `unmapped`."""
+    sub, unmapped = {}, []
+    for col in old_cols:
+        slot = _slot_of(col)
+        nt = client_mapping.get(slot) if slot is not None else None
+        if nt is None or nt in (UNMAPPED, CONFLICT):
+            unmapped.append(col)
+            continue
+        cnt, val = new_type_columns(nt)
+        new = val if (col.endswith("_VALUE") or col == "CONVERSION_VALUE") else cnt
+        if new:
+            sub[col] = new
+        else:
+            unmapped.append(col)
+    return sub, unmapped
+
+def apply_substitution(text, sub_map):
+    """Replace each OLD column by its NEW column in SQL/JSON text, whole-word and
+    case-preserving. Longest keys first; guarded so CONVERSIONS doesn't match inside
+    CONVERSIONS_1, nor CONVERSIONS_1 inside CONVERSIONS_10, nor re-hit CUSTOM_CONVERSIONS_1.
+    SQL string literals '...' are never rewritten (same masking as detection)."""
+    if not text:
+        return text
+    masked, parts = _mask_literals(text)
+    for old in sorted(sub_map, key=len, reverse=True):
+        new = sub_map[old]
+        masked = re.sub(rf"(?<![A-Za-z0-9_])(?i:{re.escape(old)})(?![A-Za-z0-9_])",
+                        lambda m, n=new: n.lower() if m.group(0).islower() else n.upper(), masked)
+    return _unmask_literals(masked, parts)
+
+def build_client_mappings(records):
+    """records: [{client, type, new_type}] -> {client: {slot: new_type | UNMAPPED | CONFLICT}}."""
+    seen = defaultdict(lambda: defaultdict(set))
+    for r in records:
+        client, typ = r.get("client"), r.get("type")
+        if not client or typ not in TYPE_TO_SLOT:
+            continue
+        slot = TYPE_TO_SLOT[typ]
+        nt = r.get("new_type")
+        seen[client][slot]
+        if nt:
+            seen[client][slot].add(nt)
+    out = {}
+    for client, slots in seen.items():
+        out[client] = {}
+        for slot, nts in slots.items():
+            out[client][slot] = (next(iter(nts)) if len(nts) == 1
+                                 else CONFLICT if len(nts) > 1 else UNMAPPED)
+    return out
+
+# --- Shape axis (display x metric x breakdown) ---
+_BREAKDOWN = [("date", "date"), ("channel", "channel"), ("network", "network"),
+              ("categor", "category"), ("countr", "country"), ("location", "location"),
+              ("device", "device"), ("product", "product"), ("url", "url"), ("type", "type"),
+              ("adset", "adset"), ("adgroup", "adgroup"), ("placement", "placement"),
+              ("segment", "segment"), ("medium", "medium"), ("page", "page"),
+              ("week", "week"), ("month", "month"), ("keyword", "keyword"), ("audience", "audience")]
+
+def _breakdown_tokens(text, found):
+    """Ajoute les labels de breakdown trouvés dans `text` (déjà en minuscules).
+    'conversion type' est distingué de 'campaign type' (sinon collision sur 'type')."""
+    if "conversion type" in text or "conversion_type" in text:
+        found.add("conversion_type")
+        text = text.replace("conversion type", " ").replace("conversion_type", " ")
+    for needle, label in _BREAKDOWN:
+        if needle in text:
+            found.add(label)
+    # 'by campaign' seul (sans channel/type/...): needle trop générique pour la boucle
+    if not found and "campaign" in text:
+        found.add("campaign")
+    return found
+
+def metric_kind(name):
+    n = (name or "").upper()
+    if "COÛT PAR" in n or "COUT PAR" in n:  # FR: «Coût par conversion/acquisition» = CAC
+        return "CAC"
+    for k in ("ROAS", "CAC", "COS", "CPA", "CPI", "CTR"):
+        if re.search(rf"\b{k}\b", n):
+            return k
+    if re.search(r"\bCR\b", n) or "RATE" in n or "TAUX" in n:  # FR: «Taux de …»
+        return "RATE"
+    # AVG before VALUE: "Avg X value" / «Valeur moyenne» / «Panier moyen» is an average
+    if "AVG" in n or "AVERAGE" in n or "MOYEN" in n:
+        return "AVG"
+    if "VALUE" in n or "VALEUR" in n or "REVENU" in n:
+        return "VALUE"
+    return "COUNT"
+
+def _breakdown(name, viz):
+    found = set()
+    src = (name or "").lower()
+    m = re.search(r"\bby\b(.+)$", src)
+    if m:
+        _breakdown_tokens(m.group(1), found)
+    for d in (viz or {}).get("graph.dimensions") or []:
+        if isinstance(d, str):
+            _breakdown_tokens(d.lower(), found)
+    return tuple(sorted(found))
+
+_SCALAR_DISPLAYS = {"scalar", "smartscalar", "gauge", "progress"}
+
+def card_breakdown(card):
+    display = card.get("display") or "?"
+    # single-value displays have no breakdown -> ignore leftover graph.dimensions.
+    viz = None if display in _SCALAR_DISPLAYS else card.get("visualization_settings")
+    return _breakdown(card.get("name"), viz)
+
+def card_shape(card):  # kept for back-compat
+    return (card.get("display") or "?", metric_kind(card.get("name")), card_breakdown(card))
+
+def series_kind(name):
+    """Reduce one displayed-series name to its metric KIND, stripping the conversion identity
+    (e.g. 'CAC_CUSTOM_CONVERSIONS_1' -> CAC, 'CUSTOM_CONVERSIONS_1' -> CONV, 'COST' -> COST)."""
+    n = (name or "").upper()
+    if "COST" in n or "SPEND" in n:  # before COS: "COST" contains "COS"
+        return "COST"
+    for k in ("ROAS", "CAC", "COS", "CPA", "CPI", "CTR", "CPC", "CPM"):
+        if k in n:
+            return k
+    if re.search(r"\bCR\b", n) or n.startswith("CR") or "_CR_" in n or "RATE" in n or "TAUX" in n:
+        return "CR"
+    # AVG before VALUE (même règle que metric_kind): AVG_CONVERSION_1_VALUE est une moyenne
+    if "AVG" in n or "AVERAGE" in n or "MOYEN" in n:
+        return "AVG"
+    if "VALUE" in n or "VALEUR" in n or "REVENU" in n:  # série 'revenue' = conversion_value
+        return "VALUE"
+    return "CONV"  # bare conversion count / purchases / leads / etc.
+
+_TABLE_BASE = {"IMPRESSIONS", "CLICKS", "COST", "CTR", "CPC", "CPM"}
+
+def _table_old_kind(col):
+    """(kind, slot) d'une colonne de vieux tableau (préfixe CURRENT_ retiré).
+    kind ∈ {base, count, cr, cac, value, avgvalue, roas, None} ; slot 0=main, n positionnel."""
+    c = (col or "").upper()
+    if c.startswith("CURRENT_"):
+        c = c[len("CURRENT_"):]
+    if c in _TABLE_BASE:
+        return ("base", None)
+    if c in ("AVG_CONV_VALUE", "AVG_CONVERSION_VALUE", "AVG_REVENUE"):  # avant 'value'
+        return ("avgvalue", 0)
+    if c in ("CONVERSIONS",):
+        return ("count", 0)
+    if c == "CONVERSION_RATE":  # alias de CONV_RATE (main)
+        return ("cr", 0)
+    if c == "REVENUE":          # alias de CONVERSION_VALUE (main)
+        return ("value", 0)
+    m = re.fullmatch(r"CONVERSIONS_(\d+)", c)
+    if m:
+        return ("count", int(m.group(1)))
+    if c == "CONV_RATE":
+        return ("cr", 0)
+    m = re.fullmatch(r"CR_(\d+)", c)
+    if m:
+        return ("cr", int(m.group(1)))
+    if c == "CAC":
+        return ("cac", 0)
+    m = re.fullmatch(r"CAC_(\d+)", c)
+    if m:
+        return ("cac", int(m.group(1)))
+    if c in ("CONVERSION_VALUE", "CONV_VALUE"):
+        return ("value", 0)
+    m = re.fullmatch(r"CONV(?:ERSION)?_(\d+)_VALUE", c)
+    if m:
+        return ("value", int(m.group(1)))
+    if c == "ROAS":
+        return ("roas", 0)
+    return (None, None)
+
+def _is_table_dim(base):
+    # dimension de breakdown : préfixée CAMPAIGN_ ou nom nu (channel/network/...)
+    return (base in ("DATE", "TIME_PERIOD", "URL", "CHANNEL", "NETWORK", "CATEGORY",
+                     "TYPE", "PRODUCT", "NAME", "LOCATION", "DEVICE")
+            or base.startswith("CAMPAIGN_"))
+
+def _new_conv_col(kind, base_token, evo=False):
+    # côté neuf : valeur courante = CURRENT_<...> ; évolution = <...>_EVOLUTION (sans CURRENT_)
+    if kind == "avgvalue":
+        return f"AVG_{base_token}_VALUE_EVOLUTION" if evo else f"CURRENT_AVG_{base_token}_VALUE"
+    suf = {"count": "", "cr": "_CR", "cac": "_CAC", "value": "_VALUE", "roas": "_ROAS"}[kind]
+    return f"{base_token}{suf}_EVOLUTION" if evo else f"CURRENT_{base_token}{suf}"
+
+def map_table_columns(old_visible, client_mapping, new_cols, dimension_new):
+    """Mappe les colonnes VISIBLES d'un vieux tableau multi-slot vers les colonnes
+    de la famille mixte (toutes conversions). Retourne (mapping {old->new}, unmapped[]).
+    - dimension (DATE/CAMPAIGN_*/...) -> dimension_new
+    - base (cost/impressions/...) -> CURRENT_<base>
+    - métrique de conversion (slot 0=main, n positionnel) -> via mapping client Airtable
+      slot->new_type (Purchases/Custom k), puis colonne CURRENT_<token>[_CR/_CAC/_VALUE/_ROAS].
+    Une colonne sans mapping client, ou dont la cible n'existe pas dans new_cols, va en unmapped
+    (le moteur garde alors l'ancien tableau / signale)."""
+    new_cols = {str(c).upper() for c in new_cols}
+    mapping, unmapped = {}, []
+    for col in old_visible:
+        c = col.upper()
+        evo = c.endswith("_EVOLUTION")
+        cbase = c[:-len("_EVOLUTION")] if evo else c
+        base = cbase[len("CURRENT_"):] if cbase.startswith("CURRENT_") else cbase
+        kind, slot = _table_old_kind(cbase)
+        if kind is None:
+            target = (dimension_new if (not evo and _is_table_dim(base)) else None)
+        elif kind == "base":
+            target = f"{base}_EVOLUTION" if evo else f"CURRENT_{base}"
+        else:
+            nt = client_mapping.get(slot)
+            if nt in (None, UNMAPPED, CONFLICT):
+                target = None
+            else:
+                base_token = new_type_columns(nt)[0]
+                target = _new_conv_col(kind, base_token, evo) if base_token else None
+        if target and target.upper() in new_cols:
+            mapping[col] = target
+        else:
+            unmapped.append(col)
+    return mapping, unmapped
+
+def series_display_map(old_metrics, new_metrics):
+    """Mappe chaque série AFFICHÉE de l'ancienne carte vers UNE série de la nouvelle,
+    par nature de métrique (series_kind), en préférant les variantes non
+    BRAND_EXCLUDED sauf si l'ancienne série est elle-même hors-brand. Permet de
+    réutiliser une carte 11673 plus riche en MASQUANT ses séries en trop au niveau
+    du dashcard (graph.metrics override). None si ambigu, manquant ou non injectif."""
+    out = []
+    for om in old_metrics or []:
+        kind = series_kind(om)
+        want_brand = "BRAND_EXCLUDED" in str(om).upper()
+        cands = [nm for nm in new_metrics or [] if series_kind(nm) == kind
+                 and ("BRAND_EXCLUDED" in str(nm).upper()) == want_brand]
+        if len(cands) != 1:
+            return None
+        out.append(cands[0])
+    if len(set(out)) != len(out):
+        return None
+    return out
+
+_BRAND_ATOM = re.compile(
+    r"LOWER\(\s*coalesce\(\s*([A-Za-z0-9_\.]*?)campaign_(\w+)\s*,\s*''\s*\)\s*\)\s*NOT\s+LIKE\s*'%brand%'",
+    re.I)
+_BRAND_CAT_STRICT = re.compile(
+    r"\s+AND\s+LOWER\(TRIM\(coalesce\([A-Za-z0-9_\.]*?campaign_category,''\)\)\) != 'brand'")
+_BRAND_STRICT_ATOM = re.compile(
+    r"LOWER\(TRIM\(coalesce\([A-Za-z0-9_\.]*?campaign_category,''\)\)\)\s*!=\s*'brand'", re.I)
+
+def strip_brand_atoms(sql):
+    """Remplace tout atome d'exclusion brand par un marqueur §B§ et fusionne les
+    « §B§ AND §B§ » : deux SQL qui ne diffèrent QUE par leur clause brand deviennent
+    identiques. Gate du batch — strip(old)==strip(new) prouve qu'on n'a touché à
+    rien d'autre que la clause brand."""
+    s = _BRAND_STRICT_ATOM.sub("§B§", sql or "")
+    s = _BRAND_ATOM.sub("§B§", s)
+    return re.sub(r"§B§(\s+AND\s+§B§)+", "§B§", s)
+
+def fix_brand_clause(sql):
+    """Règle métier FINALE (validée 2026-06-12) : une campagne est « brand » si
+    campaign_TYPE contient brand OU si campaign_CATEGORY vaut exactement 'Brand'
+    (égalité stricte — un LIKE attraperait « Push Brand To Media », « Branding »…).
+    L'exclusion canonique émise est donc la paire :
+      LOWER(coalesce(<p>campaign_type,'')) NOT LIKE '%brand%'
+      AND LOWER(TRIM(coalesce(<p>campaign_category,''))) != 'brand'
+    Tout autre atome NOT LIKE '%brand%' (channel/category/location/...) est faux
+    et remplacé. Préfixe d'alias préservé. Idempotent (sa sortie se reconnaît :
+    l'atome catégorie-stricte est retiré puis ré-émis)."""
+    # 1. retire l'atome catégorie-stricte (sortie d'un passage précédent)
+    out = _BRAND_CAT_STRICT.sub("", sql or "")
+    # 2. canonise chaque atome fautif vers campaign_type (préfixe préservé)
+    out = _BRAND_ATOM.sub(
+        lambda m: f"LOWER(coalesce({m.group(1)}campaign_type,'')) NOT LIKE '%brand%'", out)
+    # 3. déduplique les atomes type identiques enchaînés par AND
+    dedup = re.compile(
+        r"(LOWER\(coalesce\([A-Za-z0-9_\.]*?campaign_type,''\)\) NOT LIKE '%brand%')"
+        r"(\s+AND\s+\1)+")
+    prev = None
+    while prev != out:
+        prev = out
+        out = dedup.sub(r"\1", out)
+    # 4. étend chaque atome type en paire canonique (catégorie stricte)
+    pair = re.compile(r"LOWER\(coalesce\(([A-Za-z0-9_\.]*?)campaign_type,''\)\) NOT LIKE '%brand%'")
+    return pair.sub(
+        lambda m: (f"LOWER(coalesce({m.group(1)}campaign_type,'')) NOT LIKE '%brand%' "
+                   f"AND LOWER(TRIM(coalesce({m.group(1)}campaign_category,''))) != 'brand'"),
+        out)
+
+def displayed_cells(cols, rows, metrics):
+    """Cellules numériques triées/arrondies (convention card_values), restreintes
+    aux colonnes `metrics` (insensible à la casse) ; toutes si metrics est None."""
+    if metrics is None:
+        keep = set(range(len(cols)))
+    else:
+        wanted = {str(m).upper() for m in metrics}
+        keep = {i for i, c in enumerate(cols) if str(c).upper() in wanted}
+    return sorted(round(float(x), 4) for row in rows for i, x in enumerate(row)
+                  if i in keep and isinstance(x, (int, float)))
+
+def kpi_signature(card):
+    """The SET of metric KINDS the card displays. For real charts use graph.metrics
+    (reliable); for single-value displays graph.metrics is leftover/unreliable, so fall
+    back to the headline metric from the name."""
+    display = (card.get("display") or "").lower()
+    metrics = (card.get("visualization_settings") or {}).get("graph.metrics")
+    if display not in _SCALAR_DISPLAYS and metrics:
+        kinds = {series_kind(m) for m in metrics if isinstance(m, str)}
+        if kinds:
+            return tuple(sorted(kinds))
+    return (metric_kind(card.get("name")),)
+
+def brand_excluded(card):
+    """True if the card is a hardcoded 'without brand' / 'brand excluded' variant.
+    The new tree names these explicitly; old cards instead use the brand_included filter."""
+    n = (card.get("name") or "").lower()
+    return ("without brand" in n) or ("brand exclud" in n) or ("brand_exclud" in n)
+
+def _old_slots_and_value(card):
+    """(sorted distinct slots, is_value) inferred from the old columns the card sums.
+    Returns ([], False) if the card references no old conversion column."""
+    sql, _ = native_and_tags(card)
+    cols = old_conversion_columns(sql)
+    if not cols:
+        return [], False
+    is_value = any(c.endswith("_VALUE") for c in cols)
+    slots = set()
+    for c in cols:
+        if c in ("CONVERSIONS", "CONVERSION_VALUE"):
+            slots.add(0)
+        else:
+            mm = re.search(r"(\d+)", c)
+            if mm:
+                slots.add(int(mm.group(1)))
+    return sorted(slots), is_value
+
+def resolve_new_card(old_card, client_mapping, new_index):
+    """Return {status: ok|unmapped|conflict|multi|review|skip, ...}. The `ok` result
+    carries old_col + new_col + source so the caller can reconcile without recomputing.
+
+    new_index maps (NEW_COL, breakdown) -> [{id, source, display, kpis, brand}]. A candidate
+    is eligible iff it has the SAME source table, the SAME displayed-KPI set, and the SAME
+    brand-exclusion flag as the old card. Chart type is allowed to differ (bar->combo); when
+    several remain, prefer the same display, else it's a genuine `multi`."""
+    sql, _ = native_and_tags(old_card)
+    slots, is_value = _old_slots_and_value(old_card)
+    if not slots:
+        return {"status": "skip", "reason": "no old conversion column"}
+    if len(slots) > 1:
+        return {"status": "review", "reason": f"multi-slot combo {slots}", "slots": slots}
+    source = conversion_source(sql)
+    slot = slots[0]
+    nt = client_mapping.get(slot)
+    if nt is None:
+        return {"status": "review", "reason": f"slot {slot} absent from client mapping", "source": source}
+    if nt in (UNMAPPED, CONFLICT):
+        return {"status": nt.strip("_").lower(), "slot": slot, "source": source}
+    count_col, value_col = new_type_columns(nt)
+    new_col = value_col if is_value else count_col
+    old_col = slot_old_columns(slot)[1 if is_value else 0]
+    base = {"new_type": nt, "old_col": old_col, "new_col": new_col, "slot": slot, "source": source}
+    if not new_col:
+        return {"status": "review", **base,
+                "reason": f"new_type {nt!r} has no {'value' if is_value else 'count'} column"}
+    bd = card_breakdown(old_card)
+    kpis, brand, disp = kpi_signature(old_card), brand_excluded(old_card), (old_card.get("display") or "")
+    all_cands = new_index.get((new_col, bd)) or []
+    same_src = [c for c in all_cands if c.get("source") == source]
+    match = [c for c in same_src if tuple(c.get("kpis") or ()) == kpis and bool(c.get("brand")) == brand]
+    if len(match) > 1:  # several true matches -> prefer same chart type
+        sd = [c for c in match if c.get("display") == disp]
+        if len(sd) == 1:
+            match = sd
+    if len(match) == 1:
+        return {"status": "ok", "new_card_id": match[0]["id"], **base}
+    if len(match) > 1:
+        return {"status": "multi", "candidates": [c["id"] for c in match], **base}
+    if same_src:
+        return {"status": "review", **base,
+                "reason": f"no KPI/brand match for {new_col} kpis={list(kpis)} brand={brand} "
+                          f"(same-source candidates: {[c['id'] for c in same_src][:6]})"}
+    if all_cands:
+        return {"status": "review", **base,
+                "reason": f"no new card on source {source!r} (other-source: {[c['id'] for c in all_cands][:5]})"}
+    return {"status": "review", **base, "reason": f"no new card for {new_col} breakdown {list(bd)}"}

--- a/scripts/conv_preflight.py
+++ b/scripts/conv_preflight.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Résout CHAQUE tuile de conversion découverte (sans rien modifier) et produit :
+- migration/conv-preflight.csv : worklist par tuile (client, dashboard, carte, statut, cible…)
+- un résumé des statuts (la file de revue = tout ce qui n'est pas 'ok').
+Cartes lues depuis l'audit-cache (rapide), fallback live pour les manquantes.
+Usage: python3 scripts/conv_preflight.py [migration/conv-targets.json]"""
+import csv, json, sys
+from collections import Counter, defaultdict
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+import conv_lib
+
+CACHE = REPO / "migration" / "audit-cache"
+_MB = [None]
+
+def get_card(cid):
+    p = CACHE / f"card-{cid}.json"
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            pass
+    if _MB[0] is None:
+        from spark_metabase_api import Metabase_API
+        from reorg_phase1 import _load_env
+        e = _load_env()
+        _MB[0] = Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+    return _MB[0].get(f"/api/card/{cid}") or {}
+
+def main():
+    targets = json.loads(Path(sys.argv[1] if len(sys.argv) > 1 else REPO / "migration" / "conv-targets.json").read_text())
+    mapping_all = json.loads((REPO / "migration" / "conv-client-mapping.json").read_text())
+    raw = json.loads((REPO / "migration" / "conv-new-index.json").read_text())
+    index = {}
+    for k, v in raw.items():
+        col, bd = json.loads(k)
+        index[(col, tuple(bd))] = v
+
+    rows, counts, per_client = [], Counter(), defaultdict(Counter)
+    rescache = {}
+    for d in targets:
+        client = d["client"]
+        cmap = {int(k): v for k, v in mapping_all.get(client, {}).items()}
+        for t in d["tiles"]:
+            cid = t["card_id"]
+            key = (client, cid)
+            if key not in rescache:
+                rescache[key] = conv_lib.resolve_new_card(get_card(cid), cmap, index) if cmap \
+                    else {"status": "no_client_mapping", "reason": f"client {client!r} absent du mapping"}
+            res = rescache[key]
+            st = res["status"]
+            counts[st] += 1
+            per_client[client][st] += 1
+            rows.append({"client": client, "dashboard_id": d["dashboard_id"], "dashboard_name": d["dashboard_name"],
+                         "is_template_like": d["is_template_like"], "dashcard_id": t["dashcard_id"],
+                         "card_id": cid, "card_name": t["card_name"], "status": st,
+                         "new_card_id": res.get("new_card_id"), "candidates": res.get("candidates"),
+                         "new_type": res.get("new_type"), "source": res.get("source"),
+                         "old_cols": ";".join(t.get("old_cols", [])), "reason": res.get("reason")})
+    base = REPO / "migration"
+    (base / "conv-preflight.json").write_text(json.dumps(rows, ensure_ascii=False, indent=2, default=str))
+    with open(base / "conv-preflight.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys())); w.writeheader()
+        for r in rows:
+            w.writerow({k: (json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v) for k, v in r.items()})
+    print(f"{len(rows)} tiles | {len(targets)} dashboards | {len(per_client)} clients")
+    print("status counts:", dict(counts.most_common()))
+    auto = counts.get("ok", 0)
+    print(f"AUTO-applicable (ok): {auto}/{len(rows)} = {100*auto//max(len(rows),1)}%")
+    print("-> migration/conv-preflight.csv / .json")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/conv_tracker.py
+++ b/scripts/conv_tracker.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Suivi de la migration conversions, client par client, + ancre de campagne.
+
+- ANCRE (TAG) : "[conv-2026-06]" — marqueur de CAMPAGNE (pas date de création). TOUT dashboard
+  dupliqué par le chantier conversions le porte, qu'il soit créé en juin, juillet ou après.
+- REGISTRE / tracker : migration/conv-migration-tracker.json — 1 entrée par dashboard migré
+  (client, dashboard, copy_id, original_id, tagged, status, archive_old, old_archived, notes).
+  = source de vérité du « qui remplace qui » → pilote scripts/archive_superseded.py.
+- VUE humaine : docs/conversion-migration-tracker.md (régénérée via --render).
+
+Logique pure testée dans tests/test_conv_tracker.py. I/O fines + CLI.
+
+CLI :
+  python3 scripts/conv_tracker.py --render   # régénère le markdown depuis le json
+  python3 scripts/conv_tracker.py --list     # affiche le tracker
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRACKER_JSON = REPO_ROOT / "migration" / "conv-migration-tracker.json"
+TRACKER_MD = REPO_ROOT / "docs" / "conversion-migration-tracker.md"
+
+TAG = "[conv-2026-06]"   # ancre de CAMPAGNE
+
+
+# ─── logique pure (testée) ───────────────────────────────────────────
+
+def is_tagged(name) -> bool:
+    return bool(name) and TAG in name
+
+
+def apply_tag(name, tag: str = TAG) -> str:
+    """Ajoute l'ancre en suffixe si absente (idempotent)."""
+    name = name or ""
+    return name if tag in name else f"{name} {tag}".strip()
+
+
+def upsert_entry(tracker: list, entry: dict) -> list:
+    """Ajoute ou MERGE l'entrée (clé = copy_id), sans doublon, ordre préservé."""
+    out, found = [], False
+    for e in tracker:
+        if e.get("copy_id") == entry.get("copy_id"):
+            out.append({**e, **entry}); found = True
+        else:
+            out.append(e)
+    if not found:
+        out.append(entry)
+    return out
+
+
+def archivable_originals(tracker: list) -> list:
+    """Originaux à archiver = OPT-IN EXPLICITE (`archive_old: true`) + original connu + pas déjà
+    archivé. Aucune inférence depuis le statut : il faut poser `archive_old` à la main par ligne."""
+    return [e["original_id"] for e in tracker
+            if e.get("archive_old") is True and e.get("original_id") and not e.get("old_archived")]
+
+
+_COLS = [("client", "Client"), ("dashboard", "Dashboard"), ("copy_id", "Copie"),
+         ("original_id", "Original"), ("tagged", "Taggé"), ("status", "Statut"),
+         ("archive_old", "Archiver ancien"), ("old_archived", "Ancien archivé"), ("notes", "Notes")]
+
+
+def render_markdown(tracker: list) -> str:
+    def cell(e, k):
+        v = e.get(k)
+        if isinstance(v, bool):
+            return "✅" if v else "—"
+        return "" if v is None else str(v).replace("|", "\\|")  # échappe le séparateur de table
+    head = "| " + " | ".join(h for _, h in _COLS) + " |"
+    sep = "|" + "|".join("---" for _ in _COLS) + "|"
+    rows = ["| " + " | ".join(cell(e, k) for k, _ in _COLS) + " |" for e in tracker]
+    return "\n".join([head, sep, *rows])
+
+
+# ─── I/O ─────────────────────────────────────────────────────────────
+
+def load(path: Path = TRACKER_JSON) -> list:
+    return json.loads(path.read_text()) if path.exists() else []
+
+
+def save(tracker: list, path: Path = TRACKER_JSON):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(tracker, ensure_ascii=False, indent=2) + "\n")
+
+
+def render_to_file(tracker: list, path: Path = TRACKER_MD):
+    n = len(tracker)
+    tagged = sum(1 for e in tracker if e.get("tagged"))
+    archived = sum(1 for e in tracker if e.get("old_archived"))
+    by_client = {}
+    for e in tracker:
+        by_client.setdefault(e.get("client", "?"), 0)
+        by_client[e.get("client", "?")] += 1
+    header = (
+        "# Migration conversions — SUIVI (généré, ne pas éditer à la main)\n\n"
+        f"> Source : `migration/conv-migration-tracker.json` · régénérer : `conv_tracker.py --render`.\n"
+        f"> Ancre de campagne : `{TAG}`. **{n} dashboards** · {tagged} taggés · {archived} anciens archivés.\n"
+        f"> Clients : " + ", ".join(f"{c} ({k})" for c, k in by_client.items()) + ".\n\n"
+        "Statuts : `migré` (copie faite) · `validé` (consultant OK) · `archive_old:true` (opt-in pour "
+        "archiver l'ancien) · `old_archived` (ancien archivé). L'archivage des anciens est piloté par "
+        "`archive_superseded.py` et ne touche QUE les lignes `archive_old:true`.\n\n"
+    )
+    path.write_text(header + render_markdown(tracker) + "\n")
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--render", action="store_true", help="régénère le markdown depuis le json")
+    ap.add_argument("--list", action="store_true", help="affiche le tracker")
+    args = ap.parse_args()
+    tracker = load()
+    if args.render:
+        render_to_file(tracker)
+        print(f"{TRACKER_MD.relative_to(REPO_ROOT)} régénéré ({len(tracker)} entrées).")
+    if args.list or not args.render:
+        print(render_markdown(tracker))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_generic_temporal.py
+++ b/scripts/convert_generic_temporal.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Crée des COPIES temporal-unit de cartes « by date » non-conversion (Cost, Clicks,
+Orders, COS…) bloquant la bascule du filtre temps. JAMAIS in-place (casserait les
+dashboards originaux) : copie dans la sandbox 13885, inscrite au registre
+migration/tu-generic-<id>.json (lu par bascule_time_filter).
+
+Recette (éprouvée sur 41349/41350) : préfixe la CTE 'granularity' (sonde l'unité via
+le tag temporal-unit sur utils.calendar.date 419201) + remplace chaque
+LATERAL(... metabase_filters.time_periods ... {{time_period}} ... LIMIT 1) par
+LATERAL(SELECT name FROM granularity LIMIT 1). temporal_units = [day,week,month,year]
+(comme l'ancien filtre, sans quarter). Vérif baseline (ancien field-filter) vs copie
+(temporal-unit) sur les 4 granularités, sinon archive la copie + skip.
+
+Usage : .venv/bin/python scripts/convert_generic_temporal.py --ids 4324,27970 --client "Goodiespub" --yes
+"""
+import argparse, json, re, sys, uuid, copy
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from archive_collections import connect_resilient
+import conv_lib
+
+SANDBOX = 13885
+CTE = Path("/tmp/granularity_cte.sql").read_text()
+LATERAL_RE = re.compile(
+    r"LATERAL\s*\(\s*SELECT\s+.*?FROM\s+metabase_filters\.time_periods.*?LIMIT\s+1\s*\)",
+    re.I | re.S)
+GRANS = ["day", "week", "month", "year"]
+
+
+def transform(sql):
+    n_lat = len(LATERAL_RE.findall(sql))
+    if n_lat == 0:
+        raise ValueError("aucun LATERAL time_periods")
+    sql = LATERAL_RE.sub("LATERAL (SELECT name FROM granularity LIMIT 1)", sql)
+    s = sql.lstrip()
+    if s.upper().startswith("WITH"):
+        i = sql.upper().find("WITH") + 4
+        return sql[:i] + " " + CTE + sql[i:], n_lat   # CTE finit par ',' -> suivi de la 1ère CTE existante
+    # pas de WITH : on en crée un (CTE sans la virgule terminale, suivi du SELECT)
+    return "WITH " + CTE.rstrip().rstrip(",") + "\n" + sql, n_lat
+
+
+def inline_baseline_sql(sql, g):
+    """Remplace le LATERAL time_periods par la granularité littérale -> baseline fiable
+    (l'ancien field-filter peut être cassé/vide)."""
+    return LATERAL_RE.sub(f"(SELECT '{g}' AS name)", sql)
+
+
+def run(mb, cid, params):
+    r = mb.post(f"/api/card/{cid}/query", json={"parameters": params}, timeout=300)
+    if not isinstance(r, dict) or r.get("status") != "completed":
+        return None
+    cols = [c["name"] for c in r["data"]["cols"]]
+    return sorted(round(float(x), 4) for row in r["data"]["rows"] for x in row if isinstance(x, (int, float)))
+
+
+def run_dataset(mb, dq, params):
+    body = json.loads(json.dumps(dq)); body["parameters"] = params
+    r = mb.post("/api/dataset", json=body, timeout=300)
+    if not isinstance(r, dict) or r.get("status") != "completed":
+        return None
+    cols = [c["name"] for c in r["data"]["cols"]]
+    return sorted(round(float(x), 4) for row in r["data"]["rows"] for x in row if isinstance(x, (int, float)))
+
+
+def close(a, b, tol=1e-9):
+    return a is not None and b is not None and len(a) == len(b) and \
+        all(x == y or abs(x - y) <= tol * max(abs(x), abs(y), 1e-12) for x, y in zip(a, b))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ids", required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--window", default="2026-05-01~2026-05-31")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    ids = [int(x) for x in args.ids.split(",") if x.strip()]
+    mb = connect_resilient()
+    done = sum(1 for cid in ids if convert_card(mb, cid, args.client, args.window, dry=not args.yes))
+    print(f"\n=> {done}/{len(ids)} converties")
+
+
+def _ptype(tags, name, default):
+    return (tags.get(name) or {}).get("widget-type") or default
+
+
+def base_params(tags, client, window, time_payload):
+    p = []
+    for ct in ("clients", "client"):  # 'client' singulier (magento) = souvent string/=
+        if ct in tags:
+            p.append({"type": _ptype(tags, ct, "category"), "value": [client],
+                      "target": ["dimension", ["template-tag", ct]]})
+    if "date" in tags:
+        p.append({"type": _ptype(tags, "date", "date/all-options"), "value": window,
+                  "target": ["dimension", ["template-tag", "date"]]})
+    if "brand_included" in tags:
+        p.append({"type": _ptype(tags, "brand_included", "category"), "value": ["yes"],
+                  "target": ["dimension", ["template-tag", "brand_included"]]})
+    if time_payload:
+        p.append(time_payload)
+    return p
+
+
+def convert_card(mb, cid, client, window, dry=False):
+    """Crée une COPIE temporal-unit (sandbox 13885) d'une carte time-driven (conversion
+    ou non), vérifiée sur les 4 granularités, inscrite au registre. Retourne new_id si
+    OK, None sinon. Idempotent : si déjà au registre, renvoie l'id existant."""
+    reg = REPO / "migration" / f"tu-generic-{cid}.json"
+    if reg.exists():
+        d = json.loads(reg.read_text())
+        if d.get("verified"):
+            return d["new_id"]
+    (REPO / "migration" / "snapshots").mkdir(parents=True, exist_ok=True)
+    card = mb.get(f"/api/card/{cid}")
+    (REPO / "migration" / "snapshots" / f"card-{cid}-genconv-before.json").write_text(json.dumps(card))
+    st0 = card["dataset_query"]["stages"][0]
+    sql, tags = st0["native"], st0.get("template-tags") or {}
+    try:
+        new_sql, n_lat = transform(sql)
+    except Exception as e:
+        print(f"{cid}: ⛔ transform impossible ({e})"); return None
+
+    base = {}
+    base_dq = copy.deepcopy(card["dataset_query"])
+    base_dq["stages"][0]["template-tags"] = {k: v for k, v in tags.items() if k != "time_period"}
+    for g in GRANS:
+        base_dq["stages"][0]["native"] = inline_baseline_sql(sql, g)
+        base[g] = run_dataset(mb, base_dq, base_params(tags, client, window, None))
+
+    ndq = copy.deepcopy(card["dataset_query"])
+    ndq["stages"][0]["native"] = new_sql
+    tag_id = (tags.get("time_period") or {}).get("id") or str(uuid.uuid4())
+    ndq["stages"][0]["template-tags"]["time_period"] = {
+        "type": "temporal-unit", "name": "time_period", "id": tag_id, "display-name": "Time Period",
+        "dimension": ["field", {"lib/uuid": str(uuid.uuid4())}, 419201], "default": "week", "required": False}
+    params = [p for p in (card.get("parameters") or []) if p.get("slug") != "time_period"]
+    params.append({"id": tag_id, "type": "temporal-unit", "name": "Time Period", "slug": "time_period",
+                   "target": ["dimension", ["template-tag", "time_period"]],
+                   "temporal_units": GRANS, "default": "week", "required": False, "isMultiSelect": False})
+    if dry:
+        print(f"{cid} «{card['name'][:40]}»: {n_lat} LATERAL(s) → temporal-unit (dry, baseline {[bool(base[g]) for g in GRANS]})")
+        return None
+    r = mb.post("/api/card", json={"name": card["name"], "collection_id": SANDBOX, "display": card.get("display"),
+                                   "dataset_query": ndq, "parameters": params,
+                                   "visualization_settings": card.get("visualization_settings") or {}})
+    new_id = r.get("id") if isinstance(r, dict) else None
+    if not new_id:
+        print(f"{cid}: ⛔ création échouée"); return None
+    ok = all(base[g] is not None for g in GRANS)
+    for g in GRANS:
+        tp = {"type": "temporal-unit", "value": g, "target": ["dimension", ["template-tag", "time_period"]]}
+        if not close(base[g], run(mb, new_id, base_params(tags, client, window, tp))):
+            ok = False
+    if ok:
+        reg.write_text(json.dumps({"old_id": cid, "new_id": new_id, "name": card["name"], "verified": True}))
+        print(f"{cid} -> {new_id} ✅ ({card['name'][:42]})")
+        return new_id
+    mb.put(f"/api/card/{new_id}", "raw", json={"archived": True})
+    print(f"{cid}: ⛔ vérif échouée → copie {new_id} archivée")
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/discover_conversion_targets.py
+++ b/scripts/discover_conversion_targets.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Crawl tous les dashboards sous la collection 317 et liste les tuiles de conversion
+(ancien système). Sortie: migration/conv-targets-<ts>.json (+ un lien stable conv-targets.json).
+Le client est déduit du param 'client' du dashboard (fallback: nom de la collection cliente).
+Usage: python3 scripts/discover_conversion_targets.py [--root 317]"""
+import argparse, json, re, sys
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import conv_lib
+
+TEMPLATE_RX = re.compile(r"template|\bspec\b|master|exemple|\bdemo\b", re.I)
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def items(mb, cid):
+    r = mb.get(f"/api/collection/{cid}/items")
+    return (r.get("data") if isinstance(r, dict) else r) or []
+
+def dashboards_under(mb, cid, acc):
+    for it in items(mb, cid):
+        if it.get("model") == "collection":
+            dashboards_under(mb, it["id"], acc)
+        elif it.get("model") == "dashboard":
+            acc.append(it["id"])
+
+def client_of(dash, fallback):
+    for p in dash.get("parameters") or []:
+        if p.get("slug") == "client" and p.get("default"):
+            d = p["default"]
+            return d[0] if isinstance(d, list) and d else d
+    return fallback
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--root", type=int, default=317)
+    args = ap.parse_args()
+    mb = connect()
+    clients = [(c["id"], c["name"]) for c in items(mb, args.root) if c.get("model") == "collection"]
+    card_cache, out = {}, []
+    n_dash = 0
+    for coll_id, coll_name in clients:
+        dl = []
+        dashboards_under(mb, coll_id, dl)
+        for did in dl:
+            n_dash += 1
+            full = mb.get(f"/api/dashboard/{did}")
+            if not isinstance(full, dict):
+                continue
+            tiles = []
+            for dc in (full.get("dashcards") or full.get("ordered_cards") or []):
+                cid = dc.get("card_id")
+                if not cid:
+                    continue
+                if cid not in card_cache:
+                    card_cache[cid] = mb.get(f"/api/card/{cid}") or {}
+                c = card_cache[cid]
+                sql, _ = conv_lib.native_and_tags(c)
+                oc = conv_lib.old_conversion_columns(sql)
+                if oc:
+                    tiles.append({"dashcard_id": dc["id"], "card_id": cid,
+                                  "card_name": c.get("name"), "display": c.get("display"), "old_cols": sorted(oc)})
+            if tiles:
+                out.append({"client": client_of(full, coll_name), "collection_id": coll_id,
+                            "dashboard_id": did, "dashboard_name": full.get("name"),
+                            "is_template_like": bool(TEMPLATE_RX.search(full.get("name") or "")),
+                            "n_tiles": len(tiles), "tiles": tiles})
+        print(f"[{coll_name[:28]:28}] dashboards so far={n_dash} targets={len(out)}", flush=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    p = REPO / "migration" / f"conv-targets-{ts}.json"
+    p.write_text(json.dumps(out, ensure_ascii=False, indent=2))
+    (REPO / "migration" / "conv-targets.json").write_text(json.dumps(out, ensure_ascii=False, indent=2))
+    print(f"\nDONE: {len(clients)} clients | {n_dash} dashboards | {len(out)} with conversion tiles | "
+          f"{sum(d['n_tiles'] for d in out)} tiles | template-like: {sum(d['is_template_like'] for d in out)}")
+    print(f"-> {p}  (+ migration/conv-targets.json)")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_conv_mapping.py
+++ b/scripts/export_conv_mapping.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Transforme les lignes Airtable exportées (Conversions table) en mapping client résolu.
+Usage: python3 scripts/export_conv_mapping.py migration/conv-airtable-rows-<ts>.json"""
+import json, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import conv_lib
+
+def main():
+    rows = json.loads(Path(sys.argv[1]).read_text())
+    mapping = conv_lib.build_client_mappings(rows)
+    n_un = sum(1 for c in mapping.values() for v in c.values() if v == conv_lib.UNMAPPED)
+    n_cf = sum(1 for c in mapping.values() for v in c.values() if v == conv_lib.CONFLICT)
+    out = Path(__file__).resolve().parent.parent / "migration" / "conv-client-mapping.json"
+    out.write_text(json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True))
+    print(f"{len(mapping)} clients -> {out}  (UNMAPPED slots: {n_un}, CONFLICT slots: {n_cf})")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/find_dupes.py
+++ b/scripts/find_dupes.py
@@ -45,18 +45,31 @@ def connect_resilient() -> Metabase_API:
     return Metabase_API(domain=domain, email=email, password=password)
 
 
-def query_fingerprint(dq: dict) -> str:
-    """Empreinte normalisée de la requête (ignore le nom/la mise en forme)."""
-    if not dq:
-        return "empty"
-    db = dq.get("database")
-    qtype = dq.get("type")
-    if qtype == "native":
-        sql = (dq.get("native", {}) or {}).get("query", "") or ""
+def query_fingerprint(card: dict) -> str:
+    """Empreinte normalisée de la requête, basée sur `legacy_query` (format classique).
+
+    Les versions récentes de Metabase stockent `dataset_query` au nouveau format
+    `lib/type`/`stages` (souvent vide via l'API) ; `legacy_query` (string JSON)
+    contient la requête classique fiable.
+    """
+    lq = card.get("legacy_query")
+    if isinstance(lq, str):
+        try:
+            lq = json.loads(lq)
+        except Exception:
+            lq = None
+    if not isinstance(lq, dict) or not lq:
+        # repli : sérialiser le dataset_query nouveau format
+        dq = card.get("dataset_query", {}) or {}
+        return "ds|" + hashlib.md5(
+            json.dumps(dq, sort_keys=True).encode("utf-8")).hexdigest()
+    db = lq.get("database")
+    if lq.get("type") == "native":
+        sql = (lq.get("native", {}) or {}).get("query", "") or ""
         norm = re.sub(r"\s+", " ", sql.strip().lower())
         payload = f"native|{db}|{norm}"
     else:
-        payload = f"mbql|{db}|" + json.dumps(dq.get("query", {}), sort_keys=True)
+        payload = f"mbql|{db}|" + json.dumps(lq.get("query", {}), sort_keys=True)
     return hashlib.md5(payload.encode("utf-8")).hexdigest()
 
 
@@ -80,7 +93,7 @@ def main():
                     "collection_id": d.get("collection_id"),
                     "dashboard_count": d.get("dashboard_count", 0),
                     "display": d.get("display") or "",
-                    "fp": query_fingerprint(d.get("dataset_query", {})),
+                    "fp": query_fingerprint(d),
                 })
 
     walk(ROOT_COLLECTION_ID)

--- a/scripts/find_dupes.py
+++ b/scripts/find_dupes.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Détecte les cartes fonctionnellement identiques dans la collection 215.
+
+Pour chaque carte (hors Nouvelles Conversions), calcule une empreinte de sa
+requête (`dataset_query`) normalisée :
+- native : SQL minuscule, espaces compactés.
+- MBQL   : JSON trié.
+L'empreinte inclut la base de données. Regroupe ensuite :
+- même requête + même display  -> vrais doublons fonctionnels (consolidables).
+- même requête, displays ≠      -> même logique déclinée en plusieurs viz.
+
+Lecture seule. Écrit un rapport JSON dans migration/.
+
+Usage : python3 scripts/find_dupes.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+
+ROOT_COLLECTION_ID = 215
+EXCLUDE_COLLECTION_ID = 11673
+MIGRATION_DIR = REPO_ROOT / "migration"
+
+
+def connect_resilient() -> Metabase_API:
+    env = _load_env()
+    domain, email, password = (env.get("METABASE_DOMAIN"),
+                               env.get("METABASE_EMAIL"),
+                               env.get("METABASE_PASSWORD"))
+    if not (domain and email and password):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env.")
+    return Metabase_API(domain=domain, email=email, password=password)
+
+
+def query_fingerprint(dq: dict) -> str:
+    """Empreinte normalisée de la requête (ignore le nom/la mise en forme)."""
+    if not dq:
+        return "empty"
+    db = dq.get("database")
+    qtype = dq.get("type")
+    if qtype == "native":
+        sql = (dq.get("native", {}) or {}).get("query", "") or ""
+        norm = re.sub(r"\s+", " ", sql.strip().lower())
+        payload = f"native|{db}|{norm}"
+    else:
+        payload = f"mbql|{db}|" + json.dumps(dq.get("query", {}), sort_keys=True)
+    return hashlib.md5(payload.encode("utf-8")).hexdigest()
+
+
+def main():
+    mb = connect_resilient()
+    print(f"Scan complet de la collection {ROOT_COLLECTION_ID} (hors Conversions)...")
+    cards = []
+
+    def walk(cid):
+        items = mb.get(f"/api/collection/{cid}/items?limit=2000").get("data", [])
+        for it in items:
+            if it["model"] == "collection":
+                if it["id"] != EXCLUDE_COLLECTION_ID:
+                    walk(it["id"])
+            elif it["model"] in ("card", "dataset"):
+                d = mb.get(f"/api/card/{it['id']}")
+                if d.get("archived"):
+                    continue
+                cards.append({
+                    "id": d["id"], "name": d["name"],
+                    "collection_id": d.get("collection_id"),
+                    "dashboard_count": d.get("dashboard_count", 0),
+                    "display": d.get("display") or "",
+                    "fp": query_fingerprint(d.get("dataset_query", {})),
+                })
+
+    walk(ROOT_COLLECTION_ID)
+    print(f"  {len(cards)} cartes actives scannées")
+
+    # Groupe par (empreinte requête)
+    by_query = defaultdict(list)
+    for c in cards:
+        by_query[c["fp"]].append(c)
+
+    # Niveau 1 : même requête + même display
+    pure_dups = []        # groupes [cartes] partageant fp ET display
+    same_q_diff_disp = [] # groupes partageant fp mais displays variés
+    for fp, group in by_query.items():
+        if len(group) < 2:
+            continue
+        by_disp = defaultdict(list)
+        for c in group:
+            by_disp[c["display"]].append(c)
+        for disp, sub in by_disp.items():
+            if len(sub) >= 2:
+                pure_dups.append(sub)
+        if len(by_disp) >= 2:
+            same_q_diff_disp.append(group)
+
+    pure_dups.sort(key=len, reverse=True)
+    same_q_diff_disp.sort(key=len, reverse=True)
+
+    n_pure_cards = sum(len(g) for g in pure_dups)
+    n_redundant = sum(len(g) - 1 for g in pure_dups)  # cartes "en trop"
+    print(f"\n=== Vrais doublons fonctionnels (même requête + même viz) ===")
+    print(f"  {len(pure_dups)} groupes, {n_pure_cards} cartes, "
+          f"dont {n_redundant} redondantes (consolidables)")
+    for g in pure_dups[:20]:
+        total_dash = sum(c["dashboard_count"] for c in g)
+        print(f"\n  Groupe de {len(g)} (total {total_dash} dashboards) :")
+        for c in sorted(g, key=lambda x: -x["dashboard_count"]):
+            print(f"    #{c['id']:>6}  dash={c['dashboard_count']:>4}  "
+                  f"[{c['display']}]  {c['name']}")
+
+    print(f"\n=== Même requête, viz différentes (logique déclinée) ===")
+    print(f"  {len(same_q_diff_disp)} groupes")
+
+    # Rapport JSON complet
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    report = MIGRATION_DIR / f"dupes-report-{ts}.json"
+    report.write_text(json.dumps({
+        "scanned": len(cards),
+        "pure_dups": [[c for c in g] for g in pure_dups],
+        "same_query_diff_display": [[c for c in g] for g in same_q_diff_disp],
+    }, indent=2, ensure_ascii=False))
+    print(f"\nRapport complet : {report}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fit_text_cards.py
+++ b/scripts/fit_text_cards.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Ajuste la hauteur des cartes texte à leur contenu (supprime le blanc) + reflow.
+
+Estimation CONSERVATRICE des lignes (on surestime un peu pour ne JAMAIS tronquer).
+SHRINK uniquement : new_h = min(current_h, estimate). Jamais d'agrandissement.
+Les cartes vides (espaceurs de section) et les headings (h=1) sont laissés tels quels.
+Reflow : quand une carte rétrécit de delta, on remonte de delta les cartes du même
+onglet situées dessous.
+
+Usage:
+  python3 scripts/fit_text_cards.py --dashboard 24576           # dry-run (tableau)
+  python3 scripts/fit_text_cards.py --dashboard 24576 --yes     # applique + snapshot
+"""
+import argparse, json, sys, copy, math, requests
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+MIG = REPO / "migration"
+
+CPR = 100        # caractères par ligne en pleine largeur (24 col)
+CAP = 1.6        # lignes visuelles par rangée de grille
+PAD = 0.4        # marge interne (rangée)
+
+
+def content_rows(text):
+    visual = 0.0
+    for ln in (text or "").split("\n"):
+        s = ln.strip()
+        if not s:
+            visual += 0.5            # saut de paragraphe
+            continue
+        visual += max(1, math.ceil(len(s) / CPR))
+    return max(1, math.ceil((visual + PAD) / CAP))
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    d = mb.get(f"/api/dashboard/{args.dashboard}")
+    dcs = copy.deepcopy(d.get("dashcards") or [])
+    tabname = {t["id"]: t["name"] for t in (d.get("tabs") or [])}
+
+    orig_row = {dc["id"]: dc.get("row") for dc in dcs}
+    shrinks = []  # (tab_id, boundary_row, delta)
+    print(f"{'tab':10} {'row':>3} {'cur':>3} {'fit':>3} {'slack':>5}  text")
+    for dc in dcs:
+        vs = dc.get("visualization_settings") or {}
+        vc = vs.get("virtual_card") or {}
+        if vc.get("display") != "text":
+            continue
+        txt = (vs.get("text") or "").strip()
+        if not txt:
+            continue  # espaceur volontaire
+        cur = dc.get("size_y")
+        fit = content_rows(txt)
+        new_h = min(cur, fit)
+        slack = cur - new_h
+        if slack > 0:
+            print(f"{tabname.get(dc['dashboard_tab_id'],'?'):10} {dc['row']:>3} {cur:>3} {new_h:>3} {slack:>5}  {txt[:50]!r}")
+            shrinks.append((dc["dashboard_tab_id"], dc["row"] + cur - 1, slack))
+            dc["size_y"] = new_h
+
+    if not shrinks:
+        print("\nAucun slack détecté.")
+        return
+
+    # reflow : remonter les cartes situées sous chaque carte rétrécie (coords figées)
+    for dc in dcs:
+        tab = dc.get("dashboard_tab_id")
+        up = sum(delta for tb, b, delta in shrinks if tb == tab and b < orig_row[dc["id"]])
+        dc["row"] -= up
+
+    print(f"\n{len(shrinks)} carte(s) rétrécie(s).")
+    if not args.yes:
+        print("(DRY-RUN — aucune modification.)")
+        return
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"fit-snapshot-{args.dashboard}-{ts}.json").write_text(
+        json.dumps({"dashboard": args.dashboard, "dashcards": d.get("dashcards"), "tabs": d.get("tabs")}, ensure_ascii=False, indent=2))
+    payload = {"dashcards": dcs}
+    if d.get("tabs"):
+        payload["tabs"] = d["tabs"]
+    r = requests.put(mb.domain + f"/api/dashboard/{args.dashboard}", headers=mb.header, auth=mb.auth, json=payload, timeout=120)
+    print("PUT:", r.status_code); r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_antipatterns.py
+++ b/scripts/fix_antipatterns.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Applique les correctifs anti-patterns aux cartes Metabase, avec preuve avant/après.
+
+Procédure par carte (cf. [[feedback-metabase-card-changes]]) :
+  1. GET + extrait le SQL actuel (legacy_query.native.query).
+  2. Calcule le SQL corrigé (find/replace exacts issus de l'audit) — abort si le
+     find n'est pas trouvé exactement.
+  3. PREUVE LECTURE SEULE : exécute OLD et NEW via /api/dataset (mêmes substitutions
+     de tags, scope client Tradis multi-zones) et diff. Gate : NEW compile ; pour A,
+     lignes(NEW) <= lignes(OLD) (le fix ne peut que retirer le fan-out).
+  4. --apply seulement : backup JSON, PUT (format natif classique, "raw"), puis
+     re-GET + run live ; revert (PUT backup) si la carte casse.
+
+Usage :
+  python3 scripts/fix_antipatterns.py 28512                 # preuve seule (dry-run)
+  python3 scripts/fix_antipatterns.py 28512 --apply         # applique + vérifie
+  python3 scripts/fix_antipatterns.py --all-a --apply
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts")); sys.path.insert(0, str(ROOT))
+import spark_metabase_api.main_methods as MM
+MM.DEFAULT_TIMEOUT = 180
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB = 144
+HTTP_TIMEOUT = 240
+TEST_CLIENT = "Tradis"            # client multi-zones (preuve d'inflation A)
+BACKUP_DIR = ROOT / "migration" / "fix-backups"
+
+
+def connect():
+    e = _load_env()
+    for a in range(6):
+        try:
+            mb = Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current"); return mb
+        except Exception as ex:
+            print(f"  retry {a+1}: {type(ex).__name__}"); time.sleep(5)
+    sys.exit("conn failed")
+
+
+def get_card(mb, cid):
+    """Retourne (carte, dataset_query, sql_natif_canonique, index_stage).
+
+    La source de vérité est dataset_query.stages[i].native (format MBQL courant) ;
+    legacy_query est un champ dérivé qui ne se régénère pas après un PUT.
+    """
+    d = mb.get(f"/api/card/{cid}")
+    dq = d.get("dataset_query") or {}
+    for i, st in enumerate(dq.get("stages") or []):
+        if isinstance(st.get("native"), str):
+            return d, dq, st["native"], i
+    # repli format classique
+    if isinstance(dq.get("native"), dict) and isinstance(dq["native"].get("query"), str):
+        return d, dq, dq["native"]["query"], -1
+    raise RuntimeError(f"#{cid}: SQL natif introuvable dans dataset_query")
+
+
+def put_native(mb, cid, d, dq, stage_idx, sql):
+    """PUT en réécrivant le SQL natif IN PLACE dans le dataset_query (format courant)."""
+    import copy
+    new_dq = copy.deepcopy(dq)
+    if stage_idx >= 0:
+        new_dq["stages"][stage_idx]["native"] = sql
+    else:
+        new_dq["native"]["query"] = sql
+    payload = {
+        "name": d.get("name"), "collection_id": d.get("collection_id"),
+        "dataset_query": new_dq,
+        "display": d.get("display"), "visualization_settings": d.get("visualization_settings"),
+        "parameters": d.get("parameters"), "description": d.get("description"),
+    }
+    r = mb.put(f"/api/card/{cid}", "raw", json=payload, timeout=180)
+    return getattr(r, "status_code", "?")
+
+
+def run_dataset(mb, sql):
+    r = mb.post("/api/dataset", "raw", json={"database": DB, "type": "native", "native": {"query": sql}}, timeout=HTTP_TIMEOUT)
+    j = r.json() if hasattr(r, "json") else r
+    if isinstance(j, dict) and j.get("error"):
+        return None, None, str(j.get("error"))[:400]
+    dd = j.get("data", {})
+    return [c.get("name") for c in dd.get("cols", [])], dd.get("rows", []), None
+
+
+def subst(sql):
+    """Substitutions de tags Metabase, IDENTIQUES pour OLD et NEW (scope Tradis).
+
+    Le but est UNIQUEMENT de rendre les deux requêtes exécutables pour isoler
+    l'effet du fix ; toutes les substitutions sont identiques OLD/NEW.
+    """
+    sql = re.sub(r"\[\[.*?\]\]", "", sql, flags=re.S)          # blocs optionnels
+    client_col = "utils.clients.name" if "utils.clients" in sql else "serp_requests.client_name"
+    sql = sql.replace("{{client}}", f"{client_col} = '{TEST_CLIENT}'")
+    sql = sql.replace("{{date}}", "TRUE")
+    sql = re.sub(r"\{\{\w+\}\}", "TRUE", sql)                   # ctr_scenario/time_period/corpus/... -> TRUE
+    return sql
+
+
+def numeric_sums(cols, rows):
+    sums = {}
+    for i, c in enumerate(cols):
+        vals = [r[i] for r in rows if isinstance(r[i], (int, float))]
+        if vals:
+            sums[c] = round(sum(vals), 2)
+    return sums
+
+
+def apply_fixes(sql, fixes):
+    new = sql
+    applied = []
+    for find, repl in fixes:
+        n = new.count(find)
+        if n == 0:
+            return None, f"FIND introuvable: {find[:80]!r}"
+        new = new.replace(find, repl)
+        applied.append((find, repl, n))
+    if new == sql:
+        return None, "aucun changement après application"
+    return new, applied
+
+
+def process(mb, card, fixes, antipattern, apply=False):
+    cid = card["card_id"]
+    name = card["name"]
+    print(f"\n{'='*70}\n#{cid} [{antipattern}] {name}")
+    d, dq, old_sql, sidx = get_card(mb, cid)
+    new_sql, info = apply_fixes(old_sql, fixes)
+    if new_sql is None:
+        # déjà corrigé ? (les replace présents, les find absents)
+        if all(repl in old_sql for _, repl in fixes) and all(find not in old_sql for find, _ in fixes):
+            print("  ✓ déjà corrigé (no-op)"); return {"id": cid, "status": "already_fixed"}
+        print("  ✗ ABORT:", info); return {"id": cid, "status": "abort_find", "detail": info}
+    for find, repl, n in info:
+        print(f"  fix ×{n}: …{find[-55:]!r} -> …{repl[-55:]!r}")
+
+    # ---- Stage 1 : preuve lecture seule (diff OLD vs NEW via /api/dataset) ----
+    co, ro, eo = run_dataset(mb, subst(old_sql))
+    cn, rn, en = run_dataset(mb, subst(new_sql))
+    if en:
+        print("  ✗ NEW NE COMPILE PAS:", en); return {"id": cid, "status": "new_compile_fail", "detail": en}
+    n_old = len(ro) if ro is not None else None
+    n_new = len(rn)
+    print(f"  lignes  OLD={n_old}  NEW={n_new}" + ("  ⚠OLD-no-compile" if eo else ""))
+    so, sn = (numeric_sums(co, ro) if ro else {}), numeric_sums(cn, rn)
+    changed = [(k, so.get(k), sn.get(k)) for k in sn if so.get(k) != sn.get(k)]
+    for k, a, b in changed[:8]:
+        delta = f"{(b-a)/a*100:+.1f}%" if isinstance(a, (int, float)) and a else "—"
+        print(f"    Σ {k}: {a} -> {b}  ({delta})")
+    if antipattern == "A" and not eo and n_old is not None and n_new > n_old:
+        print(f"  ✗ GATE A: NEW lignes ({n_new}) > OLD ({n_old}) — abort")
+        return {"id": cid, "status": "gate_rows", "n_old": n_old, "n_new": n_new}
+    print(f"  ✓ gate {antipattern} OK (NEW compile)")
+
+    res = {"id": cid, "antipattern": antipattern, "n_old": n_old, "n_new": n_new,
+           "changed_sums": changed, "status": "proven"}
+    if not apply:
+        print("  (dry-run : pas de PUT)"); return res
+
+    # ---- Stage 2 : backup + PUT (réécriture in-place du dataset_query) ----
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    (BACKUP_DIR / f"card-{cid}-backup-{ts}.json").write_text(json.dumps(d, ensure_ascii=False, indent=2))
+    sc = put_native(mb, cid, d, dq, sidx, new_sql)
+    print(f"  backup ok · PUT status: {sc}")
+
+    # ---- Stage 3 : vérif persistance (champ canonique) + compile, SANS params ----
+    _, _, srv_sql, _ = get_card(mb, cid)
+    persisted = (srv_sql == new_sql)
+    _, _, srv_err = run_dataset(mb, subst(srv_sql))
+    if persisted and not srv_err:
+        print(f"  ✓ APPLIQUÉ & vérifié (SQL serveur == corrigé, compile OK)")
+        res["status"] = "applied_ok"
+    else:
+        why = "non persisté" if not persisted else f"ne compile pas: {srv_err}"
+        print(f"  ✗ ÉCHEC post-PUT ({why}) — REVERT")
+        rb = put_native(mb, cid, d, dq, sidx, old_sql)
+        print(f"  revert PUT status: {rb}")
+        res["status"] = "reverted"
+    return res
+
+
+def load_bugs():
+    full = json.load(open(sorted(glob.glob(str(ROOT / "migration" / "antipattern-audit-full-*.json")))[-1]))
+    return {r["card_id"]: r for r in full["results"] if r["corrected"] == "BUG"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ids", nargs="*", type=int)
+    ap.add_argument("--all-a", action="store_true")
+    ap.add_argument("--all-b", action="store_true")
+    ap.add_argument("--apply", action="store_true")
+    args = ap.parse_args()
+    bugs = load_bugs()
+    ids = list(args.ids)
+    if args.all_a: ids += [c for c, r in bugs.items() if r["antipattern"] == "A"]
+    if args.all_b: ids += [c for c, r in bugs.items() if r["antipattern"] == "B"]
+    ids = sorted(set(ids))
+    if not ids:
+        sys.exit("aucun id (passe des ids, --all-a ou --all-b)")
+    mb = connect(); print("connected.", "MODE:", "APPLY" if args.apply else "DRY-RUN (preuve seule)")
+    out = []
+    for cid in ids:
+        if cid not in bugs:
+            print(f"\n#{cid}: pas dans la liste BUG, skip"); continue
+        r = bugs[cid]
+        out.append(process(mb, r, r["fixes"], r["antipattern"], apply=args.apply))
+    print(f"\n{'='*70}\nRÉSUMÉ")
+    for o in out:
+        print(f"  #{o['id']}: {o['status']}" + (f"  OLD={o.get('n_old')} NEW={o.get('n_new')}" if o.get('n_new') is not None else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_brand_clause_cards.py
+++ b/scripts/fix_brand_clause_cards.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Corrige la clause d'exclusion brand (-> campaign_type) sur des cartes données.
+
+Par carte : GET -> conv_lib.fix_brand_clause(sql) ; si changement :
+  - contrôle statique : il ne reste que des atomes campaign_type ;
+  - run AVANT (params épinglés, brand_included au DÉFAUT 'yes' -> clause inerte) ;
+  - snapshot JSONL ; PUT ; re-GET ; run APRÈS -> valeurs identiques sinon RESTORE.
+Avec --show-no : run brand_included='no' avant/après pour MONTRER le changement
+de comportement (attendu : c'est le correctif).
+
+Usage :
+  .venv/bin/python scripts/fix_brand_clause_cards.py --ids 49098,49100 --yes
+  .venv/bin/python scripts/fix_brand_clause_cards.py --ids 42580 --yes --show-no
+"""
+import argparse, json, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from archive_collections import connect_resilient
+import conv_lib
+from audit_brand_clause import RX
+
+PIN = [
+    {"type": "category", "target": ["dimension", ["template-tag", "clients"]], "value": ["Pro Nutrition"]},
+    {"type": "date/all-options", "target": ["dimension", ["template-tag", "date"]], "value": "2026-05-01~2026-05-31"},
+]
+BRAND_NO = {"type": "category", "target": ["dimension", ["template-tag", "brand_included"]], "value": ["no"]}
+
+def run_cells(mb, cid, tags, extra=()):
+    params = [p for p in PIN if p["target"][1][1] in tags] + list(extra)
+    r = mb.post(f"/api/card/{cid}/query", json={"parameters": params}, timeout=300)
+    if r.get("status") != "completed":
+        return None
+    cols = [str(x.get("name")) for x in r["data"]["cols"]]
+    return conv_lib.displayed_cells(cols, r["data"]["rows"], None)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ids", required=True, help="ids de cartes, séparés par des virgules")
+    ap.add_argument("--show-no", action="store_true")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    ids = [int(x) for x in args.ids.split(",") if x.strip()]
+    mb = connect_resilient()
+    snap = open(REPO / "migration" / "snapshots" / "brand-fix-snapshots.jsonl", "a")
+    n_fixed = 0
+    for cid in ids:
+        card = mb.get(f"/api/card/{cid}")
+        dq = card["dataset_query"]
+        st = dq["stages"][0] if "stages" in dq else dq["native"]
+        key = "native" if "stages" in dq else "query"
+        sql = st[key]
+        fixed = conv_lib.fix_brand_clause(sql)
+        if fixed == sql:
+            print(f"{cid}: déjà conforme — rien à faire")
+            continue
+        rest = sorted({m.group(1).lower() for m in RX.finditer(fixed)})
+        if rest != ["type"]:
+            print(f"{cid}: ⛔ après correction il reste {rest} — carte SAUTÉE")
+            continue
+        _, tags = conv_lib.native_and_tags(card)
+        before = run_cells(mb, cid, tags)
+        before_no = run_cells(mb, cid, tags, [BRAND_NO]) if args.show_no and "brand_included" in tags else None
+        if not args.yes:
+            print(f"{cid}: clause corrigée (dry-run) — {card['name'][:55]!r}")
+            continue
+        snap.write(json.dumps(card) + "\n")
+        st[key] = fixed
+        resp = mb.put(f"/api/card/{cid}", "raw", json={"dataset_query": dq})
+        if resp.status_code != 200:
+            print(f"{cid}: ⛔ PUT {resp.status_code} — {resp.text[:120]}")
+            continue
+        after = run_cells(mb, cid, tags)
+        if before is None or after != before:
+            st[key] = sql
+            mb.put(f"/api/card/{cid}", "raw", json={"dataset_query": dq})
+            print(f"{cid}: ⛔ valeurs au défaut MODIFIÉES ({len(before or [])} vs {len(after or [])}) — RESTAURÉE")
+            continue
+        n_fixed += 1
+        msg = f"{cid}: corrigée ✅ valeurs au défaut identiques ({len(after)} cellules)"
+        if before_no is not None:
+            after_no = run_cells(mb, cid, tags, [BRAND_NO])
+            msg += f" | brand=no: {'CHANGE (attendu)' if after_no != before_no else 'identique'}"
+        print(msg, f"— {card['name'][:50]!r}")
+    snap.close()
+    print(f"\n=> {n_fixed} carte(s) corrigée(s)")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_fallback.py
+++ b/scripts/generate_fallback.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Fallback GÉNÉRATION (pour atteindre 100%) : pour chaque tuile encore sur l'ancien
+système (colonnes positionnelles) APRÈS reuse+swap, génère une COPIE de la vieille
+carte avec substitution des colonnes (conversions_N -> nouvelle colonne nommée via le
+mapping client). Dédupliqué : 1 carte générée par (vieille carte × client), dans une
+collection dédiée (13950). Repointe le dashcard. Onglets supportés.
+
+Politique « génère tout » (user 2026-06-15) : si la carte n'existe pas (pas d'équivalent
+11673), on la crée ; sinon on réutilise (le reuse a déjà fait ça en amont).
+
+Usage : python3 scripts/generate_fallback.py --copy 25765 --client "Goodiespub" [--yes]
+"""
+import argparse, json, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+import conv_lib
+from migrate_dashboard_full import connect, load_inputs, generate_card, _dcs
+
+GEN_COLL = 13950
+REG = REPO / "migration" / "generated-cards.json"
+DC_FIELDS = ("card_id", "row", "col", "size_x", "size_y", "series",
+             "parameter_mappings", "visualization_settings", "dashboard_tab_id")
+
+
+def load_reg():
+    return json.loads(REG.read_text()) if REG.exists() else {}
+
+
+def render_ok(mb, cid, client):
+    """True sauf si VRAIE erreur SQL. Un timeout/non-complétion (grosses tables lentes)
+    n'est PAS un échec : la substitution est structurellement cohérente (SQL+viz substitués
+    ensemble) -> on garde la carte. On n'archive que sur une erreur SQL explicite."""
+    c = mb.get(f"/api/card/{cid}")
+    _, tags = conv_lib.native_and_tags(c)
+    params = []
+    if "clients" in tags:
+        params.append({"type": "string/=", "value": [client], "target": ["dimension", ["template-tag", "clients"]]})
+    if "client" in tags:
+        wt = (tags.get("client") or {}).get("widget-type") or "string/="
+        params.append({"type": wt, "value": [client], "target": ["dimension", ["template-tag", "client"]]})
+    for _ in range(2):
+        r = mb.post(f"/api/card/{cid}/query", "raw", json={"parameters": params}, timeout=300)
+        try:
+            b = r.json() if r.text else {}
+        except Exception:
+            b = {}
+        st = b.get("status") if isinstance(b, dict) else None
+        if st == "completed":
+            return True  # la carte s'exécute ; substitution SQL+viz cohérente -> rend comme l'ancienne
+        if st == "failed":  # vraie erreur SQL
+            return False
+    return True  # timeout/incomplet -> bénéfice du doute (struct. cohérent)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copy", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    mapping_all, _ = load_inputs()
+    cmap = {int(k): v for k, v in mapping_all.get(args.client, {}).items()}
+    reg = load_reg()
+    dash = mb.get(f"/api/dashboard/{args.copy}")
+
+    new_dcs, report = [], []
+    for dc in _dcs(dash):
+        cid = dc.get("card_id")
+        if not cid:
+            new_dcs.append(dc); continue
+        card = mb.get(f"/api/card/{cid}")
+        sql, _ = conv_lib.native_and_tags(card)
+        old_cols = conv_lib.old_conversion_columns(sql)
+        if not old_cols:
+            new_dcs.append(dc); continue
+        sub_map, unmapped = conv_lib.substitution_map(old_cols, cmap)
+        # colonnes VISIBLES non substituées = vrai trou ; les cachées non mappées sont tolérées
+        if not sub_map:
+            report.append((cid, card.get("name"), f"⛔ rien de substituable (conflit/non mappé: {sorted(old_cols)})"))
+            new_dcs.append(dc); continue
+        key = f"{cid}|{args.client}"
+        gen_id = reg.get(key)
+        if not gen_id and args.yes:
+            gen_id = generate_card(mb, card, sub_map, GEN_COLL)
+            if gen_id and render_ok(mb, gen_id, args.client):
+                reg[key] = gen_id
+            elif gen_id:
+                mb.put(f"/api/card/{gen_id}", "raw", json={"archived": True})
+                report.append((cid, card.get("name"), f"⛔ généré {gen_id} mais rendu KO → archivé"))
+                new_dcs.append(dc); continue
+        if not gen_id:
+            report.append((cid, card.get("name"), f"(dry) substituable: {sub_map}" + (f" | non mappé {unmapped}" if unmapped else "")))
+            new_dcs.append(dc); continue
+        nd = {k: json.loads(json.dumps(dc.get(k))) for k in DC_FIELDS if dc.get(k) is not None}
+        nd["id"] = dc.get("id")
+        nd["card_id"] = gen_id
+        # la config de colonnes du DASHCARD (table.columns / column_settings / series) référence
+        # les anciens noms -> substituer pareil pour que l'affichage (visibilité, ordre, titres) colle.
+        if nd.get("visualization_settings"):
+            nd["visualization_settings"] = json.loads(
+                conv_lib.apply_substitution(json.dumps(nd["visualization_settings"]), sub_map))
+        for pm in nd.get("parameter_mappings") or []:
+            pm["card_id"] = gen_id
+        new_dcs.append(nd)
+        report.append((cid, card.get("name"), f"généré -> {gen_id}" + (f" | colonnes non mappées (cachées?): {unmapped}" if unmapped else "")))
+
+    print(f"Dashboard {args.copy} — fallback génération ({args.client}) :")
+    for cid, n, st in report:
+        print(f"  {cid} {str(n)[:38]:38} {st}")
+    gen = [r for r in report if str(r[2]).startswith("généré")]
+    if args.yes and (gen or any('archivé' in str(r[2]) for r in report)):
+        REG.write_text(json.dumps(reg, ensure_ascii=False, indent=0))
+        put = {"dashcards": new_dcs}
+        if dash.get("tabs"):
+            put["tabs"] = dash["tabs"]
+        res = mb.put(f"/api/dashboard/{args.copy}", "raw", json=put)
+        print(f"PUT {args.copy}: {res.status_code}" + ("" if res.status_code == 200 else f" — {res.text[:200]}"))
+    elif not args.yes:
+        print("(DRY-RUN — rien généré.)")
+    # contrôle 100%
+    chk = mb.get(f"/api/dashboard/{args.copy}")
+    left = [dc.get("card_id") for dc in _dcs(chk) if dc.get("card_id")
+            and conv_lib.old_conversion_columns(conv_lib.native_and_tags(mb.get(f"/api/card/{dc['card_id']}"))[0])]
+    print(f"Tuiles encore sur l'ancien système : {left if left else 'AUCUNE ✅ (100%)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_client.py
+++ b/scripts/migrate_client.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Orchestrateur : migre une liste de dashboards d'un client de bout en bout, sur des
+COPIES. Pour chaque dashboard original : copie shallow → reuse (conversions) → swap_tables
+(tableaux) → bascule_time_filter --auto-prepare (filtre temps). Politique d'écarts :
+--accept-diffs partout (petit écart = nouveau mapping fait foi) ; les conflits / no-match
+restent sur l'ancien (signalés par chaque étape).
+
+Usage :
+  python3 scripts/migrate_client.py --client "Father and Sons" --dashboards 11804,15963 --test-collection 13917
+  ... ajouter --yes pour appliquer (sinon dry-run des 3 étapes).
+"""
+import argparse, subprocess, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from archive_collections import connect_resilient
+import conv_tracker
+
+PY = str(REPO / ".venv" / "bin" / "python")
+
+
+def run_step(script, copy, client, extra, yes):
+    cmd = [PY, str(REPO / "scripts" / script), "--copy", str(copy), "--client", client] + extra
+    if yes:
+        cmd.append("--yes")
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+    tail = "\n".join((out.stdout or "").strip().splitlines()[-4:])
+    return tail, (out.returncode == 0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--dashboards", required=True, help="ids ORIGINAUX séparés par virgules")
+    ap.add_argument("--test-collection", type=int, default=13917)
+    ap.add_argument("--name-prefix", default="[TEST conv]")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    origs = [int(x) for x in args.dashboards.split(",") if x.strip()]
+    mb = connect_resilient()
+
+    for orig in origs:
+        d = mb.get(f"/api/dashboard/{orig}")
+        name = d.get("name", str(orig))
+        copy_name = conv_tracker.apply_tag(f"{args.name_prefix} {name}")  # ancre de campagne
+        cp = mb.post(f"/api/dashboard/{orig}/copy",
+                     json={"name": copy_name, "collection_id": args.test_collection,
+                           "is_deep_copy": False})
+        copy = cp.get("id") if isinstance(cp, dict) else None
+        print(f"\n### {orig} «{name}» → copie {copy}")
+        if not copy:
+            print("  ⛔ copie échouée"); continue
+        # consigne la paire ancien→copie dans le registre (pilote archive_superseded.py)
+        tr = conv_tracker.upsert_entry(conv_tracker.load(), {
+            "client": args.client, "dashboard": name, "copy_id": copy, "original_id": orig,
+            "tagged": True, "status": "migré", "archive_old": False, "old_archived": False, "notes": ""})
+        conv_tracker.save(tr); conv_tracker.render_to_file(tr)
+        for script, extra in [
+            ("migrate_dashboard_reuse.py", ["--source", str(orig), "--planned-temporal-unit", "--accept-diffs"]),
+            ("swap_tables.py", ["--accept-diffs"]),
+            ("bascule_time_filter.py", ["--auto-prepare"]),
+            ("generate_fallback.py", []),       # génère les tuiles sans équivalent (objectif 100%)
+            ("polish_generated_viz.py", []),    # repolit la viz des cartes générées
+        ]:
+            tail, ok = run_step(script, copy, args.client, extra, args.yes)
+            print(f"  --- {script} {'' if ok else '(exit≠0)'}")
+            for line in tail.splitlines():
+                print(f"      {line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_conversions_on_dashboard.py
+++ b/scripts/migrate_conversions_on_dashboard.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Migre les tuiles de conversion d'UN dashboard vers le nouveau système.
+Par tuile : détecte la carte ancienne, résout new_type (mapping client) + carte cible
+(index de forme), garde-fous relâchés, snapshot, repointe (swap_lib), recâble les
+column_settings, valide (structurel + lecture de valeur + réconciliation Snowflake).
+NE archive JAMAIS la carte partagée. Réversible (snapshot).
+
+Usage:
+  python3 scripts/migrate_conversions_on_dashboard.py --dashboard 14118 --client "Pro Nutrition"          # dry-run
+  python3 scripts/migrate_conversions_on_dashboard.py --dashboard 14118 --client "Pro Nutrition" --copy --yes  # migre une COPIE
+  python3 scripts/migrate_conversions_on_dashboard.py --dashboard 14118 --client "Pro Nutrition" --yes     # applique in-place + snapshot
+"""
+import argparse, json, sys
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import swap_lib, conv_lib
+
+MIG = REPO / "migration"
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def _dashcards(d):
+    return d.get("dashcards") or d.get("ordered_cards") or []
+
+def load_inputs():
+    mapping = json.loads((MIG / "conv-client-mapping.json").read_text())
+    raw = json.loads((MIG / "conv-new-index.json").read_text())
+    index = {}
+    for k, v in raw.items():
+        col, bd = json.loads(k)
+        index[(col, tuple(bd))] = v
+    return mapping, index
+
+def remap_column_settings(viz, old_col, new_col):
+    """Re-key dashcard column_settings ["name","OLD_COL"] -> NEW_COL so number formatting applies."""
+    cs = (viz or {}).get("column_settings")
+    if not cs:
+        return viz
+    out = dict(viz)
+    new_cs = {}
+    for k, val in cs.items():
+        nk = k.replace(f'"{old_col}"', f'"{new_col}"').replace(f'"{old_col.lower()}"', f'"{new_col.lower()}"')
+        new_cs[nk] = val
+    out["column_settings"] = new_cs
+    return out
+
+def reconcile(mb, client, old_col, new_col, start, end):
+    """Independent SUM of old/new columns over the same join chain (Snowflake via /api/dataset)."""
+    sql = f"""
+WITH base AS (
+  SELECT global.campaign_daily_metrics.{old_col} AS old_c,
+         global.campaign_daily_metrics.{new_col} AS new_c
+  FROM utils.clients
+    JOIN utils.client_ad_platforms ON client_id = utils.clients.id
+    JOIN reports.campaign_details ON reports.campaign_details.account_id = utils.client_ad_platforms.account_id
+    JOIN global.campaign_daily_metrics ON global.campaign_daily_metrics.campaign_id = reports.campaign_details.campaign_id
+  WHERE utils.clients.name = '{client}'
+    AND global.campaign_daily_metrics.date BETWEEN '{start}' AND '{end}')
+SELECT COALESCE(SUM(old_c),0), COALESCE(SUM(new_c),0) FROM base""".strip()
+    ds = mb.post("/api/dataset", json={"database": 144, "type": "native", "native": {"query": sql}}, timeout=180)
+    rows = ds.get("data", {}).get("rows") if isinstance(ds, dict) else None
+    return (rows[0][0], rows[0][1]) if rows else (None, None)
+
+def tile_value(mb, dash_id, dc_id, card_id, client, date_range):
+    d = mb.get(f"/api/dashboard/{dash_id}")
+    dc = next((x for x in _dashcards(d) if x.get("id") == dc_id), {})
+    params = []
+    for pm in dc.get("parameter_mappings") or []:
+        p = next((q for q in d.get("parameters") or [] if q.get("id") == pm.get("parameter_id")), {})
+        val = [client] if p.get("slug") == "client" else (date_range if p.get("slug") == "date" else None)
+        if val is not None:
+            params.append({"id": p["id"], "type": p.get("type"), "value": val, "target": pm.get("target")})
+    r = mb.post(f"/api/dashboard/{dash_id}/dashcard/{dc_id}/card/{card_id}/query", json={"parameters": params}, timeout=120)
+    try:
+        return r["data"]["rows"][-1][-1]
+    except Exception:
+        return None
+
+def card_values(mb, card_id, client, window):
+    """All numeric values a card returns for (client, window), sorted. Used to prove a
+    swap doesn't change anything (old card values == new card values)."""
+    c = mb.get(f"/api/card/{card_id}")
+    _, tags = conv_lib.native_and_tags(c)
+    params = []
+    if "clients" in tags:
+        params.append({"type": "string/=", "value": [client], "target": ["dimension", ["template-tag", "clients"]]})
+    if "date" in tags:
+        params.append({"type": "date/all-options", "value": window, "target": ["dimension", ["template-tag", "date"]]})
+    r = mb.post(f"/api/card/{card_id}/query", json={"parameters": params}, timeout=120)
+    rows = (r or {}).get("data", {}).get("rows", []) or []
+    return sorted(round(float(x), 4) for row in rows for x in row if isinstance(x, (int, float)))
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--copy", action="store_true", help="migrer une copie (test) au lieu de l'original")
+    ap.add_argument("--yes", action="store_true", help="appliquer (sinon dry-run)")
+    ap.add_argument("--window", default="2026-05-01~2026-05-31", help="fenêtre de validation date/all-options")
+    ap.add_argument("--no-verify", action="store_true", help="ne PAS vérifier avant/après (déconseillé)")
+    args = ap.parse_args()
+    mb = connect()
+    mapping_all, index = load_inputs()
+    cmap = {int(k): v for k, v in mapping_all.get(args.client, {}).items()}
+    if not cmap:
+        sys.exit(f"Aucun mapping pour client {args.client!r} (conv-client-mapping.json).")
+
+    src = args.dashboard
+    if args.copy and args.yes:
+        cp = mb.post(f"/api/dashboard/{src}/copy", json={"collection_id": None, "name": f"MIGRATION TEST {src}", "is_deep_copy": False})
+        src = cp["id"]
+        print(f"copie -> dashboard {src}")
+    dash = mb.get(f"/api/dashboard/{src}")
+    dcs = _dashcards(dash)
+
+    plan, report = [], {"dashboard": src, "client": args.client, "tiles": []}
+    for dc in dcs:
+        cid = dc.get("card_id")
+        if not cid:
+            continue
+        card = mb.get(f"/api/card/{cid}")
+        sql, _ = conv_lib.native_and_tags(card)
+        if not conv_lib.old_conversion_columns(sql):
+            continue
+        res = conv_lib.resolve_new_card(card, cmap, index)
+        entry = {"dashcard_id": dc["id"], "old_card": cid, "old_name": card.get("name"), **res}
+        if res["status"] == "ok":
+            new = mb.get(f"/api/card/{res['new_card_id']}")
+            ref = swap_lib.referenced_template_tags(dcs, cid)
+            _, ntags = conv_lib.native_and_tags(new)
+            renames = conv_lib.tag_rename_map(card, new)  # e.g. location -> campaign_location
+            problems = []
+            if new.get("archived"):
+                problems.append("new archived")
+            if card.get("database_id") != new.get("database_id"):
+                problems.append("different DB")
+            miss = ref - set(ntags) - set(renames)  # a renamed filter is re-wireable, not missing
+            if miss:
+                problems.append(f"new misses tags {sorted(miss)}")
+            entry["safety"] = problems
+            if renames:
+                entry["renames"] = renames
+            if problems:
+                entry["status"] = "blocked"
+            else:
+                oc = res["old_col"]  # resolver supplies old+new cols for reconciliation
+                entry["old_col"] = oc
+                plan.append((dc, card, new, res, oc, renames))
+        report["tiles"].append(entry)
+
+    MIG.mkdir(exist_ok=True)
+    rpt = MIG / f"conv-report-{src}.json"
+    rpt.write_text(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+    print(f"REPORT_FILE: {rpt}")  # consumers read this (wrapper pollutes stdout with an auth line)
+    print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+    if not args.yes or not plan:
+        print("\n(DRY-RUN ou rien à faire — aucune modification.)")
+        return
+
+    # GARDE-FOU: ne remplacer une tuile que si la valeur avant == après (sinon on la laisse sur l'ancien).
+    if not args.no_verify:
+        verified = []
+        for item in plan:
+            _dc, _card, _new, _res, _oc, _ren = item
+            before = card_values(mb, _card["id"], args.client, args.window)
+            after = card_values(mb, _res["new_card_id"], args.client, args.window)
+            if before == after:
+                verified.append(item)
+            else:
+                print(f"  ⚠️ NON migrée «{_card.get('name')}» — valeur avant/après différente "
+                      f"({len(before)} vs {len(after)} valeurs) → laissée sur l'ancien système")
+        plan = verified
+        print(f"Vérifiées identiques avant/après : {len(plan)} tuile(s) à migrer.")
+        if not plan:
+            print("(Rien de vérifié-identique — aucune modification.)")
+            return
+
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    snap = MIG / f"conv-migrate-snapshot-{src}-{ts}.json"
+    snap.write_text(json.dumps({"dashboard": src, "dashcards": dcs}, ensure_ascii=False, indent=2))
+    print(f"snapshot: {snap}")
+
+    new_dcs = dcs
+    for dc, card, new, res, oc, renames in plan:
+        new_dcs, _ = swap_lib.rewrite_dashcards(new_dcs, card["id"], res["new_card_id"])
+        for ndc in new_dcs:
+            if ndc.get("id") == dc["id"]:
+                ndc["visualization_settings"] = remap_column_settings(ndc.get("visualization_settings") or {}, oc, res["new_col"])
+                for pm in ndc.get("parameter_mappings") or []:
+                    tgt = pm.get("target")
+                    try:
+                        if tgt[1][0] == "template-tag" and tgt[1][1] in renames:
+                            tgt[1][1] = renames[tgt[1][1]]  # re-wire renamed filter (location->campaign_location)
+                    except Exception:
+                        pass
+    rc = mb.put(f"/api/dashboard/{src}", json={"dashcards": new_dcs})
+    print(f"PUT dashboard {src}: {rc}")
+
+    start, end = args.window.split("~")
+    for dc, card, new, res, oc, renames in plan:
+        nv = tile_value(mb, src, dc["id"], res["new_card_id"], args.client, args.window)
+        if res.get("source") == "global.campaign_daily_metrics":
+            o_sum, n_sum = reconcile(mb, args.client, oc, res["new_col"], start, end)
+            ok = (nv is not None and n_sum is not None and abs(float(nv) - float(n_sum)) < 1e-6)
+            print(f"  tile {dc['id']} {card['name']!r} -> #{res['new_card_id']}: tile={nv} snowflake_new={n_sum} reconciled={ok} (old_sum={o_sum})")
+        else:
+            print(f"  tile {dc['id']} {card['name']!r} -> #{res['new_card_id']}: tile={nv} (source {res.get('source')}: réconciliation manuelle)")
+    print(f"\nRollback: restaurer dashcards depuis {snap}.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_dashboard_full.py
+++ b/scripts/migrate_dashboard_full.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Migration COMPLÈTE d'un dashboard : AUCUNE tuile ne reste sur l'ancien système.
+Par tuile : carte nouvelle pré-existante si elle correspond exactement (avant==après),
+sinon on GÉNÈRE une copie exacte (substitution des colonnes de conversion). Chaque tuile
+est classée `identique ✅` ou `valeur changée ⚠️` (ex. Main conversion -> Purchases).
+Copy-first, snapshot, réversible.
+
+Usage:
+  python3 scripts/migrate_dashboard_full.py --dashboard 14016 --client "Pro Nutrition"           # dry-run (rapport)
+  python3 scripts/migrate_dashboard_full.py --dashboard 14016 --client "Pro Nutrition" --copy --yes
+"""
+import argparse, json, sys
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+import swap_lib, conv_lib
+MIG = REPO / "migration"
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+def _dcs(d): return d.get("dashcards") or d.get("ordered_cards") or []
+
+def load_inputs():
+    mapping = json.loads((MIG / "conv-client-mapping.json").read_text())
+    raw = json.loads((MIG / "conv-new-index.json").read_text())
+    index = {}
+    for k, v in raw.items():
+        col, bd = json.loads(k); index[(col, tuple(bd))] = v
+    return mapping, index
+
+def card_values(mb, card_id, client, window):
+    c = mb.get(f"/api/card/{card_id}"); _, tags = conv_lib.native_and_tags(c)
+    params = []
+    if "clients" in tags: params.append({"type": "string/=", "value": [client], "target": ["dimension", ["template-tag", "clients"]]})
+    if "date" in tags: params.append({"type": "date/all-options", "value": window, "target": ["dimension", ["template-tag", "date"]]})
+    r = mb.post(f"/api/card/{card_id}/query", json={"parameters": params}, timeout=180)
+    rows = (r or {}).get("data", {}).get("rows", []) or []
+    return sorted(round(float(x), 4) for row in rows for x in row if isinstance(x, (int, float)))
+
+def generate_card(mb, old_card, sub_map, coll_id):
+    dq = json.loads(json.dumps(old_card["dataset_query"]))
+    for st in dq.get("stages", []) or []:
+        if st.get("lib/type") == "mbql.stage/native":
+            st["native"] = conv_lib.apply_substitution(st["native"], sub_map)
+    if dq.get("type") == "native":
+        dq["native"]["query"] = conv_lib.apply_substitution(dq["native"]["query"], sub_map)
+    viz = json.loads(conv_lib.apply_substitution(json.dumps(old_card.get("visualization_settings") or {}), sub_map))
+    r = mb.post("/api/card", json={"name": f"[migré] {old_card['name']}", "dataset_query": dq,
+                                   "display": old_card.get("display"), "visualization_settings": viz,
+                                   "collection_id": coll_id})
+    return r.get("id") if isinstance(r, dict) else None
+
+def head(vals): return vals[-1] if vals else None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--copy", action="store_true"); ap.add_argument("--yes", action="store_true")
+    ap.add_argument("--window", default="2026-05-01~2026-05-31")
+    ap.add_argument("--gen-collection", type=int, default=13851)
+    args = ap.parse_args()
+    mb = connect()
+    mapping_all, index = load_inputs()
+    cmap = {int(k): v for k, v in mapping_all.get(args.client, {}).items()}
+    if not cmap: sys.exit(f"Aucun mapping pour {args.client!r}.")
+
+    src = args.dashboard
+    if args.copy and args.yes:
+        cp = mb.post(f"/api/dashboard/{src}/copy", json={"collection_id": None, "name": f"[TEST nouvelles conversions] {src}", "is_deep_copy": False})
+        src = cp["id"]; print(f"copie -> dashboard {src}")
+    dash = mb.get(f"/api/dashboard/{src}"); dcs = _dcs(dash)
+
+    gen_cache, plan, report = {}, [], []
+    for dc in dcs:
+        cid = dc.get("card_id")
+        if not cid: continue
+        card = mb.get(f"/api/card/{cid}"); sql, _ = conv_lib.native_and_tags(card)
+        old_cols = conv_lib.old_conversion_columns(sql)
+        if not old_cols: continue
+        # On GÉNÈRE une copie exacte (mêmes alias/colonnes que l'ancienne -> rendu garanti).
+        sub_map, unmapped = conv_lib.substitution_map(old_cols, cmap)
+        if not sub_map:
+            report.append({"tile": card.get("name"), "status": "BLOQUÉ", "reason": f"slots non mappés: {sorted(unmapped)}"}); continue
+        key = (cid, tuple(sorted(sub_map.items())))
+        chosen = gen_cache.get(key) or generate_card(mb, card, sub_map, args.gen_collection)
+        gen_cache[key] = chosen
+        new_sql, _ = conv_lib.native_and_tags(mb.get(f"/api/card/{chosen}"))
+        residual = sorted(conv_lib.old_conversion_columns(new_sql))
+        before, after = card_values(mb, cid, args.client, args.window), card_values(mb, chosen, args.client, args.window)
+        report.append({"tile": card.get("name"), "method": "générée", "old_card": cid, "new_card": chosen,
+                       "identical": before == after, "before": head(before), "after": head(after),
+                       "unmapped": sorted(unmapped), "residual_old": residual})
+        plan.append((dc, cid, chosen, sub_map, {}))
+
+    # rapport
+    print(f"\n{'TUILE':42} {'MÉTHODE':12} {'AVANT':>12} {'APRÈS':>12}  ÉTAT")
+    for r in report:
+        if r.get("status") == "BLOQUÉ":
+            print(f"{r['tile'][:42]:42} {'—':12} {'':>12} {'':>12}  ⛔ {r['reason']}"); continue
+        flag = "✅ identique" if r["identical"] else "⚠️ VALEUR CHANGÉE"
+        warn = (f" · slots non mappés {r['unmapped']}" if r["unmapped"] else "") + (f" · ancien restant {r['residual_old']}" if r["residual_old"] else "")
+        print(f"{r['tile'][:42]:42} {r['method']:12} {str(r['before']):>12} {str(r['after']):>12}  {flag}{warn}")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"conv-full-report-{src}.json").write_text(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+
+    if not args.yes or not plan:
+        print("\n(DRY-RUN — aucune modification du dashboard.)"); return
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    snap = MIG / f"conv-full-snapshot-{src}-{ts}.json"
+    snap.write_text(json.dumps({"dashboard": src, "dashcards": dcs}, ensure_ascii=False, indent=2))
+    new_dcs = dcs
+    for dc, old_cid, new_cid, sub_map, renames in plan:
+        new_dcs, _ = swap_lib.rewrite_dashcards(new_dcs, old_cid, new_cid)
+        for ndc in new_dcs:
+            if ndc.get("id") == dc.get("id"):
+                if ndc.get("visualization_settings"):
+                    ndc["visualization_settings"] = json.loads(conv_lib.apply_substitution(json.dumps(ndc["visualization_settings"]), sub_map))
+                for pm in ndc.get("parameter_mappings") or []:
+                    tg = pm.get("target")
+                    try:
+                        if tg[1][0] == "template-tag" and tg[1][1] in renames: tg[1][1] = renames[tg[1][1]]
+                    except Exception: pass
+    rc = mb.put(f"/api/dashboard/{src}", json={"dashcards": new_dcs})
+    print(f"\nPUT dashboard {src}: {rc} | snapshot: {snap}")
+    # contrôle final : plus aucune tuile sur l'ancien système ?
+    chk = mb.get(f"/api/dashboard/{src}"); left, broken = [], []
+    for dc in _dcs(chk):
+        c = dc.get("card_id")
+        if not c:
+            continue
+        card = mb.get(f"/api/card/{c}")
+        if conv_lib.old_conversion_columns(conv_lib.native_and_tags(card)[0]):
+            left.append(c)
+        gm = (dc.get("visualization_settings") or {}).get("graph.metrics") or []
+        # contrôle rendu (graphes uniquement — les scalaires ignorent graph.metrics ; insensible casse)
+        if gm and card.get("display") not in conv_lib._SCALAR_DISPLAYS:
+            r = mb.post(f"/api/card/{c}/query", json={"parameters": [{"type": "string/=", "value": [args.client],
+                        "target": ["dimension", ["template-tag", "clients"]]}]}, timeout=120)
+            cols = {str(x.get("name")).upper() for x in (r or {}).get("data", {}).get("cols", []) or []}
+            miss = [m for m in gm if str(m).upper() not in cols]
+            if miss:
+                broken.append({"dashcard": dc.get("id"), "card": c, "missing": miss})
+    print(f"Tuiles encore sur ANCIEN système (slots non mappés cachés): {left if left else 'AUCUNE ✅'}")
+    print(f"Graphes au RENDU cassé (série inexistante): {broken if broken else 'AUCUNE ✅'}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_dashboard_reuse.py
+++ b/scripts/migrate_dashboard_reuse.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Re-migre un dashboard COPIE en réutilisant les cartes de 11673 (AUCUNE génération).
+
+Repart de l'ORIGINAL (--source) pour retrouver les anciennes cartes, et écrit sur la
+COPIE (--copy) en conservant les ids de dashcard de la copie. Par tuile de conversion :
+- `migrée`  : carte 11673 résolue + TOUS les garde-fous verts ->
+    garde-fous : résolution unique (mapping client + colonne + breakdown + KPIs + brand
+    + même table source) ; types de tags câblés compatibles (ex. time_period
+    dimension->temporal-unit = REFUS) ; aucun filtre câblé orphelin après renommage ;
+    rendu cohérent (graph.metrics ⊆ colonnes, hors scalaires, insensible casse) ;
+    valeurs avant==après NON vides.
+- sinon     : on GARDE l'ancienne carte, statut explicite (à décider / à vérifier).
+JAMAIS de génération de carte. PUT vérifié (raw). Dashboards à onglets refusés (pilotes
+sans onglets ; support tabs à ajouter avant la généralisation).
+
+Usage:
+  python3 scripts/migrate_dashboard_reuse.py --copy 25566 --source 14118 --client "Pro Nutrition"        # dry-run
+  python3 scripts/migrate_dashboard_reuse.py --copy 25566 --source 14118 --client "Pro Nutrition" --yes
+"""
+import argparse, json, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+import conv_lib
+import bascule_lib
+from migrate_dashboard_full import connect, load_inputs, card_values, _dcs
+
+def _client_date_params(tags, client, window):
+    """Params client/date robustes : gère 'clients' (pluriel) ET 'client' (singulier,
+    magento), avec le bon type (widget-type du tag : string/=, category…)."""
+    p = []
+    for ct in ("clients", "client"):
+        if ct in tags:
+            wt = (tags.get(ct) or {}).get("widget-type") or "string/="
+            p.append({"type": wt, "value": [client], "target": ["dimension", ["template-tag", ct]]})
+    if "date" in tags:
+        wt = (tags.get("date") or {}).get("widget-type") or "date/all-options"
+        p.append({"type": wt, "value": window, "target": ["dimension", ["template-tag", "date"]]})
+    return p
+
+
+def card_values_pinned(mb, card_id, client, window, gran):
+    """card_values + granularité épinglée selon le mécanisme du tag de LA carte
+    (category pour l'ancien field-filter, temporal-unit pour le nouveau).
+    Nécessaire pour comparer avant/après à travers la bascule du filtre temps."""
+    c = mb.get(f"/api/card/{card_id}"); _, tags = conv_lib.native_and_tags(c)
+    params = _client_date_params(tags, client, window)
+    tp = bascule_lib.time_param_payload(tags, gran)
+    if tp:
+        params.append(tp)
+    r = mb.post(f"/api/card/{card_id}/query", json={"parameters": params}, timeout=180)
+    rows = (r or {}).get("data", {}).get("rows", []) or []
+    return sorted(round(float(x), 4) for row in rows for x in row if isinstance(x, (int, float)))
+
+def card_cells(mb, card_id, client, window, gran, metrics):
+    """Cellules AFFICHÉES seulement (colonnes `metrics`), params épinglés
+    (client/date, + granularité si gran). Pour comparer deux cartes dont l'une
+    sort des colonnes supplémentaires masquées au niveau du dashcard."""
+    c = mb.get(f"/api/card/{card_id}"); _, tags = conv_lib.native_and_tags(c)
+    params = _client_date_params(tags, client, window)
+    if gran:
+        tp = bascule_lib.time_param_payload(tags, gran)
+        if tp:
+            params.append(tp)
+    r = mb.post(f"/api/card/{card_id}/query", json={"parameters": params}, timeout=180)
+    data = (r or {}).get("data", {})
+    cols = [str(x.get("name")) for x in data.get("cols", []) or []]
+    return conv_lib.displayed_cells(cols, data.get("rows", []) or [], metrics)
+
+# viz du dashcard conservée sur tuile migrée : titre, comparaisons, navigation au clic.
+# graph.metrics / column_settings / series_settings sont jetés (clés sur anciens alias)
+# -> la carte 11673 affiche avec SA viz propre.
+KEEP_VIZ = {"card.title", "scalar.comparisons", "click_behavior"}
+
+# Champs du payload PUT (whitelist : jamais d'entity_id/card/timestamps d'un autre dashboard)
+DC_FIELDS = ("card_id", "row", "col", "size_x", "size_y", "series",
+             "parameter_mappings", "visualization_settings", "dashboard_tab_id")
+
+def render_coherent(mb, card_id, client):
+    """(ok: bool|None, raison) — None = la requête de contrôle a échoué (≠ rendu cassé)."""
+    c = mb.get(f"/api/card/{card_id}")
+    if not isinstance(c, dict):
+        return None, "carte inaccessible"
+    if (c.get("display") or "") in conv_lib._SCALAR_DISPLAYS:
+        return True, ""
+    gm = (c.get("visualization_settings") or {}).get("graph.metrics") or []
+    if not gm:
+        return True, ""
+    r = mb.post(f"/api/card/{card_id}/query", json={"parameters": [{"type": "string/=", "value": [client],
+                "target": ["dimension", ["template-tag", "clients"]]}]}, timeout=120)
+    if not isinstance(r, dict):
+        return None, "échec requête de contrôle"
+    cols = {str(x.get("name")).upper() for x in r.get("data", {}).get("cols", []) or []}
+    miss = [m for m in gm if str(m).upper() not in cols]
+    return (False, f"séries absentes: {miss}") if miss else (True, "")
+
+def wired_tags_of(dc):
+    tags = set()
+    for pm in dc.get("parameter_mappings") or []:
+        tgt = pm.get("target")
+        try:
+            if tgt[1][0] == "template-tag":
+                tags.add(tgt[1][1])
+        except Exception:
+            pass
+    return tags
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copy", type=int, required=True)
+    ap.add_argument("--source", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--window", default="2026-05-01~2026-05-31")
+    ap.add_argument("--planned-temporal-unit", action="store_true",
+                    help="bascule du filtre temps planifiée sur ce dashboard : le passage d'un tag "
+                         "time_period dimension->temporal-unit n'est plus bloquant ; les valeurs "
+                         "avant/après sont alors comparées à granularité épinglée (week).")
+    ap.add_argument("--accept-diffs", action="store_true",
+                    help="migre même si les valeurs avant/après diffèrent (écart connu/validé, "
+                         "ex. ancien mapping erroné corrigé). Les autres garde-fous restent actifs.")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    mapping_all, index = load_inputs()
+    cmap = {int(k): v for k, v in mapping_all.get(args.client, {}).items()}
+    if not cmap:
+        sys.exit(f"Aucun mapping pour {args.client!r}.")
+
+    source = mb.get(f"/api/dashboard/{args.source}")
+    copy = mb.get(f"/api/dashboard/{args.copy}")
+    if not isinstance(source, dict) or not isinstance(copy, dict):
+        sys.exit("dashboard source/copie inaccessible")
+    # ONGLETS supportés : la copie shallow garde l'ordre des onglets de la source -> on
+    # apparie par (index d'onglet, row, col). Les ids d'onglet de la copie diffèrent de la
+    # source, d'où l'appariement par INDEX, et on garde l'id d'onglet de la COPIE.
+    src_tab_idx = {t["id"]: i for i, t in enumerate(source.get("tabs") or [])}
+    copy_tab_idx = {t["id"]: i for i, t in enumerate(copy.get("tabs") or [])}
+    if len(src_tab_idx) != len(copy_tab_idx):
+        sys.exit("⛔ source et copie n'ont pas le même nombre d'onglets — appariement impossible")
+
+    def _pos(dc, idx):
+        return (idx.get(dc.get("dashboard_tab_id")), dc.get("row"), dc.get("col"))
+
+    # appariement par position (onglet, row, col), avec détection de collision
+    src_by_pos = {}
+    for d in _dcs(source):
+        key = _pos(d, src_tab_idx)
+        if key in src_by_pos:
+            sys.exit(f"⛔ position ambiguë dans la source {key} — appariement impossible")
+        src_by_pos[key] = d
+
+    new_dcs, report = [], []
+    for cdc in _dcs(copy):
+        sdc = src_by_pos.get(_pos(cdc, copy_tab_idx))
+        if not sdc:
+            new_dcs.append(cdc)
+            if cdc.get("card_id"):
+                report.append((f"dashcard {cdc.get('id')}", "sans équivalent source — inchangée"))
+            continue
+        nd = {k: json.loads(json.dumps(sdc.get(k))) for k in DC_FIELDS}
+        nd["dashboard_tab_id"] = cdc.get("dashboard_tab_id")  # garder l'onglet de la COPIE
+        nd["id"] = cdc.get("id")
+        cid = sdc.get("card_id")
+        card = mb.get(f"/api/card/{cid}") if cid else None
+        if cid and not isinstance(card, dict):
+            report.append((f"carte #{cid}", "⛔ carte source inaccessible — tuile inchangée"))
+            new_dcs.append(nd); continue
+
+        # series jamais migrées automatiquement : si une carte de series est sur l'ancien système -> on signale
+        series_old = []
+        for s in nd.get("series") or []:
+            sc = mb.get(f"/api/card/{s.get('id') or s.get('card_id')}")
+            if isinstance(sc, dict) and conv_lib.old_conversion_columns(conv_lib.native_and_tags(sc)[0]):
+                series_old.append(sc.get("id"))
+        if series_old:
+            report.append((card.get("name") if card else f"dashcard {cdc.get('id')}",
+                           f"À DÉCIDER — series sur ancien système: {series_old}"))
+            new_dcs.append(nd); continue
+
+        if not cid:
+            new_dcs.append(nd); continue
+        sql, _ = conv_lib.native_and_tags(card)
+        old_cols = conv_lib.old_conversion_columns(sql)
+        if not old_cols:
+            if conv_lib.has_opaque_refs(sql):
+                report.append((card.get("name"), "À VÉRIFIER — snippet/carte source (contenu invisible)"))
+            new_dcs.append(nd); continue
+
+        # --- résolution + garde-fous ---
+        res = conv_lib.resolve_new_card(card, cmap, index)
+        decision = None
+        mask_keep = None  # séries 11673 à afficher (override dashcard) si masquage
+        diff_note = ""    # écart de valeurs avant/après accepté (--accept-diffs)
+        if res.get("status") != "ok":
+            decision = f"À DÉCIDER ({res.get('status')}: {str(res.get('reason') or res.get('candidates') or '')[:70]})"
+        else:
+            newc_id = res["new_card_id"]
+            new_card = mb.get(f"/api/card/{newc_id}")
+            renames = conv_lib.tag_rename_map(card, new_card)
+            _, otags = conv_lib.native_and_tags(card)
+            # seuls les câbles VIVANTS sur l'ancienne carte comptent : un mapping vers un tag
+            # que l'ancienne carte n'a pas était déjà mort (toléré par Metabase) — ne bloque pas.
+            wired = wired_tags_of(sdc) & set(otags)
+            _, ntags = conv_lib.native_and_tags(new_card)
+            orphans = {renames.get(t, t) for t in wired} - set(ntags)
+            incompat = conv_lib.incompatible_wired_tags(card, new_card, wired, renames)
+            time_exception = False
+            if args.planned_temporal_unit:
+                kept = {t: v for t, v in incompat.items() if tuple(v) != ("dimension", "temporal-unit")}
+                time_exception = len(kept) < len(incompat)
+                incompat = kept
+            rc_ok, rc_reason = render_coherent(mb, newc_id, args.client)
+            if orphans:
+                decision = f"À DÉCIDER (filtres orphelins sur 11673: {sorted(orphans)})"
+            elif incompat:
+                decision = f"À DÉCIDER (type de tag incompatible: {incompat})"
+            elif rc_ok is None:
+                decision = f"À VÉRIFIER ({rc_reason})"
+            elif not rc_ok:
+                decision = f"À DÉCIDER (rendu 11673 incohérent: {rc_reason})"
+            else:
+                if time_exception:
+                    before = card_values_pinned(mb, cid, args.client, args.window, "week")
+                    after = card_values_pinned(mb, newc_id, args.client, args.window, "week")
+                else:
+                    before = card_values(mb, cid, args.client, args.window)
+                    after = card_values(mb, newc_id, args.client, args.window)
+                if not before:
+                    decision = "À VÉRIFIER (fenêtre de validation VIDE — aucune preuve)"
+                elif before != after:
+                    # la carte 11673 affiche-t-elle simplement des séries EN PLUS ?
+                    # -> mapper les séries de l'ancienne par nature, masquer le reste
+                    #    au niveau du dashcard, et comparer sur les séries affichées.
+                    old_m = (card.get("visualization_settings") or {}).get("graph.metrics") or []
+                    new_m = (new_card.get("visualization_settings") or {}).get("graph.metrics") or []
+                    mapped = None
+                    if ((card.get("display") or "") not in conv_lib._SCALAR_DISPLAYS
+                            and old_m and new_m and len(new_m) > len(old_m)):
+                        mapped = conv_lib.series_display_map(old_m, new_m)
+                    if mapped:
+                        g = "week" if time_exception else None
+                        b2 = card_cells(mb, cid, args.client, args.window, g, old_m)
+                        a2 = card_cells(mb, newc_id, args.client, args.window, g, mapped)
+                        if b2 and b2 == a2:
+                            mask_keep = mapped
+                        else:
+                            decision = ("À DÉCIDER (valeurs ≠ même restreintes aux séries affichées : "
+                                        f"avant {b2[-1] if b2 else None} / après {a2[-1] if a2 else None})")
+                    if not mapped and not decision:
+                        if args.accept_diffs:
+                            diff_note = f" [écart accepté: avant {before[-1] if before else None} / après {after[-1] if after else None}]"
+                        else:
+                            decision = f"À DÉCIDER (valeurs ≠ : avant {before[-1] if before else None} / après {after[-1] if after else None})"
+        if decision:
+            report.append((card.get("name"), f"{decision} — reste ancien #{cid}"))
+            new_dcs.append(nd); continue
+
+        # --- tuile migrée : repointage + recâblage + viz nettoyée ---
+        nd["card_id"] = newc_id
+        for pm in nd.get("parameter_mappings") or []:
+            pm["card_id"] = newc_id
+            tgt = pm.get("target")
+            try:
+                if tgt[1][0] == "template-tag" and tgt[1][1] in renames:
+                    tgt[1][1] = renames[tgt[1][1]]
+            except Exception:
+                pass
+        nd["visualization_settings"] = {k: v for k, v in (sdc.get("visualization_settings") or {}).items() if k in KEEP_VIZ}
+        note = f" (renames {renames})" if renames else ""
+        if mask_keep:
+            nd["visualization_settings"]["graph.metrics"] = mask_keep
+            hidden = [m for m in ((new_card.get("visualization_settings") or {}).get("graph.metrics") or [])
+                      if m not in mask_keep]
+            note += f" (séries masquées: {hidden})"
+        report.append((card.get("name"), f"migrée -> 11673 #{newc_id}" + note + diff_note))
+        new_dcs.append(nd)
+
+    print(f"Dashboard {args.copy} (source {args.source}) :")
+    for n, st in report:
+        print(f"  {str(n)[:46]:46} {st}")
+    n_mig = sum(1 for _, s in report if s.startswith("migrée"))
+    print(f"\n=> {n_mig} migrée(s), {len(report) - n_mig} autre(s)")
+    if not args.yes:
+        print("(DRY-RUN — rien modifié.)"); return
+
+    (REPO / "migration" / f"reuse-snapshot-{args.copy}.json").write_text(
+        json.dumps(_dcs(copy), ensure_ascii=False))
+    put_body = {"dashcards": new_dcs}
+    if copy.get("tabs"):  # PUT d'un dash à onglets DOIT inclure tabs (sinon 500)
+        put_body["tabs"] = copy["tabs"]
+    res_put = mb.put(f"/api/dashboard/{args.copy}", "raw", json=put_body)
+    if res_put.status_code != 200:
+        print(f"⛔ PUT {args.copy} ÉCHOUÉ: HTTP {res_put.status_code} — {res_put.text[:400]}")
+        sys.exit(1)
+    print(f"PUT {args.copy}: 200 OK")
+
+    # contrôles finaux
+    chk = mb.get(f"/api/dashboard/{args.copy}")
+    gen_left, old_left = [], []
+    for dc in _dcs(chk):
+        c = dc.get("card_id")
+        if not c:
+            continue
+        cc = mb.get(f"/api/card/{c}")
+        if not isinstance(cc, dict):
+            continue
+        if str(cc.get("name", "")).startswith(("[migré]", "[généré]")):
+            gen_left.append(c)
+        if conv_lib.old_conversion_columns(conv_lib.native_and_tags(cc)[0]):
+            old_left.append(c)
+    print(f"Cartes générées encore référencées : {gen_left if gen_left else 'AUCUNE ✅'}")
+    print(f"Tuiles restées sur l'ancien système (attendues = les 'À DÉCIDER') : {old_left if old_left else 'AUCUNE ✅'}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/polish_generated_viz.py
+++ b/scripts/polish_generated_viz.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Repolit la config d'affichage des dashcards pointant vers une carte GÉNÉRÉE (coll 13950) :
+leur visualization_settings (table.columns / column_settings / series) référence encore les
+ANCIENS noms de colonnes alors que la carte générée sort les nouveaux. On substitue avec le
+sub_map COMPLET du client → titres/ordre/visibilité des colonnes reprennent correctement.
+
+Usage : python3 scripts/polish_generated_viz.py --copy 25765 --client "Goodiespub" [--yes]
+"""
+import argparse, json, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+import conv_lib
+from migrate_dashboard_full import connect, load_inputs, _dcs
+
+GEN_COLL = 13950
+ALL_OLD = (["CONVERSIONS", "CONVERSION_VALUE"]
+           + [f"CONVERSIONS_{n}" for n in range(1, 20)]
+           + [f"CONVERSION_{n}_VALUE" for n in range(1, 20)])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copy", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    cmap = {int(k): v for k, v in load_inputs()[0].get(args.client, {}).items()}
+    sub_map, _ = conv_lib.substitution_map(ALL_OLD, cmap)
+
+    dash = mb.get(f"/api/dashboard/{args.copy}")
+    new_dcs, polished = [], []
+    for dc in _dcs(dash):
+        cid = dc.get("card_id")
+        nd = json.loads(json.dumps(dc))
+        if cid:
+            c = mb.get(f"/api/card/{cid}")
+            if c.get("collection_id") == GEN_COLL and nd.get("visualization_settings"):
+                before = json.dumps(nd["visualization_settings"])
+                after = conv_lib.apply_substitution(before, sub_map)
+                if after != before:
+                    nd["visualization_settings"] = json.loads(after)
+                    polished.append((cid, c.get("name")))
+        new_dcs.append(nd)
+
+    print(f"Dashboard {args.copy} — repolissage viz ({len(polished)} dashcards générés) :")
+    for cid, n in polished:
+        print(f"  {cid} {str(n)[:50]}")
+    if not args.yes:
+        print("(DRY-RUN)"); return
+    if polished:
+        put = {"dashcards": new_dcs}
+        if dash.get("tabs"):
+            put["tabs"] = dash["tabs"]
+        res = mb.put(f"/api/dashboard/{args.copy}", "raw", json=put)
+        print(f"PUT {args.copy}: {res.status_code}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/polish_headings_24576.py
+++ b/scripts/polish_headings_24576.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Uniformise les titres de section d'un dashboard vers le type `heading` natif.
+
+Cible : les cartes texte AUTONOMES dont le contenu est une seule ligne commençant
+par `#` (titres H1/H2 markdown). Elles sont converties en cartes `heading` natives
+(taille moyenne unique, alignée sur les headings déjà présents). Les cartes Q&R
+multi-lignes (FAQ `#### …` + corps) ne sont PAS touchées.
+
+Réversible (snapshot). Workflow conseillé : --copy --yes pour tester, puis --yes.
+
+Usage:
+  python3 scripts/polish_headings_24576.py --dashboard 24576              # dry-run
+  python3 scripts/polish_headings_24576.py --dashboard 24576 --copy --yes # test sur une copie
+  python3 scripts/polish_headings_24576.py --dashboard 24576 --yes        # applique + snapshot
+"""
+import argparse, json, sys, copy, re
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+MIG = REPO / "migration"
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def _dashcards(d):
+    return d.get("dashcards") or d.get("ordered_cards") or []
+
+
+def is_title_text_card(vs):
+    """True si carte texte autonome = une seule ligne non vide commençant par '#'."""
+    if not vs or vs.get("text") is None:
+        return False
+    vc = vs.get("virtual_card") or {}
+    if vc.get("display") != "text":
+        return False
+    lines = [l for l in (vs["text"] or "").strip().splitlines() if l.strip()]
+    return len(lines) == 1 and lines[0].lstrip().startswith("#")
+
+
+def to_heading(vs):
+    """Retourne une copie de vs convertie en carte heading native."""
+    out = copy.deepcopy(vs)
+    title = re.sub(r"^\s*#+\s*", "", out["text"].strip())
+    out["text"] = title
+    vc = out.get("virtual_card") or {}
+    vc["display"] = "heading"
+    out["virtual_card"] = vc
+    out.setdefault("dashcard.background", False)
+    out.pop("text.align_vertical", None)
+    out.pop("text.align_horizontal", None)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--copy", action="store_true", help="opère sur une copie de test")
+    ap.add_argument("--yes", action="store_true", help="applique réellement")
+    args = ap.parse_args()
+
+    mb = connect()
+    src = args.dashboard
+    if args.copy and args.yes:
+        cp = mb.post(f"/api/dashboard/{src}/copy", json={"collection_id": None, "name": f"POLISH TEST {src}", "is_deep_copy": False})
+        src = cp["id"]
+        print(f"copie -> dashboard {src}")
+
+    dash = mb.get(f"/api/dashboard/{src}")
+    dcs = _dashcards(dash)
+
+    targets = []
+    for dc in dcs:
+        vs = dc.get("visualization_settings") or {}
+        if is_title_text_card(vs):
+            targets.append(dc)
+
+    print(f"{len(targets)} carte(s) titre à convertir :")
+    for dc in targets:
+        vs = dc["visualization_settings"]
+        print(f"  tab={dc.get('dashboard_tab_id')} row={dc.get('row')} h={dc.get('size_y')} | {vs['text']!r} -> heading {to_heading(vs)['text']!r}")
+
+    if not args.yes or not targets:
+        print("\n(DRY-RUN ou rien à faire — aucune modification.)")
+        return
+
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    snap = MIG / f"polish-snapshot-{src}-{ts}.json"
+    snap.write_text(json.dumps({"dashboard": src, "dashcards": dcs}, ensure_ascii=False, indent=2))
+    print(f"snapshot: {snap}")
+
+    new_dcs = copy.deepcopy(dcs)
+    tids = {dc["id"] for dc in targets}
+    for ndc in new_dcs:
+        if ndc.get("id") in tids:
+            ndc["visualization_settings"] = to_heading(ndc["visualization_settings"])
+    # Dashboards à onglets : il FAUT renvoyer `tabs`, sinon FK violation (500).
+    payload = {"dashcards": new_dcs}
+    if dash.get("tabs"):
+        payload["tabs"] = dash["tabs"]
+    rc = mb.put(f"/api/dashboard/{src}", "raw", json=payload)
+    print(f"PUT dashboard {src}: HTTP {rc.status_code} ({len(targets)} converties)")
+    rc.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_v2.py
+++ b/scripts/probe_v2.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Sondage V2 : marché GSC, gabarits de pages, brand keywords, kw FR trackés."""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+FR_KW=['vernis semi permanent','french manucure','kit vernis semi permanent','kit manucure',
+ 'vernis a ongle','top coat','lampe uv ongles','base coat','soin des ongles',
+ 'kit manucure semi permanent','dissolvant vernis semi permanent','vernis amer',
+ 'vernis durcisseur','kit semi permanent','dissolvant semi permanent','couleur vernis',
+ 'huile cuticule','vernis naturel']
+US_KW=['gel polish kit','gel polish','non toxic gel polish','gel nail polish','nail polish kit',
+ 'non toxic nail polish','vegan nail polish','natural nail polish','nail polish','nail care',
+ 'cuticle oil','nail strengthener','base & top coat','nail treatment']
+FR_IN=",".join("'%s'"%k for k in FR_KW)
+US_IN=",".join("'%s'"%k for k in US_KW)
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected")
+    def run(label,sql):
+        r=mb.post("/api/dataset","raw",json={"database":144,"type":"native","native":{"query":sql}},timeout=240)
+        j=r.json()
+        print(f"\n##### {label}")
+        if j.get("error"): print("  ERR:",str(j["error"])[:250]); return [],[]
+        d=j["data"]; cols=[c["name"] for c in d["cols"]]
+        print("  ",cols)
+        for x in d["rows"]: print("   ",x)
+        return cols, d["rows"]
+
+    run("A. Comptes GSC Manucurist","""
+SELECT account_id, account_name FROM google_search_console.gsc__accounts
+WHERE client_name='Manucurist'""")
+
+    run("B. Pays dispo (country_device_keyword), Manucurist, 90j","""
+SELECT country, SUM(clicks) clicks, COUNT(DISTINCT keyword) kws
+FROM google_search_console.gsc__country_device_keyword_daily_metrics
+WHERE client_name='Manucurist' AND date>=DATEADD('day',-90,CURRENT_DATE)
+GROUP BY 1 ORDER BY 2 DESC LIMIT 12""")
+
+    run("C. Colonnes des tables pages + brand","""
+SELECT table_name, LISTAGG(column_name,', ') WITHIN GROUP (ORDER BY ordinal_position) cols
+FROM information_schema.columns
+WHERE table_schema='GOOGLE_SEARCH_CONSOLE'
+  AND table_name IN ('GSC__PAGE_DAILY_METRICS','GSC__PAGE_KEYWORD_DAILY_METRICS','GSC__BRAND_KEYWORDS','GSC__URL_GROUPS')
+GROUP BY 1""")
+
+    run("D. Top URLs pages Manucurist (patterns gabarit/locale), 30j","""
+SELECT page, SUM(clicks) clicks
+FROM google_search_console.gsc__page_daily_metrics
+WHERE client_name='Manucurist' AND date>=DATEADD('day',-30,CURRENT_DATE)
+GROUP BY 1 ORDER BY 2 DESC LIMIT 30""")
+
+    run("E. Brand keywords Manucurist (sample)","""
+SELECT * FROM google_search_console.gsc__brand_keywords
+WHERE client_name ILIKE '%manucurist%' LIMIT 15""")
+
+    run("F. KW FR du gsheet trackés en SERP zone France ?",f"""
+SELECT LOWER(sr.keyword) kw, COUNT(DISTINCT sr.corpus_name) corpus
+FROM google_serp.serp_requests sr JOIN utils.clients c ON c.id=sr.client_id
+WHERE c.name='Manucurist' AND sr.zone='France' AND LOWER(sr.keyword) IN ({FR_IN})
+GROUP BY 1 ORDER BY 1""")
+
+    run("G. Volumes kp zone France pour ces kw",f"""
+SELECT LOWER(keyword) kw, MAX(month) last_month,
+       MAX(COALESCE(adjusted_avg_searches,avg_monthly_searches)) vol
+FROM google_keyword_planner.kp__keyword_monthly_metrics
+WHERE zone='France' AND LOWER(keyword) IN ({FR_IN}) GROUP BY 1 ORDER BY 1""")
+
+    run("H. Clics par pays pour kw stratégiques (country_device), mai",f"""
+SELECT country, COUNT(DISTINCT LOWER(keyword)) kws, SUM(clicks) clicks
+FROM google_search_console.gsc__country_device_keyword_daily_metrics
+WHERE client_name='Manucurist' AND date>=DATEADD('day',-30,CURRENT_DATE)
+  AND (LOWER(keyword) IN ({US_IN}) OR LOWER(keyword) IN ({FR_IN}))
+GROUP BY 1 ORDER BY 3 DESC LIMIT 10""")
+
+if __name__=="__main__":
+    main()

--- a/scripts/probe_v3.py
+++ b/scripts/probe_v3.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Découverte V3 : template saisonnalité #13489, CTR/potentiel, URL positionnée, géo-clics."""
+from __future__ import annotations
+import json, sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception: time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected")
+    def run(label,sql):
+        r=mb.post("/api/dataset","raw",json={"database":144,"type":"native","native":{"query":sql}},timeout=240)
+        j=r.json(); print(f"\n##### {label}")
+        if j.get("error"): print("  ERR:",str(j["error"])[:250]); return
+        d=j["data"]; print("  ",[c["name"] for c in d["cols"]])
+        for x in d["rows"]: print("   ",x)
+
+    # A. template saisonnalité #13489
+    print("##### A. Carte/dashboard #13489 (saisonnalité)")
+    try:
+        c=mb.get("/api/card/13489")
+        if isinstance(c,dict) and c.get("id"):
+            print("  CARTE:", c.get("name"),"| type:",c.get("type"),"| display:",c.get("display"),"| coll:",(c.get("collection") or {}).get("name"))
+            lq=c.get("legacy_query"); lq=json.loads(lq) if isinstance(lq,str) else lq
+            q=(lq or {}).get("native",{}).get("query","")
+            print("  SQL len:",len(q)); print("  SQL head:\n",("\n".join(q.splitlines()[:25]) if q else "(vide via legacy)"))
+            tt=(lq or {}).get("native",{}).get("template-tags") or {}
+            print("  tags:", list(tt.keys()))
+        else:
+            print("  pas une carte, essai dashboard…")
+    except Exception as ex: print("  card err:",ex)
+    try:
+        d=mb.get("/api/dashboard/13489")
+        if isinstance(d,dict) and d.get("id"):
+            print("  DASHBOARD #13489:", d.get("name"),"| tuiles:",len(d.get("dashcards",[])))
+    except Exception as ex: pass
+
+    # B. CTR scenarios pour potentiel de trafic
+    run("B. serp_ctr_scenarios (Default) — position→ctr","""
+SELECT position, ctr_low, ctr_medium, ctr_high
+FROM metabase_filters.serp_ctr_scenarios WHERE name='Default' AND position IN (1,2,3,5,8,12,24,100)
+ORDER BY position""")
+
+    # C. URL positionnée (client) pour 3 kw US
+    run("C. URL positionnée client (SERP) — sample US","""
+WITH gcd AS (
+  SELECT LOWER(km.keyword) keyword, km.url, km.request_date, sr.domain client_domain,
+    CASE WHEN km.type='featured_snippet' AND km.rank_group=1 THEN 0 ELSE km.rank_absolute END ra
+  FROM utils.clients c JOIN google_serp.serp_requests sr ON sr.client_id=c.id
+   JOIN google_serp.serp_history sh ON (sh.keyword=sr.keyword AND sh.language=sr.language AND sh.zone=sr.zone)
+   JOIN google_serp.serp__keyword_metrics km ON (km.keyword=sh.keyword AND km.language=sh.language AND km.zone=sh.zone)
+  WHERE c.name='Manucurist' AND sr.zone='United States'
+    AND LOWER(sr.keyword) IN ('gel polish kit','cuticle oil','nail polish')
+    AND km.request_date>=DATEADD('month',-2,CURRENT_DATE)
+)
+SELECT keyword, url, ra FROM gcd WHERE url ILIKE '%'||client_domain||'%'
+QUALIFY ROW_NUMBER() OVER (PARTITION BY keyword ORDER BY request_date DESC, ra) = 1""")
+
+    # D. géo-split des clics par mot-clé (section de site)
+    run("D. clics par mot-clé × marché (page_keyword, 30j)","""
+SELECT LOWER(keyword) kw,
+  CASE WHEN page ILIKE 'https://us.manucurist.com%' THEN 'US'
+       WHEN page ILIKE 'https://uk.manucurist.com%' THEN 'UK'
+       WHEN REGEXP_LIKE(page,'https://www[.]manucurist[.]com/(en|es|it|de|nl|el|pt)(/.*)?') THEN 'AUTRES'
+       WHEN page ILIKE 'https://www.manucurist.com%' THEN 'FR' ELSE 'AUTRES' END marche,
+  SUM(clicks) clics
+FROM google_search_console.gsc__page_keyword_daily_metrics
+WHERE client_name='Manucurist' AND LOWER(keyword) IN ('nail polish','non toxic nail polish','french manucure')
+  AND date>=DATEADD('day',-30,CURRENT_DATE)
+GROUP BY 1,2 ORDER BY 1,3 DESC""")
+
+if __name__=="__main__":
+    main()

--- a/scripts/probe_vol.py
+++ b/scripts/probe_vol.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Probe : SEARCH_VOLUME varie-t-il par mois dans le modèle #48633 ? (pour décider l'ajout volume au pivot inversé)"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; MODEL=48633
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex: print("retry",repr(ex)[:80],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def fr(n,bt): return ["field",n,{"base-type":bt}]
+
+def main():
+    mb=connect(); print("connected",flush=True)
+    q={"database":DB,"type":"query","query":{"source-table":f"card__{MODEL}",
+        "fields":[fr("MARCHE","type/Text"),fr("KEYWORD","type/Text"),fr("MONTH_DATE","type/Date"),fr("SEARCH_VOLUME","type/Float")],
+        "filter":["or",["=",fr("KEYWORD","type/Text"),"french manucure"],["=",fr("KEYWORD","type/Text"),"gel polish"]],
+        "order-by":[["asc",fr("KEYWORD","type/Text")],["asc",fr("MONTH_DATE","type/Date")]]}}
+    j=mb.post("/api/dataset","raw",json=q,timeout=240).json()
+    if j.get("error"): print("ERR",str(j["error"])[:300],flush=True); return
+    cols=[c["name"] for c in j["data"]["cols"]]
+    print("cols:",cols,flush=True)
+    for r in j["data"]["rows"]:
+        print("  ",r,flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/render_antipattern_report.py
+++ b/scripts/render_antipattern_report.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Synthèse finale de l'audit 2 anti-patterns SQL : digest md + JSON exhaustif.
+
+Reclasse B de façon déterministe (backslash simple = BUG, backslash double = OK,
+prouvé empiriquement sur Snowflake) ; conserve les verdicts A (vérif 3 lentilles).
+"""
+from __future__ import annotations
+
+import glob
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MIG = ROOT / "migration"
+DOCS = ROOT / "docs" / "audits"
+
+META = re.compile(r"(\\+)([.?+(){}\[\]|^$*])")              # runs de backslash avant un méta-char
+SINGLE_FIX = re.compile(r"(?<!\\)\\([.?+(){}\[\]|^$*])")    # backslash simple -> [char]
+# littéraux de pattern dans un REGEXP_* (1er ou 2e argument string)
+LITERAL = re.compile(r"'((?:[^'\\]|\\.)*)'")
+
+
+def escape_profile(sql: str):
+    single, double = set(), set()
+    for m in META.finditer(sql):
+        (single if len(m.group(1)) % 2 else double).add(m.group(2))
+    return single, double
+
+
+def b_fixes(sql: str):
+    """Retourne [(find, replace)] pour chaque littéral contenant un backslash simple+méta."""
+    out, seen = [], set()
+    # cible les littéraux situés dans un appel REGEXP_*
+    for call in re.finditer(r"(REGEXP_REPLACE|REGEXP_LIKE|REGEXP_SUBSTR|REGEXP_COUNT|RLIKE)\s*\(", sql, re.I):
+        seg = sql[call.start():call.start() + 600]
+        for lit in LITERAL.finditer(seg):
+            pat = lit.group(1)
+            s, _ = escape_profile(pat)
+            if s and pat not in seen:
+                seen.add(pat)
+                fixed = SINGLE_FIX.sub(r"[\1]", pat)
+                out.append((f"'{pat}'", f"'{fixed}'"))
+    return out
+
+
+def load():
+    res = json.load(open(MIG / "antipattern-audit-results.json"))["results"]
+    cand = json.load(open(sorted(glob.glob(str(MIG / "sql-antipattern-candidates-*.json")))[-1]))
+    emp = json.load(open(MIG / "antipattern-empirical.json"))
+    by_id = {}
+    for k in ("a_candidates", "b_candidates"):
+        for c in cand[k]:
+            by_id.setdefault(c["id"], c)  # garde la 1re (a_candidates en priorité ok)
+    sql = {c["id"]: c["sql"] for k in ("a_candidates", "b_candidates") for c in cand[k]}
+    nm = {c["id"]: c["name"] for k in ("a_candidates", "b_candidates") for c in cand[k]}
+    dash = {c["id"]: (c.get("dashboards") or []) for k in ("a_candidates", "b_candidates") for c in cand[k]}
+    return res, sql, nm, dash, emp
+
+
+def reclassify(res, sql):
+    """Ajoute corrected/severity/fixes à chaque résultat."""
+    for r in res:
+        a = r.get("analysis") or {}
+        cid = r["card_id"]
+        if r["antipattern"] == "A":
+            r["corrected"] = r.get("final_verdict", "ERROR")
+            r["severity"] = "haute" if r["corrected"] == "BUG" else ("à trancher" if r["corrected"] == "REVIEW" else "—")
+            r["fixes"] = [(a["fix_find"], a["fix_replace"])] if r["corrected"] == "BUG" and a.get("fix_find") else []
+        else:  # B — règle déterministe
+            single, double = escape_profile(sql.get(cid, ""))
+            if single:
+                r["corrected"] = "BUG"
+                r["fixes"] = b_fixes(sql.get(cid, ""))
+                # gravité : la colonne fautive est-elle réellement consommée ?
+                txt = sql.get(cid, "")
+                alias_used = bool(re.search(r"AS\s+client_domain", txt, re.I)) and txt.lower().count("client_domain") > 1
+                alias_used = alias_used or (re.search(r"AS\s+domain\b", txt, re.I) and txt.lower().count(" domain") > 2)
+                if cid == 14908:
+                    r["severity"] = "haute (domaine affiché, 17 dashboards)"
+                elif single == {"|"}:
+                    r["severity"] = "interne (cartes d'audit, 0 dashboard)"
+                elif alias_used:
+                    r["severity"] = "moyenne (colonne domaine consommée)"
+                else:
+                    r["severity"] = "latente (regex faux mais colonne non affichée)"
+            else:
+                r["corrected"] = "OK"
+                r["severity"] = "—"
+                r["fixes"] = []
+                r["ok_reason"] = "backslash double = échappement correct (vérifié empiriquement)"
+    return res
+
+
+def fmt_dash(dl, n):
+    if not dl:
+        return "0 dashboard"
+    names = [f'{d["name"]}(#{d["id"]})' for d in dl[:n]]
+    return "; ".join(names) + (f" +{len(dl)-n}" if len(dl) > n else "")
+
+
+def main():
+    res, sql, nm, dash, emp = load()
+    res = reclassify(res, sql)
+    date = datetime.now().strftime("%Y-%m-%d")
+
+    buckets = {"BUG": [], "REVIEW": [], "OK": [], "ERROR": []}
+    for r in res:
+        buckets[r["corrected"]].append(r)
+
+    def sk(r):
+        sev_order = {"haute": 0, "haute (domaine affiché, 17 dashboards)": 0, "moyenne (colonne domaine consommée)": 1,
+                     "latente (regex faux mais colonne non affichée)": 2, "interne (cartes d'audit, 0 dashboard)": 3}
+        return (0 if r["antipattern"] == "A" else 1, sev_order.get(r.get("severity"), 5), r["card_id"])
+
+    # ---------- JSON exhaustif ----------
+    full = {"generated": date, "empirical": emp,
+            "counts": {k: len(v) for k, v in buckets.items()},
+            "results": res}
+    full_path = MIG / f"antipattern-audit-full-{date}.json"
+    full_path.write_text(json.dumps(full, indent=2, ensure_ascii=False))
+
+    # ---------- digest md ----------
+    L = []
+    L.append(f"# Audit anti-patterns SQL Metabase — {date}\n")
+    L.append("Lecture seule, **aucune carte modifiée**. Scan de toutes les questions natives de "
+             "l'instance pour deux anti-patterns, puis vérification adversariale et confirmation "
+             "empirique sur Snowflake.\n")
+    L.append("- **A** — JOIN sur `kp__keyword_*` sans `language`/`zone` → produit cartésien (volumes gonflés, clients multi-zones).")
+    L.append("- **B** — backslash simple `\\.` devant un méta-char dans un REGEXP Snowflake → l'échappement est mangé.\n")
+
+    er = emp["regex_escape_proof"]
+    L.append("## Méthode & preuves empiriques (Snowflake, lecture seule)\n")
+    zones = ", ".join(dict.fromkeys(z["zone"] for z in emp["zones"]))
+    L.append(f"**A — inflation mesurée** · client `{emp['client']}` (multi-zones : {zones}), "
+             f"mois {emp['month']} :")
+    L.append(f"join bogué (keyword seul) = **{emp['buggy_join_keyword_only']:,}** vs corrigé "
+             f"(keyword+language+zone) = **{emp['fixed_join_keyword_language_zone']:,}** → "
+             f"**×{emp['inflation_factor']:.2f} (+{emp['inflation_pct']:.0f} %)**. "
+             f"Grain kp = 1 ligne/(keyword,language,zone,mois) → le fix language+zone est complet.\n")
+    L.append(f"**B — {er['instance_rule']}** Tests :\n")
+    L.append("| pattern SQL | entrée | résultat | verdict |")
+    L.append("|---|---|---|---|")
+    for t in er["tests"]:
+        L.append(f'| `{t["sql_pattern"]}` | `{t["input"]}` | `{t["result"]}` | {t["verdict"]} |')
+    L.append("\n→ Conséquence : un backslash **simple** est un vrai bug ; un backslash **double** "
+             "(`\\\\.`) ou une classe `[.]` sont corrects. La reclassification B ci-dessous est "
+             "déterministe sur ce critère.\n")
+
+    L.append("## Compte\n")
+    L.append(f"- **{len(res)}** cartes analysées (5 367 scannées, 5 068 natives, 100 % SQL extrait).")
+    L.append(f"- **{len(buckets['BUG'])} BUG** à corriger · **{len(buckets['REVIEW'])} REVIEW** à trancher · "
+             f"**{len(buckets['OK'])} OK**.")
+    nb_a_bug = sum(1 for r in buckets['BUG'] if r['antipattern'] == 'A')
+    nb_b_bug = len(buckets['BUG']) - nb_a_bug
+    L.append(f"  - BUG : {nb_a_bug} en A (cartésien), {nb_b_bug} en B (regex).")
+    L.append("- 226 cartes avec REGEXP sans backslash suspect : écartées (probable OK), non analysées une à une.\n")
+
+    # ---- A bugs ----
+    L.append("## A — BUG cartésien (correctif : ajouter language + zone à l'ON)\n")
+    for r in sorted([x for x in buckets["BUG"] if x["antipattern"] == "A"], key=sk):
+        a = r["analysis"]
+        L.append(f'### #{r["card_id"]} — {nm[r["card_id"]]}')
+        L.append(f'Dashboards : {fmt_dash(dash[r["card_id"]], 6)}')
+        if a.get("inflation_note"):
+            L.append(f'Impact : {a["inflation_note"][:280]}')
+        for find, repl in r["fixes"]:
+            L.append("\n**Find :**\n```sql\n" + (find or "").strip() + "\n```")
+            L.append("**Replace :**\n```sql\n" + (repl or "").strip() + "\n```")
+        L.append("")
+
+    # ---- B bugs ----
+    L.append("## B — BUG regex (backslash simple mangé)\n")
+    for r in sorted([x for x in buckets["BUG"] if x["antipattern"] == "B"], key=sk):
+        L.append(f'### #{r["card_id"]} — {nm[r["card_id"]]}  _(gravité : {r["severity"]})_')
+        L.append(f'Dashboards : {fmt_dash(dash[r["card_id"]], 6)}')
+        for find, repl in r["fixes"]:
+            L.append("\n**Find :**\n```\n" + find + "\n```")
+            L.append("**Replace :**\n```\n" + repl + "\n```")
+        L.append("")
+
+    # ---- REVIEW ----
+    L.append("## REVIEW — à trancher\n")
+    for r in sorted(buckets["REVIEW"], key=sk):
+        a = r.get("analysis") or {}
+        q = a.get("review_question") or (a.get("reasoning") or "")[:200]
+        L.append(f'- **#{r["card_id"]}** {nm[r["card_id"]]} ({r["antipattern"]}) — {q}')
+    L.append("")
+
+    # ---- OK (B double-backslash) compacted ----
+    okb = [r for r in buckets["OK"] if r["antipattern"] == "B"]
+    if okb:
+        L.append("## OK confirmés — B backslash double (aucune action)\n")
+        L.append(", ".join(f'#{r["card_id"]}' for r in sorted(okb, key=lambda r: r["card_id"])))
+        L.append("")
+
+    L.append(f"\n_Détail complet (extraits, raisonnements, votes de vérification) : "
+             f"`{full_path.relative_to(ROOT)}`_")
+
+    DOCS.mkdir(parents=True, exist_ok=True)
+    md_path = DOCS / f"sql-antipatterns-{date}.md"
+    md_path.write_text("\n".join(L))
+    print("Digest :", md_path)
+    print("Détail :", full_path)
+    print(f"BUG={len(buckets['BUG'])} (A={nb_a_bug} B={nb_b_bug}) "
+          f"REVIEW={len(buckets['REVIEW'])} OK={len(buckets['OK'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seo_collapse_fix.py
+++ b/scripts/seo_collapse_fix.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Applique le retour Loom Manucurist (dashboard #25137) :
+1) TOGGLE DE PLIAGE par Marché sur POSITIONS #48634 + SAISONNALITE #49426
+   -> pivot.show_column_totals=True  (sous-total de groupe = porte le +/-),
+      pivot.show_row_totals=False     (pas de colonne 'Row totals' across-mois superflue).
+   PUT visualization_settings SEULEMENT -> ne touche pas dataset_query (préserve MLv2 + result_metadata).
+2) RETRAIT des liens Metabase #13489 (cassés hors embed -> mur de login) de la text card Saisonnalité.
+Backups préalables: scripts/seo_collapse_probe.py (migration/*-backup-*.json).
+"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DASH=25137; GRID=48634; SAIS=49426; HTTP_TIMEOUT=300
+SAIS_DASHCARD=131700
+NEW_TEXT=("### 🗓️ Saisonnalité\n"
+          "Volume de recherche mensuel par mot-clé sur les **24 derniers mois** "
+          "(source : Google Keyword Planner).")
+DC_FIELDS=("id","card_id","dashboard_tab_id","row","col","size_x","size_y",
+           "series","parameter_mappings","visualization_settings")
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:", repr(ex)[:120]); time.sleep(8)
+    sys.exit("conn failed")
+
+def enable_toggle(mb,cid,label):
+    c=mb.get(f"/api/card/{cid}")
+    viz=dict(c.get("visualization_settings") or {})
+    before=(viz.get("pivot.show_row_totals"),viz.get("pivot.show_column_totals"))
+    viz["pivot.show_column_totals"]=True
+    viz["pivot.show_row_totals"]=False
+    r=mb.put(f"/api/card/{cid}","raw",json={"visualization_settings":viz},timeout=HTTP_TIMEOUT)
+    print(f"  PUT {label} #{cid}: {getattr(r,'status_code','?')} | (row,col) {before} -> (False, True)")
+
+def main():
+    mb=connect(); print("connected")
+    print("--- 1) toggle de pliage ---")
+    enable_toggle(mb,GRID,"POSITIONS")
+    enable_toggle(mb,SAIS,"SAISONNALITE")
+
+    print("--- 2) retrait liens #13489 ---")
+    d=mb.get(f"/api/dashboard/{DASH}")
+    dcs=d.get("dashcards") or []
+    out=[]; edited=False
+    for dc in dcs:
+        nd={k:dc.get(k) for k in DC_FIELDS if k in dc}
+        if dc.get("id")==SAIS_DASHCARD:
+            vs=dict(dc.get("visualization_settings") or {})
+            assert "13489" in (vs.get("text") or ""), "text card saiso inattendue (pas de 13489)"
+            vs["text"]=NEW_TEXT; nd["visualization_settings"]=vs; edited=True
+        out.append(nd)
+    assert edited, "dashcard saiso introuvable"
+    body={"parameters":d.get("parameters") or [], "dashcards":out}
+    if d.get("tabs"): body["tabs"]=d["tabs"]
+    r=mb.put(f"/api/dashboard/{DASH}","raw",json=body,timeout=HTTP_TIMEOUT)
+    bb=r.json() if hasattr(r,"json") else r
+    n=len(bb.get("dashcards") or []) if isinstance(bb,dict) else "?"
+    print(f"  PUT dashboard #{DASH}: {getattr(r,'status_code','?')} | dashcards {n}/{len(dcs)}")
+
+    print("--- 3) vérification post-PUT (re-GET) ---")
+    okc=True
+    for cid,label in [(GRID,"POSITIONS"),(SAIS,"SAISONNALITE")]:
+        v=mb.get(f"/api/card/{cid}").get("visualization_settings") or {}
+        cok = v.get("pivot.show_column_totals") is True and v.get("pivot.show_row_totals") is False
+        okc &= cok
+        print(f"  {label} #{cid}: show_column_totals={v.get('pivot.show_column_totals')} show_row_totals={v.get('pivot.show_row_totals')} {'OK' if cok else 'KO'}")
+    dd=mb.get(f"/api/dashboard/{DASH}")
+    txt=next((dc.get("visualization_settings",{}).get("text","") for dc in (dd.get("dashcards") or []) if dc.get("id")==SAIS_DASHCARD),"")
+    link_gone = "13489" not in txt and "metabaseapp.com" not in txt
+    print(f"  text card saiso: liens #13489 retirés={link_gone}")
+    print(f"  TEXTE FINAL:\n----\n{txt}\n----")
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> {'TOUT OK' if (okc and link_gone) else '⚠️ VERIF INCOMPLETE'}  {dom}/dashboard/{DASH}")
+
+if __name__=="__main__":
+    main()

--- a/scripts/seo_collapse_probe.py
+++ b/scripts/seo_collapse_probe.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Probe + backup pour le fix 'toggle de pliage' (Loom Manucurist) :
+- compare les réglages pivot des 3 grilles : POSITIONS #48634 / SAISONNALITE #49426 (sans toggle)
+  vs PAGES #49063 (qui A le toggle) -> isole le réglage qui pilote le +/-.
+- trouve la text card des liens #13489 sur le dashboard #25137 + détecte les onglets.
+- sauvegarde les JSON complets (cartes + dashboard) dans migration/ pour rollback.
+Lecture seule côté Metabase (GET uniquement).
+"""
+from __future__ import annotations
+import json, sys, time
+from datetime import datetime
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DASH=25137; GRID=48634; SAIS=49426; PAGES=49063
+BK = ROOT/"migration"; BK.mkdir(exist_ok=True)
+TS = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:", repr(ex)[:120]); time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected")
+    for cid,label in [(GRID,"POSITIONS #48634"),(SAIS,"SAISONNALITE #49426"),(PAGES,"PAGES #49063 (A le toggle)")]:
+        c=mb.get(f"/api/card/{cid}")
+        (BK/f"card-{cid}-backup-{TS}.json").write_text(json.dumps(c,ensure_ascii=False,indent=2))
+        viz=c.get("visualization_settings") or {}
+        piv=[k for k in viz if k.startswith("pivot")]
+        print(f"\n=== {label} ===")
+        print("  display                 :", c.get("display"))
+        print("  pivot.show_row_totals   :", viz.get("pivot.show_row_totals"))
+        print("  pivot.show_column_totals:", viz.get("pivot.show_column_totals"))
+        print("  pivot_table.collapsed_rows:", viz.get("pivot_table.collapsed_rows"))
+        print("  toutes clés pivot*      :", piv)
+    d=mb.get(f"/api/dashboard/{DASH}")
+    (BK/f"dashboard-{DASH}-backup-{TS}.json").write_text(json.dumps(d,ensure_ascii=False,indent=2))
+    tabs=d.get("tabs") or d.get("ordered_tabs")
+    print(f"\n=== DASHBOARD #{DASH} ===")
+    print("  tabs:", "AUCUN" if not tabs else f"{len(tabs)} -> {[t.get('name') for t in tabs]}")
+    dcs=d.get("dashcards") or d.get("ordered_cards") or []
+    print("  dashcards:", len(dcs))
+    for dc in dcs:
+        vs=dc.get("visualization_settings") or {}
+        t=vs.get("text") or ""
+        if "13489" in t:
+            print("  >> SAISO TEXT CARD dashcard_id:", dc.get("id"), "| card_id:", dc.get("card_id"))
+            print("  >> TEXTE ACTUEL:\n----\n"+t+"\n----")
+    print("\nBackups TS:", TS, "->", BK)
+
+if __name__=="__main__":
+    main()

--- a/scripts/seo_perf_probe.py
+++ b/scripts/seo_perf_probe.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Diagnostic perf dashboard SEO Manucurist #25137 :
+- état RÉEL de la persistance (réglage global + PersistedInfo par modèle)
+- timing à froid des requêtes (POST /api/card/{id}/query) pour localiser la lenteur.
+Lecture seule (GET + .../query exécute mais ne modifie aucun objet).
+"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+MODELS={48633:"Positions (SERP+GSC)",49062:"Pages (GSC 27M)",49425:"Saisonnalite (kp)"}
+HEAVY ={48634:"Grille positions",49063:"Pivot pages"}
+TMO=420
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected\n",flush=True)
+    # 1) réglage global de persistance
+    try: print("setting persisted-models-enabled =", mb.get("/api/setting/persisted-models-enabled"),flush=True)
+    except Exception as ex: print("setting persisted-models-enabled:",repr(ex)[:90],flush=True)
+    # 2) état persistance par modèle
+    print("\n--- persistance par modèle ---",flush=True)
+    pmap={}
+    try:
+        pj=mb.get("/api/persist")
+        items=pj.get("data") if isinstance(pj,dict) else pj
+        if isinstance(items,list): pmap={it.get("card_id"):it for it in items}
+    except Exception as ex:
+        print("  /api/persist indispo:",repr(ex)[:90],flush=True)
+    for mid,lbl in MODELS.items():
+        it=pmap.get(mid)
+        if it:
+            print(f"  #{mid} {lbl}: state={it.get('state')} active={it.get('active')} "
+                  f"refresh_end={it.get('refresh_end')} error={str(it.get('error'))[:60]}",flush=True)
+        else:
+            c=mb.get(f"/api/card/{mid}")
+            print(f"  #{mid} {lbl}: PAS de PersistedInfo | champ card.persisted={c.get('persisted')}",flush=True)
+    # 3) timing à froid
+    print("\n--- timing (POST /api/card/{id}/query, sans filtre = pire cas) ---",flush=True)
+    for cid,lbl in {**MODELS,**HEAVY}.items():
+        t0=time.monotonic()
+        try:
+            r=mb.post(f"/api/card/{cid}/query","raw",json={},timeout=TMO)
+            j=r.json() if hasattr(r,"json") else {}
+            err=j.get("error") if isinstance(j,dict) else None
+            n=len(j.get("data",{}).get("rows",[])) if isinstance(j,dict) and not err else "?"
+            print(f"  #{cid:5d} {lbl:20s}: {time.monotonic()-t0:6.1f}s  rows={n}  {('ERR '+str(err)[:50]) if err else ''}",flush=True)
+        except Exception as ex:
+            print(f"  #{cid:5d} {lbl:20s}: {time.monotonic()-t0:6.1f}s  EXC {repr(ex)[:60]}",flush=True)
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/seo_persist_apply.py
+++ b/scripts/seo_persist_apply.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Active la persistance des 3 modèles SEO Manucurist + cron de refresh quotidien 9h.
+- lit report-timezone + cron actuel (propre, via /api/setting liste)
+- POST /api/card/{id}/persist pour 48633 / 49062 / 49425 (matérialise + refresh planifié)
+- PUT cron persisted-model-refresh-cron-schedule = quotidien 09:00 (Quartz)
+- poll /api/persist jusqu'à state=persisted (ou timeout)
+Réversible : POST /api/card/{id}/unpersist.
+"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+MODELS={48633:"Positions",49062:"Pages",49425:"Saisonnalite"}
+NEW_CRON="0 0 9 * * ? *"   # tous les jours à 09:00 (fuseau instance)
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def getset(allset,k):
+    for s in allset:
+        if s.get("key")==k: return s.get("value")
+    return None
+
+def persist_state(mb):
+    pj=mb.get("/api/persist"); items=pj.get("data") if isinstance(pj,dict) else pj
+    return {it.get("card_id"):it for it in (items or []) if it.get("card_id") in MODELS}
+
+def main():
+    mb=connect(); print("connected\n",flush=True)
+    allset=mb.get("/api/setting")
+    tz=getset(allset,"report-timezone"); cur=getset(allset,"persisted-model-refresh-cron-schedule")
+    print(f"  report-timezone (avant) = {tz!r}",flush=True)
+    print(f"  cron persistance (avant) = {cur!r}\n",flush=True)
+
+    print("--- activation persistance des 3 modèles ---",flush=True)
+    for mid,lbl in MODELS.items():
+        try:
+            r=mb.post(f"/api/card/{mid}/persist","raw",json={},timeout=120)
+            print(f"  persist #{mid} {lbl}: HTTP {getattr(r,'status_code','?')}",flush=True)
+        except Exception as ex:
+            print(f"  persist #{mid} {lbl}: EXC {repr(ex)[:80]}",flush=True)
+
+    print("\n[cron global NON modifié ici — réglage instance partagé, décision séparée]",flush=True)
+
+    print("\n--- poll matérialisation (max ~4 min) ---",flush=True)
+    deadline=time.monotonic()+240
+    while time.monotonic()<deadline:
+        st=persist_state(mb)
+        line=" | ".join(f"#{mid}:{st.get(mid,{}).get('state')}" for mid in MODELS)
+        print(f"  [{int(time.monotonic()%100000):05d}] {line}",flush=True)
+        if st and all((st.get(mid,{}).get("state")=="persisted") for mid in MODELS):
+            print("  -> tous persistés ✅",flush=True); break
+        if any((st.get(mid,{}).get("state")=="error") for mid in MODELS):
+            print("  -> ⚠️ au moins un en ERROR",flush=True)
+            for mid in MODELS:
+                e=st.get(mid,{}).get("error")
+                if e: print(f"     #{mid} error: {str(e)[:200]}",flush=True)
+            break
+        time.sleep(12)
+
+    allset2=mb.get("/api/setting")
+    print(f"\n  cron persistance (après) = {getset(allset2,'persisted-model-refresh-cron-schedule')!r}",flush=True)
+    st=persist_state(mb)
+    for mid,lbl in MODELS.items():
+        it=st.get(mid,{})
+        print(f"  #{mid} {lbl}: state={it.get('state')} active={it.get('active')} refresh_end={it.get('refresh_end')}",flush=True)
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/seo_persist_debug.py
+++ b/scripts/seo_persist_debug.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Debug endpoints persistance : version, droits, structure /api/setting, corps du 404 persist."""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected\n",flush=True)
+    me=mb.get("/api/user/current")
+    print("superuser =",me.get("is_superuser"),"| email =",me.get("email"),flush=True)
+    try:
+        props=mb.get("/api/session/properties")
+        v=props.get("version") if isinstance(props,dict) else None
+        print("version =", (v.get("tag") if isinstance(v,dict) else v),flush=True)
+    except Exception as ex: print("version: ",repr(ex)[:90],flush=True)
+
+    print("\n--- /api/setting structure ---",flush=True)
+    allset=mb.get("/api/setting")
+    print("type:",type(allset).__name__,"| len:",len(allset) if hasattr(allset,"__len__") else "?",flush=True)
+    if isinstance(allset,list):
+        for s in allset:
+            if s.get("key") in ("report-timezone","persisted-models-enabled","persisted-model-refresh-cron-schedule","persisted-model-refresh-anchor-time"):
+                print(f"  {s.get('key')} = {s.get('value')!r} (default={s.get('default')!r})",flush=True)
+
+    print("\n--- test POST /api/card/48633/persist (corps réponse) ---",flush=True)
+    r=mb.post("/api/card/48633/persist","raw",json={},timeout=60)
+    print(f"  -> {getattr(r,'status_code','?')} | {getattr(r,'text','')[:300]}",flush=True)
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/seo_persist_probe.py
+++ b/scripts/seo_persist_probe.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Probe config persistance Metabase avant d'activer (lecture seule).
+- réglage global + cron de refresh actuel + fuseau
+- liste des modèles déjà persistés instance-wide (pour savoir si un cron global impacte d'autres projets)
+- état persistance DB 144
+"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected\n",flush=True)
+    for s in ["persisted-models-enabled","persisted-model-refresh-cron-schedule","report-timezone","instance-creation"]:
+        try: print(f"  {s} = {mb.get(f'/api/setting/{s}')!r}",flush=True)
+        except Exception as ex: print(f"  {s}: {repr(ex)[:80]}",flush=True)
+    print("\n--- modèles persistés instance-wide (/api/persist) ---",flush=True)
+    try:
+        pj=mb.get("/api/persist")
+        items=pj.get("data") if isinstance(pj,dict) else pj
+        if isinstance(items,list):
+            print(f"  total = {len(items)}",flush=True)
+            for it in items:
+                print(f"  card_id={it.get('card_id')} db={it.get('database_id')} state={it.get('state')} "
+                      f"active={it.get('active')} name={it.get('card_name')!r} schema={it.get('table_name')}",flush=True)
+        else:
+            print("  réponse:",str(pj)[:300],flush=True)
+    except Exception as ex:
+        print("  /api/persist:",repr(ex)[:120],flush=True)
+    print("\n--- DB 144 ---",flush=True)
+    try:
+        db=mb.get("/api/database/144")
+        print("  name:",db.get("name"),"| settings:",db.get("settings"),flush=True)
+    except Exception as ex:
+        print("  /api/database/144:",repr(ex)[:120],flush=True)
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/seo_persist_routes.py
+++ b/scripts/seo_persist_routes.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Cartographie des routes de persistance réelles (Metabase v62).
+Lectures + candidates d'activation pour la carte 48633 (persist = action voulue ; unpersist = no-op car déjà off)."""
+from __future__ import annotations
+import sys, time, json
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex:
+            print("retry connect:",repr(ex)[:100],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def main():
+    mb=connect(); print("connected | domain=",repr(mb.domain),"\n",flush=True)
+    pj=mb.get("/api/persist"); items=pj.get("data") if isinstance(pj,dict) else pj
+    pinfo=next((it for it in items if it.get("card_id")==48633), None)
+    pid=pinfo.get("id") if pinfo else None
+    print("PersistedInfo #48633: id=",pid," | champs=",sorted(pinfo.keys()) if pinfo else None,flush=True)
+    if pinfo: print("  contenu:", json.dumps({k:pinfo.get(k) for k in pinfo}, default=str)[:500],flush=True)
+
+    def T(verb,path,**kw):
+        fn=mb.post if verb=="POST" else (mb.put if verb=="PUT" else mb.get)
+        try:
+            r=fn(path,"raw",timeout=60,**kw)
+            print(f"  {verb:4s} {path} -> {getattr(r,'status_code','?')} | {getattr(r,'text','')[:120]}",flush=True)
+        except Exception as ex:
+            print(f"  {verb:4s} {path} -> EXC {repr(ex)[:90]}",flush=True)
+
+    print("\n-- lectures (cartographie namespace) --",flush=True)
+    if pid is not None: T("GET", f"/api/persist/{pid}")
+    T("GET", "/api/persist/card/48633")
+
+    print("\n-- candidates d'activation (persist=voulu / unpersist=no-op) --",flush=True)
+    T("POST", "/api/card/48633/unpersist", json={})
+    T("POST", "/api/persist/card/48633", json={})
+    if pid is not None:
+        T("POST", f"/api/persist/{pid}/refresh", json={})
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/serp_difftest.py
+++ b/scripts/serp_difftest.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Test différentiel #32496 : requête ACTUELLE vs NETTOYÉE, mêmes filtres Manucurist.
+
+But : prouver que le nettoyage (suppression CTE/jointure ctr_scenario + code mort)
+- RÉCUPÈRE les cellules (mot-clé × date) où la meilleure position client > 100
+  (silencieusement droppées aujourd'hui par le INNER JOIN ctr_scenario),
+- ne supprime RIEN d'autre,
+- ne change AUCUNE valeur sur les cellules communes.
+
+Lecture seule. Usage: python3 scripts/serp_difftest.py
+"""
+from __future__ import annotations
+import json, sys, time, glob
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+import spark_metabase_api.main_methods as MM
+MM.DEFAULT_TIMEOUT = 180
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+CLIENT = "Manucurist"
+DATE_WINDOW_DAYS = 120
+HTTP_TIMEOUT = 240
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current"); return mb
+        except Exception as ex:
+            print(f"  retry {a+1}: {type(ex).__name__}"); time.sleep(6)
+    sys.exit("conn failed")
+
+def run(mb, sql):
+    r=mb.post("/api/dataset","raw",json={"database":144,"type":"native","native":{"query":sql}},timeout=HTTP_TIMEOUT)
+    j=r.json() if hasattr(r,"json") else r
+    if j.get("error"):
+        print("  SQL ERROR:", str(j.get("error"))[:500]); return None, None
+    dd=j.get("data",{}); return [c.get("name") for c in dd.get("cols",[])], dd.get("rows",[])
+
+# ---- substitutions communes (OLD et NEW reçoivent EXACTEMENT les mêmes) ----
+def subst_common(sql, corpus):
+    return sql
+
+def build_old(corpus):
+    bk=sorted(glob.glob(str(ROOT/"migration"/"card-32496-backup-*.json")))[-1]
+    d=json.loads(Path(bk).read_text())
+    lq=d.get("legacy_query"); lq=json.loads(lq) if isinstance(lq,str) else lq
+    sql=lq["native"]["query"]
+    sql=sql.replace("[[AND {{date}}]]", f"AND date >= DATEADD('day',-{DATE_WINDOW_DAYS},CURRENT_DATE)")
+    sql=sql.replace("{{client}}", f"(utils.clients.name = '{CLIENT}')")
+    sql=sql.replace("{{corpus_name}}", f"(serp_requests.corpus_name = '{corpus}')")
+    sql=sql.replace("{{category}}", "1=1")
+    sql=sql.replace("[[AND {{time_period}}]]", "AND name = 'day'")
+    sql=sql.replace("{{ctr_scenario}}", "name = 'Default'")
+    sql=sql.replace("[[AND serp_requests.keyword ILIKE ('%' || {{pattern_keyword}} || '%')]]", "")
+    sql=sql.replace("[[AND serp_requests.keyword = {{exact_keyword}}]]", "")
+    # qualifier rn/url ambigus + dedup DÉTERMINISTE (meilleure position par url/run)
+    sql=sql.replace("url, rn ORDER BY request_date DESC",
+                    "serp__keyword_metrics.url, rr.rn ORDER BY rank_absolute")
+    return sql, bk
+
+NEW_TMPL = r"""
+WITH get_dates AS (
+  SELECT MIN(date) AS min_date_filter, MAX(date) AS max_date_filter
+  FROM utils.calendar
+  WHERE TRUE AND date >= DATEADD('day',-%DW%,CURRENT_DATE) AND date <= CURRENT_DATE
+),
+recent_runs AS (
+  SELECT client_id, corpus_name, run_date, rn FROM (
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY corpus_name, client_id ORDER BY run_date DESC) AS rn
+    FROM utils.clients
+      JOIN google_serp.serp_refresh_runs ON google_serp.serp_refresh_runs.client_id = utils.clients.id,
+      LATERAL (SELECT min_date_filter, max_date_filter FROM get_dates)
+    WHERE TRUE AND (utils.clients.name = '%CLIENT%')
+      AND run_date >= min_date_filter AND run_date <= max_date_filter
+  )
+),
+time_period AS (
+  SELECT name FROM metabase_filters.time_periods WHERE TRUE AND name = 'day'
+),
+get_current_data AS (
+  SELECT rr.rn, serp_requests.domain AS client_domain,
+    REGEXP_REPLACE(serp__keyword_metrics.domain, '^(www\.|app\.|mail\.|ftp\.|blog\.|shop\.|m\.|secure\.|dev\.|staging\.|api\.|portal\.|web\.|beta\.)', '', 1, 1, 'i') AS domain,
+    serp__keyword_metrics.keyword, serp__keyword_metrics.url, request_date, request_month,
+    CASE WHEN type = 'featured_snippet' AND rank_group = 1 THEN 0 ELSE rank_absolute END AS rank_absolute,
+    rank_group,
+    COALESCE(adjusted_avg_searches, avg_monthly_searches, 0) AS search_volume
+  FROM utils.clients
+    JOIN google_serp.serp_requests ON google_serp.serp_requests.client_id = utils.clients.id
+    JOIN google_serp.serp_history ON (serp_history.keyword = serp_requests.keyword AND serp_history.language = serp_requests.language AND serp_history.zone = serp_requests.zone)
+    JOIN google_serp.serp__keyword_metrics ON (serp__keyword_metrics.keyword = serp_history.keyword AND serp__keyword_metrics.language = serp_history.language AND serp__keyword_metrics.zone = serp_history.zone)
+    LEFT JOIN google_keyword_planner.kp__keyword_monthly_metrics ON (
+        kp__keyword_monthly_metrics.keyword = serp__keyword_metrics.keyword
+        AND kp__keyword_monthly_metrics.language = serp__keyword_metrics.language
+        AND kp__keyword_monthly_metrics.zone = serp__keyword_metrics.zone
+        AND kp__keyword_monthly_metrics.month = TO_VARCHAR(DATEADD('MONTH',
+              CASE WHEN EXTRACT(DAY FROM CURRENT_DATE()) >= 10 THEN -2 ELSE -3 END,
+              TO_DATE(serp__keyword_metrics.request_month || '-01','YYYY-MM-DD')), 'YYYY-MM'))
+    JOIN recent_runs AS rr ON (rr.client_id = serp_requests.client_id
+        AND rr.corpus_name = serp_requests.corpus_name
+        AND rr.run_date = serp__keyword_metrics.request_date)
+  WHERE TRUE AND (utils.clients.name = '%CLIENT%')
+    AND (serp_requests.corpus_name = '%CORPUS%') AND 1=1
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY serp_history.keyword, serp_history.language, serp_history.zone, serp__keyword_metrics.url, rr.rn ORDER BY rank_absolute) = 1
+),
+current_final AS (
+  SELECT keyword, request_date, search_volume, rank_absolute, rank_group, url
+  FROM get_current_data AS d
+  WHERE url ILIKE '%' || client_domain || '%'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY keyword, request_date ORDER BY rank_absolute) = 1
+),
+aggregated_positions AS (
+  SELECT d.keyword, tp.name AS period_type,
+    CASE tp.name WHEN 'aggregated' THEN NULL WHEN 'year' THEN DATE_TRUNC('YEAR',d.request_date)
+      WHEN 'month' THEN DATE_TRUNC('MONTH',d.request_date) WHEN 'week' THEN DATE_TRUNC('WEEK',d.request_date)
+      WHEN 'day' THEN DATE_TRUNC('DAY',d.request_date) END AS period_start,
+    AVG(d.search_volume) AS avg_search_volume,
+    AVG(d.rank_absolute) AS avg_rank_absolute,
+    AVG(d.rank_group)    AS avg_rank_group,
+    COUNT(*)             AS nb_observations
+  FROM current_final AS d CROSS JOIN time_period AS tp
+  WHERE d.request_date BETWEEN (SELECT min_date_filter FROM get_dates) AND (SELECT max_date_filter FROM get_dates)
+  GROUP BY d.keyword, tp.name,
+    CASE tp.name WHEN 'aggregated' THEN NULL WHEN 'year' THEN DATE_TRUNC('YEAR',d.request_date)
+      WHEN 'month' THEN DATE_TRUNC('MONTH',d.request_date) WHEN 'week' THEN DATE_TRUNC('WEEK',d.request_date)
+      WHEN 'day' THEN DATE_TRUNC('DAY',d.request_date) END
+)
+SELECT keyword,
+  CASE period_type WHEN 'aggregated' THEN 'aggregated' WHEN 'year' THEN TO_CHAR(period_start,'YYYY')
+    WHEN 'month' THEN TO_CHAR(period_start,'YYYY')||'-'||INITCAP(MONTHNAME(period_start))
+    WHEN 'week' THEN YEAROFWEEK(period_start)::VARCHAR||'-W'||LPAD(WEEKOFYEAR(period_start)::VARCHAR,2,'0')
+    WHEN 'day' THEN TO_CHAR(period_start,'YYYY-MM-DD') END AS periode_label,
+  avg_search_volume, avg_rank_absolute, avg_rank_group, nb_observations AS nb_points
+FROM aggregated_positions
+ORDER BY keyword, period_start DESC NULLS LAST
+"""
+
+def build_new(corpus):
+    return (NEW_TMPL.replace("%DW%", str(DATE_WINDOW_DAYS))
+                    .replace("%CLIENT%", CLIENT)
+                    .replace("%CORPUS%", corpus))
+
+def to_map(cols, rows):
+    ki, kl = cols.index("KEYWORD") if "KEYWORD" in cols else 0, cols.index("PERIODE_LABEL") if "PERIODE_LABEL" in cols else 1
+    ai = cols.index("AVG_RANK_ABSOLUTE") if "AVG_RANK_ABSOLUTE" in cols else 3
+    m={}
+    for r in rows:
+        m[(r[ki], r[kl])] = r[ai]
+    return m
+
+def main():
+    mb=connect(); print("connected")
+    # corpus exact
+    c,r=run(mb, f"""
+      SELECT DISTINCT corpus_name FROM google_serp.serp_requests sr
+      JOIN utils.clients c ON c.id=sr.client_id
+      WHERE c.name='{CLIENT}' AND corpus_name ILIKE '%transactionnel%' ORDER BY 1
+    """)
+    print("corpus transactionnels Manucurist:", r)
+    target="Corpus transactionnel FR - Mots clés stratégiques"
+    cands=[x[0] for x in r]
+    corpus = target if target in cands else (cands[0] if cands else target)
+    print("corpus retenu:", repr(corpus))
+
+    # --- la carte LIVE #32496 compile-t-elle ? (params Manucurist, fenêtre courte) ---
+    params=[
+      {"type":"string/=","value":["Manucurist"],"target":["dimension",["template-tag","client"]]},
+      {"type":"string/=","value":[corpus],"target":["dimension",["template-tag","corpus_name"]]},
+      {"type":"string/=","value":["day"],"target":["dimension",["template-tag","time_period"]]},
+      {"type":"string/=","value":["Default"],"target":["dimension",["template-tag","ctr_scenario"]]},
+      {"type":"date/all-options","value":"2026-03-01~2026-05-28","target":["dimension",["template-tag","date"]]},
+    ]
+    try:
+        rr=mb.post("/api/card/32496/query/json","raw",data={"parameters":json.dumps(params)},timeout=HTTP_TIMEOUT)
+        body=rr.json() if hasattr(rr,"json") else rr
+        if isinstance(body,dict) and body.get("error"):
+            print("  CARTE LIVE #32496 -> ERREUR:", str(body.get("error"))[:200])
+        elif isinstance(body,list):
+            print(f"  CARTE LIVE #32496 -> OK, {len(body)} lignes")
+        else:
+            print("  CARTE LIVE #32496 -> réponse:", str(body)[:200])
+    except Exception as ex:
+        print("  CARTE LIVE #32496 -> exception:", type(ex).__name__, str(ex)[:160])
+
+    print("\n... run OLD (actuel)"); co,ro=run(mb, build_old(corpus)[0])
+    if co is None: return
+    print("    OLD lignes:", len(ro))
+    print("... run NEW (nettoyé)"); cn,rn=run(mb, build_new(corpus))
+    if cn is None: return
+    print("    NEW lignes:", len(rn))
+
+    mo, mn = to_map(co,ro), to_map(cn,rn)
+    ko, kn = set(mo), set(mn)
+    new_only = kn-ko; old_only = ko-kn
+    common = ko & kn
+    diffs = [(k, mo[k], mn[k]) for k in common if mo[k]!=mn[k]]
+
+    print("\n========== RÉSULTAT DU DIFF ==========")
+    print(f"cellules (mot-clé × date)  OLD={len(ko)}  NEW={len(kn)}")
+    print(f"  RÉCUPÉRÉES par le fix (NEW only) : {len(new_only)}")
+    print(f"  perdues (OLD only, attendu 0)    : {len(old_only)}")
+    print(f"  communes valeurs différentes (attendu 0): {len(diffs)}")
+
+    if new_only:
+        vals=[mn[k] for k in new_only]
+        over100=sum(1 for v in vals if v is not None and v>100)
+        print(f"\n  parmi les récupérées : {over100}/{len(new_only)} ont position > 100 "
+              f"(min={min(vals)}, max={max(vals)})")
+        print("  exemples récupérés (mot-clé, date, position):")
+        for k in sorted(new_only)[:8]:
+            print(f"    {k[0][:45]:45}  {k[1]}  pos={mn[k]}")
+    if old_only:
+        print("\n  !! OLD only (régression?) exemples:", sorted(old_only)[:5])
+    if diffs:
+        print("\n  !! valeurs divergentes exemples:", diffs[:5])
+
+if __name__=="__main__":
+    main()

--- a/scripts/set_card_heights.py
+++ b/scripts/set_card_heights.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Règle explicitement la hauteur de cartes texte ciblées (par onglet + préfixe) + reflow.
+
+Ciblage robuste (insensible aux décalages de row) : (tab_name, text_prefix) -> new_h.
+Reflow : si une carte change de hauteur de delta, les cartes du même onglet situées
+dessous sont décalées de delta (remontée si shrink). Snapshot + réversible.
+
+Édite TARGETS puis :
+  python3 scripts/set_card_heights.py --dashboard 24576           # dry-run
+  python3 scripts/set_card_heights.py --dashboard 24576 --yes     # applique
+"""
+import argparse, json, sys, copy, requests
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+MIG = REPO / "migration"
+
+# (tab_name, text_prefix) -> nouvelle hauteur. Préfixes FR (24576) et EN (25467).
+TARGETS = [
+    # 2e passe de resserrage (retours utilisateur : encore du blanc)
+    ("Global", "Le nombre de joueurs", 3),
+    ("Global", "The player count is your center's", 3),
+    ("Global", "Le montant investi", 2),
+    ("Global", "The amount invested", 2),
+    ("SEO", "Combien de personnes trouvent", 2),
+    ("SEO", "How many people find", 2),
+    ("SEO", "Les tables suivantes", 3),
+    ("SEO", "The tables below rank", 3),
+]
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    d = mb.get(f"/api/dashboard/{args.dashboard}")
+    dcs = copy.deepcopy(d.get("dashcards") or [])
+    tabname = {t["id"]: t["name"] for t in (d.get("tabs") or [])}
+    orig_row = {dc["id"]: dc.get("row") for dc in dcs}
+
+    deltas = []  # (tab_id, boundary_row, delta)
+    for dc in dcs:
+        vs = dc.get("visualization_settings") or {}
+        if (vs.get("virtual_card") or {}).get("display") != "text":
+            continue
+        txt = (vs.get("text") or "").lstrip()
+        tab = tabname.get(dc.get("dashboard_tab_id"))
+        for ttab, prefix, new_h in TARGETS:
+            if tab == ttab and txt.startswith(prefix):
+                cur = dc.get("size_y")
+                if new_h != cur:
+                    print(f"[{tab}] row={dc['row']} h {cur} -> {new_h} | {txt[:42]!r}")
+                    deltas.append((dc["dashboard_tab_id"], dc["row"] + cur - 1, new_h - cur))
+                    dc["size_y"] = new_h
+                break
+
+    if not deltas:
+        print("Aucune cible matchée.")
+        return
+    for dc in dcs:
+        tab = dc.get("dashboard_tab_id")
+        shift = sum(delta for tb, b, delta in deltas if tb == tab and b < orig_row[dc["id"]])
+        dc["row"] += shift
+
+    if not args.yes:
+        print("\n(DRY-RUN.)"); return
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"setheights-snapshot-{args.dashboard}-{ts}.json").write_text(
+        json.dumps({"dashboard": args.dashboard, "dashcards": d.get("dashcards"), "tabs": d.get("tabs")}, ensure_ascii=False, indent=2))
+    payload = {"dashcards": dcs}
+    if d.get("tabs"):
+        payload["tabs"] = d["tabs"]
+    r = requests.put(mb.domain + f"/api/dashboard/{args.dashboard}", headers=mb.header, auth=mb.auth, json=payload, timeout=120)
+    print("PUT:", r.status_code); r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sql_antipattern_scan.py
+++ b/scripts/sql_antipattern_scan.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Inventaire + présélection pour l'audit de deux anti-patterns SQL (lecture seule).
+
+Anti-pattern A — JOIN sur tables kp__* sans (language, zone) => produit cartésien.
+Anti-pattern B — `\\.` (et autres méta-chars échappés d'un seul backslash) dans les
+                 REGEXP Snowflake : l'échappement est mangé, le point devient « . »
+                 (n'importe quel caractère).
+
+Source SQL : payload frais de GET /api/card/ (format MBQL nouveau -> stages[].native,
+puis fallback legacy_query). Aucune écriture (no PUT/POST/DELETE).
+
+Sortie : migration/sql-antipattern-candidates-<ts>.json
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+
+# --- Tables ciblées (présélection) ------------------------------------------
+KP_TABLES = ["kp__keyword_monthly_metrics", "kp__keyword_aggregated_metrics"]
+SERP_TABLES = ["serp__keyword_metrics", "serp_requests", "serp_history", "serp_refresh_runs"]
+PRESELECT_TABLES = KP_TABLES + SERP_TABLES
+
+REGEX_FUNCS = ["REGEXP_REPLACE", "REGEXP_LIKE", "REGEXP_SUBSTR", "REGEXP_COUNT",
+               "REGEXP_INSTR", "REGEXP", "RLIKE"]
+
+# méta-chars qui, échappés d'un seul backslash, sont des candidats au bug B
+_ESCAPED_META_RE = re.compile(r"\\[.?+(){}\[\]|^$*]")
+
+
+def extract_sql(card) -> str | None:
+    """SQL natif d'une carte, tolérant aux 3 formats rencontrés sur l'instance."""
+    dq = card.get("dataset_query") or {}
+    for st in (dq.get("stages") or []):           # format MBQL « stages »
+        nat = st.get("native")
+        if isinstance(nat, str) and nat.strip():
+            return nat
+    nat = dq.get("native") or {}                  # format natif classique
+    if isinstance(nat.get("query"), str) and nat["query"].strip():
+        return nat["query"]
+    lq = card.get("legacy_query")                 # legacy_query (string JSON)
+    if isinstance(lq, str):
+        try:
+            lq = json.loads(lq)
+        except Exception:
+            lq = None
+    if isinstance(lq, dict):
+        q = (lq.get("native") or {}).get("query")
+        if isinstance(q, str) and q.strip():
+            return q
+    return None
+
+
+def main():
+    env = _load_env()
+    mb = Metabase_API(domain=env["METABASE_DOMAIN"], email=env["METABASE_EMAIL"],
+                      password=env["METABASE_PASSWORD"])
+    cards = mb.get("/api/card/")
+    if cards is False or cards is None:
+        sys.exit("GET /api/card/ a échoué (auth/perm) — arrêt (garde-fou 401/403).")
+
+    n_total = len(cards)
+    natives = [c for c in cards if c.get("query_type") == "native" and not c.get("archived")]
+    n_native = len(natives)
+
+    no_sql = []           # natives dont on n'a pas pu extraire le SQL
+    a_candidates = []
+    b_candidates = []
+    regex_no_escape = []  # regex présent mais aucun méta-char échappé suspect (probable OK)
+
+    for c in natives:
+        sql = extract_sql(c)
+        if not sql:
+            no_sql.append({"id": c["id"], "name": c.get("name")})
+            continue
+        sql_l = sql.lower()
+        coll = c.get("collection") or {}
+        base = {
+            "id": c["id"],
+            "name": c.get("name"),
+            "collection_id": c.get("collection_id"),
+            "collection_name": coll.get("name") if isinstance(coll, dict) else None,
+            "collection_path": coll.get("effective_ancestors") if isinstance(coll, dict) else None,
+            "view_count": c.get("view_count") or 0,
+            "last_used_at": c.get("last_used_at"),
+            "updated_at": c.get("updated_at"),
+        }
+
+        # ---- Anti-pattern A : tables kp__* ----
+        kp_hits = [t for t in KP_TABLES if t.lower() in sql_l]
+        if kp_hits:
+            has_join = bool(re.search(r"\bjoin\b", sql_l))
+            has_airtable = "airtable_record_id" in sql_l
+            a_candidates.append({**base, "kp_tables": kp_hits, "has_join": has_join,
+                                 "mentions_airtable_record_id": has_airtable, "sql": sql})
+
+        # ---- Anti-pattern B : REGEXP + méta-char échappé ----
+        funcs = [f for f in ("REGEXP_REPLACE", "REGEXP_LIKE", "REGEXP_SUBSTR",
+                             "REGEXP_COUNT", "REGEXP_INSTR", "RLIKE") if f.lower() in sql_l]
+        # 'REGEXP(' générique sans capter les noms ci-dessus déjà comptés
+        if not funcs and re.search(r"\bregexp\s*\(", sql_l):
+            funcs = ["REGEXP"]
+        if funcs:
+            escapes = sorted(set(_ESCAPED_META_RE.findall(sql)))
+            if escapes:
+                b_candidates.append({**base, "regex_funcs": funcs,
+                                     "escaped_metachars": escapes, "sql": sql})
+            else:
+                regex_no_escape.append({"id": c["id"], "name": c.get("name"),
+                                        "regex_funcs": funcs})
+
+    # union présélectionnée (pour le compte « N présélectionnées »)
+    preselect_ids = {x["id"] for x in a_candidates} | {x["id"] for x in b_candidates}
+
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = MIGRATION_DIR / f"sql-antipattern-candidates-{ts}.json"
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    out.write_text(json.dumps({
+        "meta": {
+            "generated_at": ts,
+            "n_total_cards": n_total,
+            "n_native_active": n_native,
+            "n_native_no_sql": len(no_sql),
+            "n_preselected_union": len(preselect_ids),
+            "n_a_candidates": len(a_candidates),
+            "n_a_with_join": sum(1 for x in a_candidates if x["has_join"]),
+            "n_b_candidates": len(b_candidates),
+            "n_regex_present_no_suspicious_escape": len(regex_no_escape),
+        },
+        "a_candidates": a_candidates,
+        "b_candidates": b_candidates,
+        "regex_no_escape": regex_no_escape,
+        "native_no_sql": no_sql,
+    }, indent=2, ensure_ascii=False))
+
+    m = json.loads(out.read_text())["meta"]
+    print(json.dumps(m, indent=2, ensure_ascii=False))
+    print("\nÉcrit :", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/swap_card_on_dashboards.py
+++ b/scripts/swap_card_on_dashboards.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Remplace une carte `old` par sa canonique `new` sur TOUS ses dashboards, en
+recâblant les filtres, puis archive `old`. Réversible (snapshot des dashboards).
+
+Sécurité :
+- Découverte via GET /api/card/<old>/dashboards.
+- Garde-fous (swap_lib.swap_safety_check) : `new` non archivée, même base, même
+  empreinte fonctionnelle, et couvre TOUS les template-tags câblés vers `old`
+  (sinon un filtre casserait) — sinon on REFUSE le swap.
+- Avertit si `new` est déjà sur un dashboard de `old` (le repointage créerait une
+  tuile en double : préférer retirer la tuile `old`).
+- Snapshot des dashcards de chaque dashboard touché avant modification.
+- Dry-run par défaut ; `--difftest` compare les résultats des 2 requêtes.
+
+Usage :
+  python3 scripts/swap_card_on_dashboards.py --old 35896 --new 35862            # dry-run
+  python3 scripts/swap_card_on_dashboards.py --old 35896 --new 35862 --difftest
+  python3 scripts/swap_card_on_dashboards.py --old 35896 --new 35862 --yes      # applique + archive old
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from spark_metabase_api import Metabase_API  # noqa: E402
+from reorg_phase1 import _load_env  # noqa: E402
+import swap_lib  # noqa: E402
+
+MIGRATION_DIR = REPO_ROOT / "migration"
+
+
+def connect_resilient():
+    env = _load_env()
+    d, e, p = env.get("METABASE_DOMAIN"), env.get("METABASE_EMAIL"), env.get("METABASE_PASSWORD")
+    if not (d and e and p):
+        sys.exit("METABASE_DOMAIN / EMAIL / PASSWORD requis dans .env.")
+    return Metabase_API(domain=d, email=e, password=p)
+
+
+def _dashcards(dash):
+    return dash.get("dashcards") or dash.get("ordered_cards") or []
+
+
+def _difftest(mb, cid):
+    """Exécute la carte et retourne (nb lignes, nb colonnes) ou None."""
+    r = mb.post(f"/api/card/{cid}/query", json={})
+    if not isinstance(r, dict):
+        return None
+    data = r.get("data", {}) or {}
+    return (len(data.get("rows", []) or []), len(data.get("cols", []) or []))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--old", type=int, required=True, help="carte à retirer")
+    ap.add_argument("--new", type=int, required=True, help="carte canonique à garder")
+    ap.add_argument("--yes", action="store_true", help="applique (sinon dry-run)")
+    ap.add_argument("--difftest", action="store_true", help="exécute et compare les 2 requêtes")
+    args = ap.parse_args()
+
+    mb = connect_resilient()
+    old = mb.get(f"/api/card/{args.old}")
+    new = mb.get(f"/api/card/{args.new}")
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        sys.exit("Carte old/new introuvable.")
+    dashboards = mb.get(f"/api/card/{args.old}/dashboards") or []
+    print(f"old #{args.old} «{old.get('name')}» sur {len(dashboards)} dashboard(s)")
+    print(f"new #{args.new} «{new.get('name')}»")
+
+    # charge les dashboards + collecte les tags câblés vers old
+    dash_full, ref_tags = {}, set()
+    for d in dashboards:
+        full = mb.get(f"/api/dashboard/{d['id']}")
+        if isinstance(full, dict):
+            dash_full[d["id"]] = full
+            ref_tags |= swap_lib.referenced_template_tags(_dashcards(full), args.old)
+
+    problems = swap_lib.swap_safety_check(old, new, ref_tags)
+    if problems:
+        print("\n⛔ SWAP REFUSÉ :")
+        for p in problems:
+            print(f"   - {p}")
+        return
+    print(f"\n✅ garde-fous OK (filtres câblés : {sorted(ref_tags) or '—'})")
+
+    if args.difftest:
+        o, n = _difftest(mb, args.old), _difftest(mb, args.new)
+        verdict = "OK identique" if o == n and o is not None else "⚠️ DIFFÉRENT / échec"
+        print(f"  difftest (lignes,colonnes) : old={o} new={n} -> {verdict}")
+
+    # plan + détection tuile en double
+    plan, warnings, prepared = [], [], {}
+    for did, full in dash_full.items():
+        dcs = _dashcards(full)
+        new_dcs, nch = swap_lib.rewrite_dashcards(dcs, args.old, args.new)
+        prepared[did] = new_dcs
+        already = any(dc.get("card_id") == args.new for dc in dcs)
+        plan.append((did, full.get("name"), nch, already))
+        if already:
+            warnings.append(did)
+
+    print("\nPlan :")
+    for did, name, nch, already in plan:
+        flag = "  ⚠️ new déjà présent → tuile en double (préférer retirer la tuile old)" if already else ""
+        print(f"  dashboard #{did} «{str(name)[:38]}» : {nch} dashcard(s) repointé(s){flag}")
+
+    if not args.yes:
+        print("\n(DRY-RUN — rien modifié. --yes pour appliquer + archiver old.)")
+        return
+    if warnings:
+        print("\n⛔ Tuile en double détectée — j'arrête (résoudre manuellement / retirer la tuile old).")
+        return
+
+    MIGRATION_DIR.mkdir(exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    snap = MIGRATION_DIR / f"swap-snapshot-{args.old}-to-{args.new}-{ts}.json"
+    snap.write_text(json.dumps({str(did): {"name": f.get("name"), "dashcards": _dashcards(f)}
+                                for did, f in dash_full.items()}, ensure_ascii=False, indent=2))
+    print(f"\nSnapshot rollback : {snap}")
+    for did in dash_full:
+        rc = mb.put(f"/api/dashboard/{did}", json={"dashcards": prepared[did]})
+        chk = mb.get(f"/api/dashboard/{did}")
+        still = any(dc.get("card_id") == args.old for dc in _dashcards(chk)) if isinstance(chk, dict) else True
+        print(f"  dashboard #{did}: PUT={rc} | référence old restante ? {still}")
+    remaining = mb.get(f"/api/card/{args.old}/dashboards") or []
+    if not remaining:
+        rc = mb.put(f"/api/card/{args.old}", json={"archived": True})
+        print(f"  old #{args.old} archivée (HTTP {rc})")
+    else:
+        print(f"  ⚠️ old encore sur {len(remaining)} dashboard(s) — NON archivée")
+    print(f"Rollback : restaurer les dashcards depuis {snap}, puis désarchiver old.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/swap_lib.py
+++ b/scripts/swap_lib.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Logique pure du swap de carte sur dashboards (réécriture de dashcards). Aucune I/O.
+
+Remplace une carte `old` par sa canonique `new` dans des dashcards : `card_id`,
+les `parameter_mappings` (le `target` — qui pointe un template-tag par NOM — reste
+valide car les cartes partagent la même empreinte fonctionnelle), et les `series`.
+"""
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from audit_lib import output_fingerprint, _legacy_query  # noqa: E402
+
+
+def _target_tag(target):
+    """Nom du template-tag d'un `target` de mapping, ex. ['dimension',['template-tag','date'],…]."""
+    try:
+        inner = target[1]
+        if isinstance(inner, list) and len(inner) >= 2 and inner[0] == "template-tag":
+            return inner[1]
+    except Exception:
+        pass
+    return None
+
+
+def referenced_template_tags(dashcards, card_id):
+    """Template-tags du dashboard câblés vers `card_id` (les filtres à préserver)."""
+    tags = set()
+    for dc in dashcards:
+        for pm in dc.get("parameter_mappings") or []:
+            if pm.get("card_id") == card_id:
+                t = _target_tag(pm.get("target"))
+                if t:
+                    tags.add(t)
+    return tags
+
+
+def rewrite_dashcards(dashcards, old_id, new_id):
+    """Retourne (dashcards réécrits, nb de dashcards modifiés). N'altère pas l'entrée."""
+    out = copy.deepcopy(dashcards)
+    n = 0
+    for dc in out:
+        changed = False
+        if dc.get("card_id") == old_id:
+            dc["card_id"] = new_id
+            changed = True
+        for pm in dc.get("parameter_mappings") or []:
+            if pm.get("card_id") == old_id:
+                pm["card_id"] = new_id  # target inchangé (pointe le tag par nom)
+                changed = True
+        for s in dc.get("series") or []:
+            if isinstance(s, dict):
+                if s.get("id") == old_id:
+                    s["id"] = new_id
+                    changed = True
+                if s.get("card_id") == old_id:
+                    s["card_id"] = new_id
+                    changed = True
+        if changed:
+            n += 1
+    return out, n
+
+
+def card_template_tags(card):
+    """Noms des template-tags de la requête native de la carte."""
+    lq = _legacy_query(card)
+    if not lq:
+        return set()
+    tags = (lq.get("native", {}) or {}).get("template-tags", {}) or {}
+    return set(tags.keys())
+
+
+def swap_safety_check(old_card, new_card, referenced_tags):
+    """Liste des raisons de NE PAS faire le swap (vide = sûr)."""
+    if not isinstance(new_card, dict):
+        return ["carte canonique introuvable"]
+    problems = []
+    if new_card.get("archived"):
+        problems.append("la canonique est archivée")
+    odb, ndb = old_card.get("database_id"), new_card.get("database_id")
+    if odb is not None and ndb is not None and odb != ndb:
+        problems.append(f"bases différentes ({odb} vs {ndb})")
+    if output_fingerprint(old_card) != output_fingerprint(new_card):
+        problems.append("empreinte fonctionnelle différente (rendu non identique)")
+    missing = referenced_tags - card_template_tags(new_card)
+    if missing:
+        problems.append(f"la canonique ne couvre pas les filtres: {sorted(missing)}")
+    return problems

--- a/scripts/swap_tables.py
+++ b/scripts/swap_tables.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Swap des tableaux multi-slot d'un dashboard COPIE vers la famille mixte 11673
+(option b). Par tableau : repointe le dashcard vers la carte mixte, reconstruit
+table.columns (colonnes mappées visibles, le reste masqué) + column_settings (titres
+repris de l'ancien dashcard), recâble les filtres. Garde-fou : chaque colonne mappée
+est vérifiée valeur-par-valeur (ancienne vs nouvelle, params épinglés) ; si une seule
+colonne diffère, le tableau GARDE l'ancienne carte et est signalé.
+
+Mapping de cible (démo Pro Nutrition 25632) : tableau ancien -> carte mixte + dimension.
+Usage :
+  python3 scripts/swap_tables.py --copy 25632 --client "Pro Nutrition"          # dry-run
+  python3 scripts/swap_tables.py --copy 25632 --client "Pro Nutrition" --yes
+"""
+import argparse, json, sys
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+import conv_lib
+import bascule_lib
+from migrate_dashboard_full import connect, load_inputs, _dcs
+
+# famille mixte 11673/13884 : breakdown -> (carte « toutes conversions », dimension, temporal-unit ?)
+MIXED_FAMILY = {
+    "type":     (49098, "CURRENT_CAMPAIGN_TYPE", False),
+    "channel":  (49100, "CURRENT_CAMPAIGN_CHANNEL", False),
+    "location": (49101, "CURRENT_CAMPAIGN_LOCATION", False),
+    "name":     (49102, "CURRENT_CAMPAIGN_NAME", False),
+    "product":  (49103, "CURRENT_CAMPAIGN_PRODUCT", False),
+    "date":     (49104, "CURRENT_TIME_PERIOD", True),
+    "device":   (49105, "CURRENT_CAMPAIGN_DEVICE", False),
+    "url":      (49106, "CURRENT_URL", False),
+    "category": (49107, "CURRENT_CAMPAIGN_CATEGORY", False),
+    "network":  (49129, "CURRENT_CAMPAIGN_NETWORK", False),
+}
+
+
+def resolve_table_target(card):
+    """Détecte si la carte est un vieux tableau multi-slot et renvoie sa carte mixte
+    cible (carte, dim, temporal) via le breakdown. None si pas un tableau conversion,
+    breakdown multi-dimension, ou breakdown non couvert par la famille mixte."""
+    if (card.get("display") or "") != "table":
+        return None
+    sql, _ = conv_lib.native_and_tags(card)
+    if not conv_lib.old_conversion_columns(sql):
+        return None
+    bd = conv_lib.card_breakdown(card)
+    if len(bd) != 1 or bd[0] not in MIXED_FAMILY:
+        return None
+    return MIXED_FAMILY[bd[0]]
+# métriques nommées hors slots positionnels (best-effort, tranché par la vérif valeur)
+NAMED_EXTRA = {"ADD_TO_CARTS": "CURRENT_ADD_TO_CARTS_NEW", "CAC_ATC": "CURRENT_ADD_TO_CARTS_NEW_CAC"}
+DC_FIELDS = ("card_id", "row", "col", "size_x", "size_y", "series", "parameter_mappings", "visualization_settings", "dashboard_tab_id")
+
+
+def card_rows(mb, cid, params, dim_col):
+    """{label_majuscule -> {COL: valeur}} ; exclut la ligne 'Total'. Alignement par
+    libellé insensible à la casse (ancien UPPER vs neuf INITCAP)."""
+    r = mb.post(f"/api/card/{cid}/query", json={"parameters": params}, timeout=300)
+    if not isinstance(r, dict) or r.get("status") != "completed":
+        return None
+    cols = [c["name"].upper() for c in r["data"]["cols"]]
+    if dim_col.upper() not in cols:
+        return None
+    di = cols.index(dim_col.upper())
+    out = {}
+    for row in r["data"]["rows"]:
+        lbl = str(row[di]).strip().upper()
+        if lbl in ("TOTAL", "∅", "NONE"):
+            continue
+        out[lbl] = {cols[i]: v for i, v in enumerate(row)}
+    return out
+
+
+def _close(a, b, tol=1e-6):
+    if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
+        return a == b
+    return a == b or abs(a - b) <= tol * max(abs(a), abs(b), 1e-12)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copy", type=int, required=True)
+    ap.add_argument("--client", required=True)
+    ap.add_argument("--window", default="2026-05-01~2026-05-31")
+    ap.add_argument("--accept-diffs", action="store_true",
+                    help="swappe malgré des écarts de VALEURS connus/validés (cosmétique libellé/casse, "
+                         "campagnes edge cost!=0 vs impressions>0). Bloque toujours sur exécution KO / "
+                         "colonnes non mappées.")
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    mapping_all, _ = load_inputs()
+    cmap = {int(k): v for k, v in mapping_all.get(args.client, {}).items()}
+
+    dash = mb.get(f"/api/dashboard/{args.copy}")
+    base = [{"type": "category", "value": [args.client], "target": ["dimension", ["template-tag", "clients"]]},
+            {"type": "date/all-options", "value": args.window, "target": ["dimension", ["template-tag", "date"]]}]
+
+    brand_yes = {"type": "category", "value": ["yes"], "target": ["dimension", ["template-tag", "brand_included"]]}
+    new_dcs, report = [], []
+    for dc in _dcs(dash):
+        cid = dc.get("card_id")
+        old_card = mb.get(f"/api/card/{cid}") if cid else None
+        target = resolve_table_target(old_card) if old_card else None
+        if not target:
+            new_dcs.append(dc)
+            continue
+        target_id, dim_new, is_temporal = target
+        old_vsettings = dc.get("visualization_settings") or {}
+        old_tc = old_vsettings.get("table.columns") or []
+        old_vis = [c["name"] for c in old_tc if c.get("enabled")]
+        old_dim = old_vis[0] if old_vis else None
+        old_titles = {k: v.get("column_title") for k, v in (old_vsettings.get("column_settings") or {}).items()
+                      if v.get("column_title")}
+        target = mb.get(f"/api/card/{target_id}")
+        new_cols = [x["name"] for x in target.get("result_metadata") or []]
+        target_tc = {e["name"]: e for e in (target.get("visualization_settings") or {}).get("table.columns") or []}
+
+        m, unmapped = conv_lib.map_table_columns(old_vis, cmap, new_cols, dim_new)
+        for col in list(unmapped):  # métriques nommées : best-effort
+            cand = NAMED_EXTRA.get(col.upper())
+            if cand and cand in new_cols:
+                m[col] = cand
+                unmapped.remove(col)
+
+        # --- vérification cellule par cellule, alignée par libellé, brand=yes (inerte) ---
+        old_params = list(base) + [brand_yes]
+        _, old_tags = conv_lib.native_and_tags(old_card)
+        if is_temporal:  # n'épingler la granularité que pour le tableau by-date
+            tp = bascule_lib.time_param_payload(old_tags, "week")
+            if tp:
+                old_params.append(tp)
+        new_params = list(base) + [brand_yes]
+        if is_temporal:
+            new_params.append({"type": "temporal-unit", "value": "week",
+                               "target": ["dimension", ["template-tag", "time_period"]]})
+        orows = card_rows(mb, cid, old_params, old_dim)
+        nrows = card_rows(mb, target_id, new_params, dim_new)
+        bad = []
+        if orows is None or nrows is None:
+            bad.append(("(exécution)", "(exécution)", None, None))
+        else:
+            labels = set(orows) & set(nrows)
+            extra_rows = sorted(set(orows) ^ set(nrows))
+            for old_col, new_col in m.items():
+                if old_dim and old_col.upper() == old_dim.upper():
+                    continue  # la dimension est la clé d'alignement, pas une valeur (casse/format)
+                diffs = sum(1 for lb in labels
+                            if not _close(orows[lb].get(old_col.upper()), nrows[lb].get(new_col.upper())))
+                if diffs:
+                    ex = next(lb for lb in labels
+                              if not _close(orows[lb].get(old_col.upper()), nrows[lb].get(new_col.upper())))
+                    bad.append((old_col, new_col, f"{ex}: {orows[ex].get(old_col.upper())}",
+                                f"{nrows[ex].get(new_col.upper())}", diffs))
+            if extra_rows:
+                bad.append(("(lignes)", "(lignes)", f"écart de lignes: {extra_rows[:6]}", "", len(extra_rows)))
+
+        # blocage DUR : exécution KO ou colonnes non mappées (jamais contournable)
+        hard = unmapped or any(b[0] == "(exécution)" for b in bad)
+        value_diffs = [b for b in bad if b[0] != "(exécution)"]
+        blocked = bool(hard) or (bool(value_diffs) and not args.accept_diffs)
+        status = "OK" if not bad and not unmapped else ("FORCÉ" if (value_diffs and args.accept_diffs and not hard) else "PARTIEL")
+        report.append({"card": cid, "target": target_id, "mapped": len(m), "unmapped": unmapped,
+                       "bad": bad, "status": status, "blocked": blocked, "name": old_card.get("name")})
+        if blocked:
+            new_dcs.append(dc)  # garde l'ancien tableau
+            continue
+
+        # --- construit le nouveau dashcard ---
+        nd = {k: json.loads(json.dumps(dc.get(k))) for k in DC_FIELDS if dc.get(k) is not None}
+        nd["id"] = dc.get("id")
+        nd["card_id"] = target_id
+        mapped_new = [m[c] for c in old_vis if c in m]
+        seen = set(mapped_new)
+        new_table_cols = []
+        for c in old_vis:
+            if c in m and m[c] in target_tc:
+                e = dict(target_tc[m[c]]); e["enabled"] = True; new_table_cols.append(e)
+        for name, e in target_tc.items():
+            if name not in seen:
+                e2 = dict(e); e2["enabled"] = False; new_table_cols.append(e2)
+        col_settings = {f'["name","{m[c]}"]': old_titles[k]
+                        for c in old_vis if c in m
+                        for k in [f'["name","{c}"]'] if k in old_titles}
+        nd["visualization_settings"] = {"table.columns": new_table_cols, "column_settings": col_settings}
+        if old_vsettings.get("card.title"):
+            nd["visualization_settings"]["card.title"] = old_vsettings["card.title"]
+        # recâble les filtres vers la cible (drop les tags absents de la cible)
+        _, ntags = conv_lib.native_and_tags(target)
+        pms = []
+        for pm in nd.get("parameter_mappings") or []:
+            tgt = pm.get("target")
+            try:
+                tag = tgt[1][1] if tgt[1][0] == "template-tag" else None
+            except Exception:
+                tag = None
+            if tag is None or tag in ntags:
+                pm["card_id"] = target_id
+                pms.append(pm)
+        nd["parameter_mappings"] = pms
+        new_dcs.append(nd)
+
+    print(f"Dashboard {args.copy} — swap des tableaux :")
+    for r in report:
+        verb = ("SWAP -> {}".format(r["target"]) if not r["blocked"]
+                else "GARDE ancien")
+        flag = "  [écarts acceptés]" if r["status"] == "FORCÉ" else ""
+        print(f"  {str(r['name'])[:34]:34} {verb}{flag}  ({r['mapped']} cols mappées)")
+        if r["unmapped"]:
+            print(f"        NON mappées (bloquant): {r['unmapped']}")
+        for b in r["bad"]:
+            print(f"        {'•' if r['status']=='FORCÉ' else '⛔'} {b[0]} -> {b[1]} : {b[4] if len(b)>4 else '?'} cellule(s) ≠  (ex. {b[2]} vs {b[3]})")
+    swaps = [r for r in report if not r["blocked"]]
+    if not args.yes:
+        print(f"\n(DRY-RUN — {len(swaps)}/{len(report)} tableaux prêts à swapper. Rien modifié.)")
+        return
+    if not swaps:
+        print("\nAucun tableau swappable — rien à faire."); return
+    (REPO / "migration" / f"swap-tables-snapshot-{args.copy}.json").write_text(
+        json.dumps(_dcs(dash), ensure_ascii=False))
+    put_body = {"dashcards": new_dcs}
+    if dash.get("tabs"):
+        put_body["tabs"] = dash["tabs"]
+    res = mb.put(f"/api/dashboard/{args.copy}", "raw", json=put_body)
+    if res.status_code != 200:
+        print(f"⛔ PUT échoué: {res.status_code} — {res.text[:300]}"); sys.exit(1)
+    print(f"\nPUT {args.copy}: 200 OK ({len(swaps)} tableaux swappés, snapshot pris)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tag_existing.py
+++ b/scripts/tag_existing.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Applique l'ancre [conv-2026-06] au NOM des dashboards déjà migrés (tracker, tagged=false).
+
+Idempotent (conv_tracker.apply_tag) et réversible (retirer le suffixe). Dry-run par défaut ;
+--yes renomme réellement, met `tagged: true` dans le tracker + régénère le markdown.
+PUT tolérant aux onglets (inclut `tabs` si présents, sinon 500).
+
+Usage :
+  python3 scripts/tag_existing.py          # dry-run : montre les renommages
+  python3 scripts/tag_existing.py --yes      # applique
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import conv_tracker as T  # noqa: E402
+from archive_collections import connect_resilient  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--yes", action="store_true", help="renomme réellement (sinon dry-run)")
+    args = ap.parse_args()
+
+    tracker = T.load()
+    todo = [e for e in tracker if not e.get("tagged")]
+    if not todo:
+        print("Toutes les copies du tracker sont déjà taggées.")
+        return
+
+    mb = connect_resilient()
+    print(f"{len(todo)} copie(s) à taguer :\n")
+    done = 0
+    for e in tracker:
+        if e.get("tagged"):
+            continue
+        cid = e["copy_id"]
+        d = mb.get(f"/api/dashboard/{cid}")
+        if not d:
+            print(f"  ⛔ #{cid} introuvable — sauté"); continue
+        old = d.get("name", "")
+        new = T.apply_tag(old)
+        if new == old:                       # déjà taggé côté Metabase
+            print(f"  = #{cid} déjà taggé : «{old}»")
+            e["tagged"] = True; done += 1; continue
+        if not args.yes:
+            print(f"  [dry-run] #{cid} «{old}»  →  + {T.TAG}")
+            continue
+        body = {"name": new}
+        if d.get("tabs"):                    # dashboards à onglets : PUT doit inclure tabs
+            body["tabs"] = d["tabs"]
+        res = mb.put(f"/api/dashboard/{cid}", "raw", json=body)
+        ok = res.ok and (mb.get(f"/api/dashboard/{cid}") or {}).get("name") == new
+        if ok:
+            e["tagged"] = True; done += 1
+            print(f"  ✅ #{cid} → «{new}»")
+        else:
+            print(f"  ❌ #{cid} échec PUT {res.status_code} {res.text[:140]}")
+
+    if args.yes and done:
+        T.save(tracker); T.render_to_file(tracker)
+        print(f"\n{done} copie(s) taguée(s). Tracker + markdown mis à jour. "
+              f"Rollback : retirer le suffixe {T.TAG} du nom.")
+    elif not args.yes:
+        print(f"\n(DRY-RUN — rien renommé. --yes pour appliquer.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/translate_en_24576.py
+++ b/scripts/translate_en_24576.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Traduit en anglais le clone EN du dashboard Franchisés Quiz Room.
+
+- Cartes texte/heading : ciblées par (onglet, row) -> texte EN.
+- Titres KPI existants (card.title) : map FR -> EN.
+- Graphes sans override affichant un nom technique : AJOUT d'un card.title EN (par card_id).
+- Onglet 'Accueil' -> 'Home'.
+NE renomme JAMAIS les cartes partagées (override par dashcard uniquement).
+
+Usage:
+  python3 scripts/translate_en_24576.py --dashboard 25467            # dry-run
+  python3 scripts/translate_en_24576.py --dashboard 25467 --yes      # applique + snapshot
+"""
+import argparse, json, sys, copy, requests
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+MIG = REPO / "migration"
+
+# --- textes par (onglet, row) ---
+POS_TEXT = {
+    ("Accueil", 0): "🏠 Home",
+    ("Accueil", 4): "💡 Glossary",
+    ("Accueil", 1): (
+        "- The **Global** tab gives an overview of all your center's digital acquisition sources and their impact on bookings.\n\n"
+        "- The **SEA / SMA** tab tracks your paid acquisition (Google Ads, Meta, TikTok). If you don't run paid acquisition, it's normal to see the metrics at 0.\n\n"
+        "- The **SEO** tab explains how your center is found on Google organically, and whether that traffic generates bookings."
+    ),
+    ("Accueil", 5): (
+        "**Acquisition channels**\n\n"
+        "- **SEO**: organic Google search.\n\n"
+        "- **SEA**: Google Ads paid advertising.\n\n"
+        "- **SMA**: paid advertising on social networks (Meta, TikTok…).\n\n\n"
+        "**Platforms**\n\n"
+        "- **Meta**: Covers ads shown on **Facebook**, **Instagram**, **Messenger** and the **Meta Audience Network** (partner sites and apps).\n\n"
+        "- **Google**: Covers ads shown on **Google Search**, **YouTube**, **Gmail**, **Google Maps** and the **Google Display Network** (banners across millions of partner sites and apps).\n\n"
+        "> [Explainer video: differences between Meta and Google](https://www.youtube.com/watch?v=Cp5nkhRyhe4) (up to the halfway point)\n\n\n"
+        "**Metrics**\n\n"
+        "- **Costs**: Budget spent on the campaign and on Google, YouTube, Instagram and Facebook marketing actions (excluding management fees).\n\n"
+        "- **Impressions**: Number of times an ad is displayed on a user's screen. The same person can generate several impressions if they see the ad multiple times.\n\n"
+        "- **Clicks**: Number of times a user clicks on an ad or a link to reach your site. The same user can generate several clicks.\n\n"
+        "- **Visits**: Total number of sessions opened on your site, all sources combined (SEO, SEA, SMA, direct access, etc.). A session is a period of continuous activity by a user on the site.\n\n"
+        "- **New visitors**: People discovering your center for the first time.\n\n"
+        "- **Conversion**: A concrete action taken by a visitor (booking, form, call).\n\n"
+        "- **Conversion rate**: Percentage of visits that led to a concrete action (booking, form, call). Calculated by dividing the number of conversions by the total number of visits.\n\n"
+        "- **Bookings**: Number of bookings confirmed online.\n\n"
+        "- **Contacts**: Number of people who viewed your contact details or submitted a contact form."
+    ),
+    ("Global", 0): "1. How many users land on my pages?",
+    ("Global", 1): (
+        "Total number of visits, all sources combined: Google search, ads, social networks, direct access.\n\n"
+        "Visits that are neither SEO, SEA nor SMA come from direct access, referrals and other sources."
+    ),
+    ("Global", 15): "2. How many bookings are generated?",
+    ("Global", 16): (
+        "The player count is your center's actual footfall, all sources combined.\n\n"
+        "Conversions count concrete actions on the site (bookings, forms, calls)."
+    ),
+    ("Global", 30): "3. Budget usage",
+    ("Global", 31): (
+        "The amount invested in advertising (Google Ads and social networks) this month; this budget only covers ad spend.\n\n"
+        "SEO does not generate any direct media cost — it's \"free\" traffic earned through content and organic search work."
+    ),
+    ("SEA / SMA", 0): "Advertising",
+    ("SEA / SMA", 7): "History",
+    ("SEO", 0): "1. Is my site attracting visitors?",
+    ("SEO", 1): "How many people find your center via Google (organic search, excluding ads).",
+    ("SEO", 23): "2. Is this traffic converting?",
+    ("SEO", 24): (
+        "Your site's traffic segmented by page type: what brings visitors to each page family, and which content drives the most engagement.\n"
+        "Clicks are the number of times a user clicks an organic link from Google to reach your site. The same user can generate several clicks.\n"
+        "Visits are the total number of sessions opened on your site, all sources combined (SEO, SEA, SMA, direct access, etc.). A session is a period of continuous activity on the site.\n\n"
+        "Pages are grouped into 4 families:\n\n"
+        "- **Home page**: the site's main homepage\n"
+        "- **City home**: main pages by location\n"
+        "- **Landing pages**: dedicated pages (birthdays, team building, etc.)\n"
+        "- **Blog**: editorial articles"
+    ),
+    ("SEO", 43): (
+        "⚠️  You may see small differences between certain totals (sessions, new users) across the dashboard's questions. "
+        "This is normal: each view is built from a report generated from a different angle, so sessions aren't always counted in exactly the same way — "
+        "but the orders of magnitude remain reliable."
+    ),
+    ("SEO", 46): "3. Which pages perform best?",
+    ("SEO", 47): (
+        "The tables below rank your pages by volume of visits on Google.\n"
+        "The Google position shows your rank in search results (the lower the number, the better). The conversion rate is the percentage of people who click your link when it appears in the results.\n\n"
+        "Reading tip: a well-ranked page (position < 10) with a low conversion rate may benefit from improving its title and description on Google. A page with many visits but few conversions may need a stronger call to action on the page."
+    ),
+}
+
+# --- titres KPI existants : FR -> EN ---
+TITLE_MAP = {
+    "Budget SEA (Google Ads)": "SEA Budget (Google Ads)",
+    "Budget SMA (Meta)": "SMA Budget (Meta)",
+    "Budget total media": "Total media budget",
+    "Clics": "Clicks",
+    "Contacts": "Contacts",
+    "Conversions SEA": "SEA Conversions",
+    "Conversions SEO": "SEO Conversions",
+    "Conversions SMA": "SMA Conversions",
+    "Impressions": "Impressions",
+    "Nombre de Joueurs": "Player count",
+    "Nouveaux utilisateurs SEO": "New SEO users",
+    "Réservations": "Bookings",
+    "Synthèse des performances": "Performance summary",
+    "Taux de conversions SEO": "SEO conversion rate",
+    "Visites": "Visits",
+    "Visites SEA": "SEA Visits",
+    "Visites SEO": "SEO Visits",
+    "Visites SMA": "SMA Visits",
+    "Visites par type de page": "Visits by page type",
+}
+
+# --- graphes sans override : card_id -> titre EN à AJOUTER ---
+ADD_TITLE = {
+    47181: "Visits by source",
+    46950: "Traffic trend by source — last 13 months",
+    46989: "Conversions by channel — last 3 months (N vs N-1)",
+    46988: "Player count — last 3 months (N vs N-1)",
+    47018: "Media budget — 12-month trend",
+    60: "Media budget by channel",
+    41662: "Cost, contacts & bookings by date",
+    41661: "Impressions by date",
+    47049: "Sessions — last 3 months",
+    47082: "Traffic breakdown (GSC)",
+    47083: "Clicks by traffic (GSC)",
+    47084: "Clicks by traffic (GSC) — N vs N-1",
+    47676: "Sessions by page type (GA4)",
+    47808: "Sessions by page type (GA4) — year N vs N-1",
+    48303: "Performance by page (GSC & GA4)",
+}
+
+TAB_RENAME = {"Accueil": "Home"}
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    d = mb.get(f"/api/dashboard/{args.dashboard}")
+    dcs = copy.deepcopy(d.get("dashcards") or [])
+    tabs = copy.deepcopy(d.get("tabs") or [])
+    tabname = {t["id"]: t["name"] for t in tabs}
+
+    n_text = n_title = n_add = 0
+    miss_text = []
+    for dc in dcs:
+        vs = dc.get("visualization_settings") or {}
+        tab = tabname.get(dc.get("dashboard_tab_id"))
+        vc = vs.get("virtual_card") or {}
+        # text/heading by (tab,row)
+        if vc.get("display") in ("text", "heading") and (vs.get("text") or "").strip():
+            key = (tab, dc.get("row"))
+            if key in POS_TEXT:
+                vs["text"] = POS_TEXT[key]; n_text += 1
+            else:
+                miss_text.append((tab, dc.get("row"), (vs.get("text") or "")[:40]))
+        # existing KPI title override
+        if vs.get("card.title") in TITLE_MAP:
+            vs["card.title"] = TITLE_MAP[vs["card.title"]]; n_title += 1
+        # add EN title to no-override charts
+        elif not vs.get("card.title") and dc.get("card_id") in ADD_TITLE:
+            vs["card.title"] = ADD_TITLE[dc["card_id"]]; n_add += 1
+        dc["visualization_settings"] = vs
+
+    for t in tabs:
+        if t["name"] in TAB_RENAME:
+            t["name"] = TAB_RENAME[t["name"]]
+
+    print(f"text/heading traduits: {n_text} | titres KPI traduits: {n_title} | titres ajoutés: {n_add}")
+    if miss_text:
+        print("NON-traduits (texte hors FAQ non mappé):")
+        for m in miss_text:
+            if m[0] and "FAQ" not in (m[0] or ""):
+                print("  ", m)
+
+    if not args.yes:
+        print("\n(DRY-RUN — aucune modification.)")
+        return
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"translate-en-snapshot-{args.dashboard}-{ts}.json").write_text(
+        json.dumps({"dashboard": args.dashboard, "dashcards": d.get("dashcards"), "tabs": d.get("tabs")}, ensure_ascii=False, indent=2))
+    r = requests.put(mb.domain + f"/api/dashboard/{args.dashboard}", headers=mb.header, auth=mb.auth,
+                     json={"dashcards": dcs, "tabs": tabs}, timeout=120)
+    print("PUT:", r.status_code); r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_brand_batch.py
+++ b/scripts/validate_brand_batch.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Validation exhaustive post-batch brand : exécute les 1967 cartes, et pour chaque
+ÉCHEC rejoue le SQL d'AVANT (snapshot) pour trancher :
+  - OLD échoue aussi  -> casse PRÉEXISTANTE (pas nous)
+  - OLD réussit       -> RÉGRESSION introduite par le batch -> à restaurer
+
+Lecture seule (aucune modif). Sortie : migration/brand-batch-validation.json.
+"""
+import json, sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from archive_collections import connect_resilient
+import conv_lib
+
+mb = connect_resilient()
+ids = json.loads(Path("/tmp/brand_batch_ids.json").read_text())
+SNAP = {}
+for line in (REPO / "migration" / "snapshots" / "brand-batch-snapshots.jsonl").read_text().splitlines():
+    c = json.loads(line)
+    SNAP[c["id"]] = c  # dernière occurrence = état juste avant PUT
+
+
+def _params(tags):
+    p = []
+    if "date" in tags:
+        p.append({"type": "date/all-options", "value": "2026-05-01~2026-05-31",
+                  "target": ["dimension", ["template-tag", "date"]]})
+    return p
+
+
+def run_live(cid, tags):
+    r = mb.post(f"/api/card/{cid}/query", "raw", json={"parameters": _params(tags)})
+    try:
+        b = r.json()
+    except Exception:
+        b = {}
+    return b.get("status") == "completed", str((b or {}).get("error") or "")[:140]
+
+
+def run_snapshot(card, tags):
+    """exécute le dataset_query d'AVANT via /api/dataset (sans toucher la carte)."""
+    body = json.loads(json.dumps(card["dataset_query"]))
+    body["parameters"] = _params(tags)
+    r = mb.post("/api/dataset", "raw", json=body)
+    try:
+        b = r.json()
+    except Exception:
+        b = {}
+    return b.get("status") == "completed"
+
+
+def check(cid):
+    card = mb.get(f"/api/card/{cid}")
+    _, tags = conv_lib.native_and_tags(card)
+    ok, err = run_live(cid, tags)
+    if ok:
+        return {"id": cid, "verdict": "ok"}
+    snap = SNAP.get(cid)
+    old_ok = run_snapshot(snap, tags) if snap else None
+    return {"id": cid, "verdict": "REGRESSION" if old_ok else "preexisting_broken",
+            "name": card.get("name"), "err": err, "old_ran": old_ok}
+
+
+def main():
+    with ThreadPoolExecutor(8) as ex:
+        res = list(ex.map(check, ids))
+    ok = [r for r in res if r["verdict"] == "ok"]
+    regr = [r for r in res if r["verdict"] == "REGRESSION"]
+    pre = [r for r in res if r["verdict"] == "preexisting_broken"]
+    (REPO / "migration" / "brand-batch-validation.json").write_text(json.dumps(res, ensure_ascii=False))
+    print(f"OK: {len(ok)}/{len(res)} | RÉGRESSIONS: {len(regr)} | casse préexistante: {len(pre)}")
+    if regr:
+        print("\n⛔ RÉGRESSIONS (restaurer depuis snapshot) :")
+        for r in regr:
+            print(f"  {r['id']} {str(r['name'])[:55]} — {r['err']}")
+    if pre:
+        print(f"\nℹ️ cartes déjà cassées AVANT le batch (à signaler, pas nous) : {len(pre)}")
+        for r in pre[:25]:
+            print(f"  {r['id']} {str(r['name'])[:50]} — {r['err'][:70]}")
+    print("\nrapport: migration/brand-batch-validation.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -759,6 +759,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_apply.add_argument("--yes", action="store_true",
                          help="Skip the interactive confirmation")
 
+    p_val = sub.add_parser("validate", help="Validate a spec / collection / card before applying")
+    p_val.add_argument("target", help="spec path | collection id/name | card id")
+    p_val.add_argument("--no-execute", action="store_true",
+                       help="skip running queries (structure+refs smoke check only)")
+
     args = parser.parse_args(argv)
     client = _build_client(args)
 
@@ -789,6 +794,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         else:
             print("\nNothing to do.")
         return 0
+
+    if args.cmd == "validate":
+        from . import validate as _v
+        units = _v.resolve_cli_target(client, args.target)
+        report = _v.gate(client, units, execute=not args.no_execute)
+        print(report.render())
+        return report.exit_code()
 
     return 1
 

--- a/spark_metabase_api/iac.py
+++ b/spark_metabase_api/iac.py
@@ -569,15 +569,22 @@ def _plan_collection(client, spec: CollectionSpec, parent_id: Optional[int],
 
 
 def apply(client, spec: CollectionSpec, parent_id: Optional[int] = None,
-          dry_run: bool = False) -> Plan:
+          dry_run: bool = False, validate: bool = False, force: bool = False) -> Plan:
     """Apply the spec to Metabase so the live state matches the spec.
 
     Returns the executed plan. With dry_run=True nothing is written and the
     returned plan is exactly what `plan(client, spec, parent_id)` would return.
+    With validate=True, runs the pre-apply gate before any mutation; raises
+    ValidationError if the gate reports errors (unless force=True).
     """
     p = plan(client, spec, parent_id=parent_id)
     if dry_run:
         return p
+    if validate:
+        from . import validate as _v
+        report = _v.gate(client, _v.units_from_spec(spec), execute=True)
+        if not report.ok() and not force:
+            raise _v.ValidationError(report)
     by_path = {a.path: a for a in p.actions}
     _execute_collection(client, spec, parent_id, parent_path="", by_path=by_path)
     return p

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -222,6 +222,9 @@ class Metabase_API:
 
         dataset_query is the shape stored in a card's definition:
             {"database": <id>, "type": "native"|"query", "native"|"query": {...}}
+
+        Note: native queries requiring template-tag/field-filter values are not
+        auto-defaulted in v1 (see spec §7) — a failing run surfaces as an execution error.
         """
         body = dict(dataset_query)
         body["parameters"] = parameters or []

--- a/spark_metabase_api/main_methods.py
+++ b/spark_metabase_api/main_methods.py
@@ -217,6 +217,21 @@ class Metabase_API:
         if data_format == "csv":
             return res.text.replace("null", "")
 
+    def run_query(self, dataset_query, parameters=None):
+        """Run an ad-hoc dataset_query (POST /api/dataset) and return parsed JSON.
+
+        dataset_query is the shape stored in a card's definition:
+            {"database": <id>, "type": "native"|"query", "native"|"query": {...}}
+        """
+        body = dict(dataset_query)
+        body["parameters"] = parameters or []
+        res = self.post("/api/dataset", "raw", json=body)
+        try:
+            return res.json()
+        except Exception:
+            return {"status": "failed", "error": "non-JSON response ({})".format(
+                getattr(res, "status_code", "?"))}
+
     def clone_card(
         self,
         card_id,

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -69,11 +69,11 @@ class Finding:
 
 def check_structure(unit: "CardUnit") -> Finding:
     dq = unit.dataset_query
-    if not isinstance(dq, dict) or "database" not in dq:
-        return Finding(unit.target, "structure", "error", "dataset_query missing 'database'")
+    if not isinstance(dq, dict) or not dq.get("database"):
+        return Finding(unit.target, "structure", "error", "dataset_query missing or invalid 'database'")
     qtype = dq.get("type")
     if qtype == "native":
-        if not (dq.get("native") or {}).get("query"):
+        if not ((dq.get("native") or {}).get("query") or "").strip():
             return Finding(unit.target, "structure", "error", "native query is empty")
     elif qtype == "query":
         if not dq.get("query"):
@@ -161,10 +161,17 @@ def _execute_unit(client, unit: "CardUnit"):
             err = rows.get("error") if isinstance(rows, dict) else None
             return [], err or "query failed (unexpected result shape)"
         return rows, None
-    res = client.run_query(unit.dataset_query)
-    if not isinstance(res, dict) or res.get("status") == "failed" or res.get("error"):
-        err = res.get("error") if isinstance(res, dict) else "HTTP error"
-        return [], err or "query failed"
+    try:
+        res = client.run_query(unit.dataset_query)
+    except Exception as e:
+        return [], str(e)
+    if not isinstance(res, dict):
+        return [], "query failed (non-dict response)"
+    # /api/dataset returns status=="completed" on success. Anything else
+    # (failed / running / missing, or a 4xx error body) is a failure, not
+    # "0 rows" — otherwise an errored query slips through the gate as a warn.
+    if res.get("error") or res.get("status") != "completed":
+        return [], res.get("error") or "query status: {!r}".format(res.get("status"))
     data = res.get("data") or {}
     cols = [c.get("name") for c in (data.get("cols") or [])]
     rows = [dict(zip(cols, r)) for r in (data.get("rows") or [])]
@@ -248,8 +255,16 @@ def guarded_apply(client, units, mutate_fn, differential="monitor",
 def resolve_cli_target(client, target: str) -> List["CardUnit"]:
     import os
     from . import iac
-    if target.lower().endswith((".yaml", ".yml", ".json")) and os.path.exists(target):
-        return units_from_spec(iac.load(target))
+    if target.lower().endswith((".yaml", ".yml", ".json")):
+        if not os.path.exists(target):
+            raise ValueError("spec file not found: {}".format(target))
+        try:
+            spec = iac.load(target)
+        except Exception as e:
+            raise ValueError("not a valid Metabase spec file {}: {}".format(target, e))
+        if not getattr(spec, "name", None):
+            raise ValueError("not a valid Metabase spec (missing 'name'): {}".format(target))
+        return units_from_spec(spec)
     if target.isdigit():
         return [unit_from_card_id(client, int(target))]
     return units_from_spec(iac.export(client, target))
@@ -272,12 +287,21 @@ def check_differential(target, before, after, mode="monitor", tolerance=0.0) -> 
         findings.append(Finding(target, "differential", level, "columns changed",
             before=sb["columns"], after=sa["columns"]))
 
+    after_cols = set(sa["columns"])
     for c, bsum in sb["sums"].items():
         asum = sa["sums"].get(c)
         if asum is None:
+            # The column was numeric before but has no numeric sum now. If it is
+            # still present (same name), it regressed to all-null or a non-numeric
+            # type — a real delta the row-count and column-set checks cannot see.
+            if c in after_cols:
+                findings.append(Finding(target, "differential", level,
+                    "sum({}) numeric -> non-numeric/all-null".format(c),
+                    before=bsum, after=None))
             continue
         denom = abs(bsum) or 1.0
-        if abs(asum - bsum) / denom > tolerance:
+        delta = abs(asum - bsum)
+        if delta != delta or delta / denom > tolerance:  # NaN, or beyond tolerance
             findings.append(Finding(target, "differential", level,
                 "sum({}) {} -> {}".format(c, bsum, asum), before=bsum, after=asum))
 

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -3,6 +3,58 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
+class CardUnit:
+    target: str
+    dataset_query: Dict[str, Any] = field(default_factory=dict)
+    display: Optional[str] = None
+    visualization_settings: Optional[Dict[str, Any]] = None
+    live_card_id: Optional[int] = None
+    expected_columns: Optional[List[str]] = None
+    metric_override: Optional[Dict[str, Any]] = None
+
+
+def units_from_spec(spec) -> List[CardUnit]:
+    units: List[CardUnit] = []
+
+    def walk(coll, path):
+        for card in coll.cards:
+            defn = card.definition or {}
+            units.append(CardUnit(
+                target=path + "/" + card.name,
+                dataset_query=defn.get("dataset_query") or {},
+                display=defn.get("display"),
+                visualization_settings=defn.get("visualization_settings"),
+            ))
+        for sub in coll.collections:
+            walk(sub, path + "/" + sub.name)
+
+    walk(spec, spec.name)
+    return units
+
+
+def unit_from_payload(target: str, payload: Dict[str, Any]) -> CardUnit:
+    return CardUnit(
+        target=target,
+        dataset_query=payload.get("dataset_query") or {},
+        display=payload.get("display"),
+        visualization_settings=payload.get("visualization_settings"),
+    )
+
+
+def unit_from_card_id(client, card_id: int) -> CardUnit:
+    card = client.get("/api/card/{}".format(card_id))
+    if not card:
+        raise ValueError("card {} not found".format(card_id))
+    return CardUnit(
+        target="card#{}".format(card_id),
+        dataset_query=card.get("dataset_query") or {},
+        display=card.get("display"),
+        visualization_settings=card.get("visualization_settings"),
+        live_card_id=card_id,
+    )
+
+
+@dataclass
 class Finding:
     target: str
     check: str

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -166,3 +166,47 @@ def check_execution(client, unit: "CardUnit") -> Finding:
             return Finding(unit.target, "execution", "warn",
                            "missing expected columns: {}".format(missing))
     return Finding(unit.target, "execution", "ok", "{} rows".format(len(rows)))
+
+
+def _signature(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compute a signature of row set: row count, columns, and sums of numeric columns.
+    A column is numeric only if all non-null values are int/float and not bool."""
+    cols = list(rows[0].keys()) if rows else []
+    sums: Dict[str, float] = {}
+    for c in cols:
+        vals = [r.get(c) for r in rows if r.get(c) is not None]
+        if vals and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in vals):
+            sums[c] = sum(vals)
+    return {"row_count": len(rows), "columns": cols, "sums": sums}
+
+
+def check_differential(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]:
+    """Compare two result sets (before/after).
+    mode="identical" => deltas are errors; mode="monitor" => deltas are warns.
+    tolerance: fractional threshold for numeric sums (absolute/denom > tolerance)."""
+    sb, sa = _signature(before), _signature(after)
+    level = "error" if mode == "identical" else "warn"
+    findings: List[Finding] = []
+
+    if sb["row_count"] != sa["row_count"]:
+        findings.append(Finding(target, "differential", level,
+            "row count {} -> {}".format(sb["row_count"], sa["row_count"]),
+            before=sb["row_count"], after=sa["row_count"]))
+
+    if set(sb["columns"]) != set(sa["columns"]):
+        findings.append(Finding(target, "differential", level, "columns changed",
+            before=sb["columns"], after=sa["columns"]))
+
+    for c, bsum in sb["sums"].items():
+        asum = sa["sums"].get(c)
+        if asum is None:
+            continue
+        denom = abs(bsum) or 1.0
+        if abs(asum - bsum) / denom > tolerance:
+            findings.append(Finding(target, "differential", level,
+                "sum({}) {} -> {}".format(c, bsum, asum), before=bsum, after=asum))
+
+    if not findings:
+        findings.append(Finding(target, "differential", "ok", "no significant change"))
+
+    return findings

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -80,6 +80,31 @@ def check_structure(unit: "CardUnit") -> Finding:
     return Finding(unit.target, "structure", "ok", "well-formed")
 
 
+def _card_exists(client, card_id: int) -> bool:
+    card = client.get("/api/card/{}".format(card_id))
+    return bool(card) and not card.get("archived")
+
+
+def check_refs(client, unit: "CardUnit") -> List[Finding]:
+    findings: List[Finding] = []
+    dq = unit.dataset_query
+    if dq.get("type") == "query":
+        src = (dq.get("query") or {}).get("source-table")
+        if isinstance(src, str) and src.startswith("card__"):
+            cid = int(src.split("__")[1])
+            if not _card_exists(client, cid):
+                findings.append(Finding(unit.target, "refs", "error",
+                    "source card {} not found / archived".format(cid)))
+    for tag in ((dq.get("native") or {}).get("template-tags") or {}).values():
+        cid = (tag.get("values_source_config") or {}).get("card_id")
+        if cid and not _card_exists(client, cid):
+            findings.append(Finding(unit.target, "refs", "error",
+                "field-filter source card {} not found / archived".format(cid)))
+    if not findings:
+        findings.append(Finding(unit.target, "refs", "ok", "refs resolve"))
+    return findings
+
+
 @dataclass
 class Report:
     findings: List[Finding] = field(default_factory=list)

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -134,3 +134,35 @@ class Report:
 
     def exit_code(self) -> int:
         return 1 if self.errors() else 0
+
+
+def _execute_unit(client, unit: "CardUnit"):
+    """Run the unit's query. Returns (rows: list[dict], error: str|None)."""
+    if unit.live_card_id is not None:
+        try:
+            rows = client.get_card_data(card_id=unit.live_card_id, data_format="json")
+        except Exception as e:
+            return [], str(e)
+        return rows or [], None
+    res = client.run_query(unit.dataset_query)
+    if not isinstance(res, dict) or res.get("status") == "failed" or res.get("error"):
+        err = res.get("error") if isinstance(res, dict) else "HTTP error"
+        return [], err or "query failed"
+    data = res.get("data") or {}
+    cols = [c.get("name") for c in (data.get("cols") or [])]
+    rows = [dict(zip(cols, r)) for r in (data.get("rows") or [])]
+    return rows, None
+
+
+def check_execution(client, unit: "CardUnit") -> Finding:
+    rows, error = _execute_unit(client, unit)
+    if error:
+        return Finding(unit.target, "execution", "error", "query failed: {}".format(error))
+    if not rows:
+        return Finding(unit.target, "execution", "warn", "query returned 0 rows")
+    if unit.expected_columns:
+        missing = [c for c in unit.expected_columns if c not in rows[0]]
+        if missing:
+            return Finding(unit.target, "execution", "warn",
+                           "missing expected columns: {}".format(missing))
+    return Finding(unit.target, "execution", "ok", "{} rows".format(len(rows)))

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -9,6 +9,9 @@ class CardUnit:
     display: Optional[str] = None
     visualization_settings: Optional[Dict[str, Any]] = None
     live_card_id: Optional[int] = None
+    # Reserved hooks — not yet wired into guarded_apply/check_differential in v1,
+    # which uses the auto metric derived from _signature. Future versions will
+    # honour these fields for column-level assertions and metric overrides.
     expected_columns: Optional[List[str]] = None
     metric_override: Optional[Dict[str, Any]] = None
 
@@ -91,13 +94,18 @@ def check_refs(client, unit: "CardUnit") -> List[Finding]:
     if dq.get("type") == "query":
         src = (dq.get("query") or {}).get("source-table")
         if isinstance(src, str) and src.startswith("card__"):
-            cid = int(src.split("__")[1])
-            if not _card_exists(client, cid):
+            try:
+                cid = int(src.split("__")[1])
+            except (ValueError, IndexError):
                 findings.append(Finding(unit.target, "refs", "error",
-                    "source card {} not found / archived".format(cid)))
+                    "malformed source-table ref {!r}".format(src)))
+            else:
+                if not _card_exists(client, cid):
+                    findings.append(Finding(unit.target, "refs", "error",
+                        "source card {} not found / archived".format(cid)))
     for tag in ((dq.get("native") or {}).get("template-tags") or {}).values():
         cid = (tag.get("values_source_config") or {}).get("card_id")
-        if cid and not _card_exists(client, cid):
+        if cid is not None and not _card_exists(client, cid):
             findings.append(Finding(unit.target, "refs", "error",
                 "field-filter source card {} not found / archived".format(cid)))
     if not findings:
@@ -149,7 +157,10 @@ def _execute_unit(client, unit: "CardUnit"):
             rows = client.get_card_data(card_id=unit.live_card_id, data_format="json")
         except Exception as e:
             return [], str(e)
-        return rows or [], None
+        if not isinstance(rows, list):
+            err = rows.get("error") if isinstance(rows, dict) else None
+            return [], err or "query failed (unexpected result shape)"
+        return rows, None
     res = client.run_query(unit.dataset_query)
     if not isinstance(res, dict) or res.get("status") == "failed" or res.get("error"):
         err = res.get("error") if isinstance(res, dict) else "HTTP error"

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -136,6 +136,12 @@ class Report:
         return 1 if self.errors() else 0
 
 
+class ValidationError(Exception):
+    def __init__(self, report: "Report"):
+        self.report = report
+        super().__init__("validation failed:\n" + report.render())
+
+
 def _execute_unit(client, unit: "CardUnit"):
     """Run the unit's query. Returns (rows: list[dict], error: str|None)."""
     if unit.live_card_id is not None:

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -64,6 +64,22 @@ class Finding:
     after: Any = None
 
 
+def check_structure(unit: "CardUnit") -> Finding:
+    dq = unit.dataset_query
+    if not isinstance(dq, dict) or "database" not in dq:
+        return Finding(unit.target, "structure", "error", "dataset_query missing 'database'")
+    qtype = dq.get("type")
+    if qtype == "native":
+        if not (dq.get("native") or {}).get("query"):
+            return Finding(unit.target, "structure", "error", "native query is empty")
+    elif qtype == "query":
+        if not dq.get("query"):
+            return Finding(unit.target, "structure", "error", "MBQL query is empty")
+    else:
+        return Finding(unit.target, "structure", "error", "unknown query type {!r}".format(qtype))
+    return Finding(unit.target, "structure", "ok", "well-formed")
+
+
 @dataclass
 class Report:
     findings: List[Finding] = field(default_factory=list)

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -180,6 +180,54 @@ def _signature(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
     return {"row_count": len(rows), "columns": cols, "sums": sums}
 
 
+def gate(client, units, execute=True) -> Report:
+    report = Report()
+    for u in units:
+        s = check_structure(u)
+        report.add(s)
+        if s.level == "error":
+            continue
+        ref_findings = check_refs(client, u)
+        for f in ref_findings:
+            report.add(f)
+        if any(f.level == "error" for f in ref_findings):
+            continue
+        if execute:
+            report.add(check_execution(client, u))
+    return report
+
+
+def guarded_apply(client, units, mutate_fn, differential="monitor",
+                  force=False, execute=True) -> Report:
+    report = Report()
+    baselines: Dict[str, List[Dict[str, Any]]] = {}
+    if differential != "off":
+        for u in units:
+            if u.live_card_id is not None:
+                rows, err = _execute_unit(client, u)
+                if not err:
+                    baselines[u.target] = rows
+    g = gate(client, units, execute=execute)
+    report.findings.extend(g.findings)
+    if g.errors() and not force:
+        report.add(Finding("apply", "gate", "error",
+                           "aborted: pre-apply errors, nothing mutated"))
+        return report
+    mutate_fn()
+    if differential != "off":
+        mode = "identical" if differential == "identical" else "monitor"
+        for u in units:
+            if u.target in baselines:
+                after, err = _execute_unit(client, u)
+                if err:
+                    report.add(Finding(u.target, "differential", "error",
+                        "post-apply query failed: {}".format(err)))
+                    continue
+                for f in check_differential(u.target, baselines[u.target], after, mode=mode):
+                    report.add(f)
+    return report
+
+
 def check_differential(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]:
     """Compare two result sets (before/after).
     mode="identical" => deltas are errors; mode="monitor" => deltas are warns.

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Finding:
+    target: str
+    check: str
+    level: str  # "error" | "warn" | "ok"
+    message: str
+    before: Any = None
+    after: Any = None
+
+
+@dataclass
+class Report:
+    findings: List[Finding] = field(default_factory=list)
+
+    def add(self, f: Finding) -> None:
+        self.findings.append(f)
+
+    def errors(self) -> List[Finding]:
+        return [f for f in self.findings if f.level == "error"]
+
+    def ok(self) -> bool:
+        return not self.errors()
+
+    def summary(self) -> str:
+        counts: Dict[str, int] = {}
+        for f in self.findings:
+            counts[f.level] = counts.get(f.level, 0) + 1
+        parts = ["{} {}".format(v, k) for k, v in sorted(counts.items())]
+        return ", ".join(parts) or "no findings"
+
+    def render(self) -> str:
+        glyph = {"error": "✗", "warn": "!", "ok": "✓"}
+        lines = ["  {}  {:<12} {}  [{}]".format(
+            glyph.get(f.level, "?"), f.check, f.target, f.message)
+            for f in self.findings]
+        return "\n".join(lines) + ("\n" if lines else "") + "Report: " + self.summary()
+
+    def exit_code(self) -> int:
+        return 1 if self.errors() else 0

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -234,6 +234,16 @@ def guarded_apply(client, units, mutate_fn, differential="monitor",
     return report
 
 
+def resolve_cli_target(client, target: str) -> List["CardUnit"]:
+    import os
+    from . import iac
+    if target.lower().endswith((".yaml", ".yml", ".json")) and os.path.exists(target):
+        return units_from_spec(iac.load(target))
+    if target.isdigit():
+        return [unit_from_card_id(client, int(target))]
+    return units_from_spec(iac.export(client, target))
+
+
 def check_differential(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]:
     """Compare two result sets (before/after).
     mode="identical" => deltas are errors; mode="monitor" => deltas are warns.

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -139,12 +139,25 @@ def phase1_readonly(mb: Metabase_API, sample_collection: Optional[str]) -> None:
     _ok("search('a') returned {} items".format(len(results)))
 
     dashboards = [r for r in results if r.get("model") == "dashboard"]
+    card_id: Optional[int] = None
     if dashboards:
         dash_id = dashboards[0]["id"]
         cards = mb.get_dashboard_question_ids(dashboard_id=dash_id)
         _ok("get_dashboard_question_ids({}) -> {} cards".format(dash_id, len(cards)))
+        if cards:
+            card_id = cards[0]
     else:
         _skip("get_dashboard_question_ids: no dashboard surfaced by search")
+
+    # Validation smoke (read-only): a known-good card must pass the gate.
+    from spark_metabase_api import validate as V  # noqa: PLC0415
+    if card_id:
+        report = V.gate(mb, [V.unit_from_card_id(mb, card_id)], execute=True)
+        print(report.render())
+        assert report.ok(), "validation gate failed on a known-good card"
+        _ok("validate.gate passed on card#{}".format(card_id))
+    else:
+        _skip("validate.gate smoke: no card id available (no dashboard with cards found)")
 
     if sample_collection is None:
         _skip("iac.export idempotency: no --collection passed")

--- a/tests/test_audit_lib.py
+++ b/tests/test_audit_lib.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Tests unitaires d'audit_lib — script autonome (convention du repo).
+
+Usage : python3 tests/test_audit_lib.py
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import audit_lib
+
+
+# --- Registre ----------------------------------------------------------------
+
+def test_patterns_registry_complete():
+    assert len(audit_lib.PATTERNS) == 11
+    for key, meta in audit_lib.PATTERNS.items():
+        assert set(meta) >= {"num", "family", "impact", "risk", "effort", "wave"}
+        assert meta["impact"] in ("H", "M", "L")
+        assert meta["risk"] in ("H", "M", "L")
+        assert meta["effort"] in ("H", "M", "L")
+        assert meta["wave"] in (0, 1, 2, 3)
+    nums = sorted(m["num"] for m in audit_lib.PATTERNS.values())
+    assert nums == list(range(1, 12))
+
+
+# --- Empreinte v2 (régression faux-positifs GSC) -----------------------------
+
+_GSC_SQL = json.dumps({
+    "type": "native",
+    "database": 2,
+    "native": {"query": "WITH get_data AS (SELECT date, clicks, ctr, weighted_position FROM gsc) SELECT * FROM get_data"},
+})
+
+
+def _gsc_card(cid, name, metric):
+    return {
+        "id": cid, "name": name, "display": "line",
+        "legacy_query": _GSC_SQL,
+        "visualization_settings": {"graph.metrics": [metric], "graph.dimensions": ["DATE", "URL_GROUP"]},
+    }
+
+
+def test_query_fingerprint_identical_for_gsc_trio():
+    a = _gsc_card(28943, "Clicks by date", "CLICKS")
+    b = _gsc_card(28945, "CTR by date", "CTR")
+    c = _gsc_card(28946, "Weighted position by date", "WEIGHTED_POSITION")
+    assert audit_lib.query_fingerprint(a) == audit_lib.query_fingerprint(b) == audit_lib.query_fingerprint(c)
+
+
+def test_output_fingerprint_distinct_for_gsc_trio():
+    a = _gsc_card(28943, "Clicks by date", "CLICKS")
+    b = _gsc_card(28945, "CTR by date", "CTR")
+    c = _gsc_card(28946, "Weighted position by date", "WEIGHTED_POSITION")
+    fps = {audit_lib.output_fingerprint(a), audit_lib.output_fingerprint(b), audit_lib.output_fingerprint(c)}
+    assert len(fps) == 3  # PAS des doublons
+
+
+def test_output_fingerprint_identical_for_true_duplicate():
+    a = _gsc_card(1, "Clicks by date", "CLICKS")
+    b = _gsc_card(2, "Clicks by date (copie)", "CLICKS")  # rendu identique
+    assert audit_lib.output_fingerprint(a) == audit_lib.output_fingerprint(b)
+
+
+# --- Classification ----------------------------------------------------------
+
+def test_classify_separates_dups_variants_and_viz():
+    # Groupe A : même requête + même display 'line', sélections ≠ -> variantes (#9),
+    # avec un doublon pur dedans (#1 == #2). variant_families ⟂ diff_viz pour un
+    # même groupe de requête, donc le cas viz≠ a besoin de sa propre requête.
+    a1 = _gsc_card(1, "Clicks", "CLICKS")
+    a2 = _gsc_card(2, "Clicks copie", "CLICKS")          # doublon de #1 (output identique)
+    a3 = _gsc_card(3, "CTR", "CTR")                       # variante
+    a4 = _gsc_card(4, "Position", "WEIGHTED_POSITION")    # variante
+    # Groupe B : autre requête, mêmes données mais displays ≠ -> diff_viz.
+    sql_b = json.dumps({"type": "native", "database": 2, "native": {"query": "SELECT a, b FROM t"}})
+    b1 = {"id": 5, "name": "B line", "display": "line", "legacy_query": sql_b,
+          "visualization_settings": {"graph.metrics": ["A"]}}
+    b2 = {"id": 6, "name": "B bar", "display": "bar", "legacy_query": sql_b,
+          "visualization_settings": {"graph.metrics": ["A"]}}
+    res = audit_lib.classify_query_groups([a1, a2, a3, a4, b1, b2])
+    assert any(sorted(c["id"] for c in g) == [1, 2] for g in res["pure_dups"])          # #6
+    assert any({c["id"] for c in g} == {1, 2, 3, 4} for g in res["variant_families"])   # #9
+    assert any({c["id"] for c in g} == {5, 6} for g in res["diff_viz"])
+
+
+# --- Graphe de sources / inutilisées -----------------------------------------
+
+def test_build_source_ids_finds_card_references():
+    details = [
+        {"id": 100, "dataset_query": {"query": {"source-table": "card__42"}}},
+        {"id": 101, "legacy_query": json.dumps({"query": {"source-table": "card__7"}})},
+    ]
+    assert audit_lib.build_source_ids(details) == {42, 7}
+
+
+def test_find_unused_cards_excludes_sources_and_used():
+    cards = [
+        {"id": 1, "name": "orpheline", "dashboard_count": 0, "archived": False},
+        {"id": 2, "name": "utilisée", "dashboard_count": 3, "archived": False},
+        {"id": 3, "name": "source", "dashboard_count": 0, "archived": False},
+        {"id": 4, "name": "archivée", "dashboard_count": 0, "archived": True},
+    ]
+    unused = audit_lib.find_unused_cards(cards, source_ids={3})
+    assert [c["id"] for c in unused] == [1]
+
+
+# --- Détecteurs de collections -----------------------------------------------
+
+def test_find_empty_collections_respects_descendants_and_personal():
+    collections = [
+        {"id": 1, "name": "Parent", "location": "/"},
+        {"id": 2, "name": "Enfant occupé", "location": "/1/"},
+        {"id": 3, "name": "Vraiment vide", "location": "/"},
+        {"id": 4, "name": "Perso vide", "location": "/", "personal_owner_id": 9},
+    ]
+    cards = [{"id": 50, "collection_id": 2, "archived": False}]
+    dashboards = []
+    empty = audit_lib.find_empty_collections(collections, cards, dashboards)
+    ids = {e["id"] for e in empty}
+    assert ids == {3}        # 1 a un descendant occupé ; 2 est occupée ; 4 est perso
+
+
+def test_find_junk_collections_matches_names():
+    collections = [
+        {"id": 1, "name": "To sort", "location": "/"},
+        {"id": 2, "name": "TMP backup", "location": "/"},
+        {"id": 3, "name": "05. Google Analytics 4", "location": "/"},
+    ]
+    junk_ids = {c["id"] for c in audit_lib.find_junk_collections(collections)}
+    assert junk_ids == {1, 2}
+
+
+def test_find_duplicate_collection_names():
+    collections = [
+        {"id": 1, "name": "Bar", "location": "/a/"},
+        {"id": 2, "name": "Bar", "location": "/b/"},
+        {"id": 3, "name": "Unique", "location": "/"},
+    ]
+    dups = audit_lib.find_duplicate_collection_names(collections)
+    assert len(dups) == 1 and dups[0]["name"] == "Bar" and dups[0]["count"] == 2
+
+
+# --- Sprawl perso / nommage --------------------------------------------------
+
+def test_find_personal_sprawl_groups_by_client():
+    collections = [
+        {"id": 1, "name": "Accor | Nanga's Personal Collection", "personal_owner_id": 5},
+        {"id": 2, "name": "Accor | Nanga's Personal Collection", "personal_owner_id": 5},
+        {"id": 3, "name": "Apple | Nanga's Personal Collection", "personal_owner_id": 5},
+        {"id": 4, "name": "Louis Monier's Personal Collection", "personal_owner_id": 7},  # pas de client
+        {"id": 5, "name": "06. Industry benchmarks"},  # partagée
+    ]
+    sprawl = {s["client"]: s["count"] for s in audit_lib.find_personal_sprawl(collections, [])}
+    assert sprawl == {"Accor": 2, "Apple": 1}
+
+
+def test_find_naming_issues_flags_non_normalized_outside_template():
+    cards = [
+        {"id": 1, "name": "Add_to_cart_rate", "archived": False, "collection_id": 99},
+        {"id": 2, "name": "Clean name", "archived": False, "collection_id": 99},
+        {"id": 3, "name": "Ignored_in_template", "archived": False, "collection_id": 99},
+    ]
+    issues = audit_lib.find_naming_issues(cards, template_card_ids={3})
+    assert [i["id"] for i in issues] == [1]  # #2 déjà propre, #3 dans le template
+
+
+# --- Dérive template ---------------------------------------------------------
+
+def test_find_template_drift_by_name_and_query():
+    def card(cid, name, sql):
+        return {"id": cid, "name": name, "collection_id": 1,
+                "legacy_query": json.dumps({"type": "native", "database": 2, "native": {"query": sql}})}
+    template = [card(10, "Daily revenue", "SELECT day, sum(amount) FROM sales GROUP BY 1")]
+    others = [
+        card(20, "Daily revenue", "SELECT day, sum(amount) FROM sales GROUP BY 1"),           # conforme
+        card(21, "Daily revenue", "SELECT day, sum(amount) FROM sales WHERE x GROUP BY 1"),   # dérivée
+        card(22, "Autre carte", "SELECT 1"),  # pas d'équivalent template
+    ]
+    drift = audit_lib.find_template_drift(template, others)
+    assert [d["id"] for d in drift] == [21]
+    assert drift[0]["template_id"] == 10
+
+
+# --- Scoring -----------------------------------------------------------------
+
+def test_summarize_findings_sorts_by_wave_then_count():
+    findings = {
+        "template_drift": {"count": 5, "items": []},        # wave 3
+        "empty_collections": {"count": 200, "items": []},   # wave 0
+        "naming_issues": {"count": 9, "items": []},         # wave 1
+    }
+    rows = audit_lib.summarize_findings(findings)
+    assert [r["key"] for r in rows][:3] == ["empty_collections", "naming_issues", "template_drift"]
+    assert rows[0]["wave"] == 0 and rows[0]["impact"] == "H"
+
+
+TESTS = [
+    test_patterns_registry_complete,
+    test_query_fingerprint_identical_for_gsc_trio,
+    test_output_fingerprint_distinct_for_gsc_trio,
+    test_output_fingerprint_identical_for_true_duplicate,
+    test_classify_separates_dups_variants_and_viz,
+    test_build_source_ids_finds_card_references,
+    test_find_unused_cards_excludes_sources_and_used,
+    test_find_empty_collections_respects_descendants_and_personal,
+    test_find_junk_collections_matches_names,
+    test_find_duplicate_collection_names,
+    test_find_personal_sprawl_groups_by_client,
+    test_find_naming_issues_flags_non_normalized_outside_template,
+    test_find_template_drift_by_name_and_query,
+    test_summarize_findings_sorts_by_wave_then_count,
+]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_audit_lib.py
+++ b/tests/test_audit_lib.py
@@ -141,12 +141,13 @@ def test_find_empty_collections_respects_descendants_and_personal():
         {"id": 2, "name": "Enfant occupé", "location": "/1/"},
         {"id": 3, "name": "Vraiment vide", "location": "/"},
         {"id": 4, "name": "Perso vide", "location": "/", "personal_owner_id": 9},
+        {"id": "root", "name": "Our analytics", "location": "/"},  # racine Metabase, à exclure
     ]
     cards = [{"id": 50, "collection_id": 2, "archived": False}]
     dashboards = []
     empty = audit_lib.find_empty_collections(collections, cards, dashboards)
     ids = {e["id"] for e in empty}
-    assert ids == {3}        # 1 a un descendant occupé ; 2 est occupée ; 4 est perso
+    assert ids == {3}        # 1 a un descendant occupé ; 2 occupée ; 4 perso ; root exclue
 
 
 def test_find_junk_collections_matches_names():

--- a/tests/test_audit_lib.py
+++ b/tests/test_audit_lib.py
@@ -133,6 +133,21 @@ def test_find_unused_cards_excludes_sources_and_used():
     assert [c["id"] for c in unused] == [1]
 
 
+def test_days_since():
+    assert audit_lib.days_since("2026-03-11T09:51:41Z", "2026-05-29") == 79
+    assert audit_lib.days_since(None, "2026-05-29") is None
+    assert audit_lib.days_since("pas une date", "2026-05-29") is None
+
+
+def test_is_stale_uses_recency():
+    now = "2026-05-29"
+    assert audit_lib.is_stale({"last_used_at": "2025-10-01T00:00:00Z"}, now)        # ~8 mois -> dormante
+    assert not audit_lib.is_stale({"last_used_at": "2026-05-01T00:00:00Z"}, now)    # récent
+    assert not audit_lib.is_stale({"last_used_at": None}, now)                       # récence inconnue -> non flaggée
+    # dormante même si très vue historiquement (le view_count n'est pas un critère)
+    assert audit_lib.is_stale({"last_used_at": "2024-01-01T00:00:00Z", "view_count": 5000}, now)
+
+
 # --- Détecteurs de collections -----------------------------------------------
 
 def test_find_empty_collections_respects_descendants_and_personal():
@@ -235,6 +250,8 @@ TESTS = [
     test_classify_separates_dups_variants_and_viz,
     test_build_source_ids_finds_card_references,
     test_find_unused_cards_excludes_sources_and_used,
+    test_days_since,
+    test_is_stale_uses_recency,
     test_find_empty_collections_respects_descendants_and_personal,
     test_find_junk_collections_matches_names,
     test_find_duplicate_collection_names,

--- a/tests/test_audit_lib.py
+++ b/tests/test_audit_lib.py
@@ -64,6 +64,32 @@ def test_output_fingerprint_identical_for_true_duplicate():
     assert audit_lib.output_fingerprint(a) == audit_lib.output_fingerprint(b)
 
 
+def test_output_fingerprint_handles_none_in_metrics():
+    # Donnée réelle sale rencontrée en prod : graph.metrics/dimensions peut contenir None.
+    card = {"id": 1, "display": "line", "legacy_query": _GSC_SQL,
+            "visualization_settings": {"graph.metrics": ["CLICKS", None], "graph.dimensions": [None]}}
+    fp = audit_lib.output_fingerprint(card)  # ne doit pas lever
+    assert isinstance(fp, str)
+
+
+def test_output_fingerprint_distinct_for_parameter_default_variants():
+    # "Conversions by device/age/country" : même SQL, même display 'pie', sans
+    # graph.metrics — diffèrent seulement par le défaut du paramètre `breakdown`
+    # (2e classe de faux positifs constatée en prod).
+    sql = json.dumps({"type": "native", "database": 2,
+                      "native": {"query": "SELECT breakdown_value AS dimension FROM t"}})
+
+    def card(cid, val):
+        return {"id": cid, "name": f"Conversions by {val}", "display": "pie", "legacy_query": sql,
+                "visualization_settings": {}, "parameters": [{"slug": "breakdown", "default": [val]}]}
+
+    a, b, c = card(1, "device"), card(2, "age"), card(3, "country")
+    assert len({audit_lib.output_fingerprint(x) for x in (a, b, c)}) == 3
+    res = audit_lib.classify_query_groups([a, b, c])
+    assert res["pure_dups"] == []
+    assert any({x["id"] for x in g} == {1, 2, 3} for g in res["variant_families"])
+
+
 # --- Classification ----------------------------------------------------------
 
 def test_classify_separates_dups_variants_and_viz():
@@ -202,6 +228,8 @@ TESTS = [
     test_query_fingerprint_identical_for_gsc_trio,
     test_output_fingerprint_distinct_for_gsc_trio,
     test_output_fingerprint_identical_for_true_duplicate,
+    test_output_fingerprint_handles_none_in_metrics,
+    test_output_fingerprint_distinct_for_parameter_default_variants,
     test_classify_separates_dups_variants_and_viz,
     test_build_source_ids_finds_card_references,
     test_find_unused_cards_excludes_sources_and_used,

--- a/tests/test_audit_lib.py
+++ b/tests/test_audit_lib.py
@@ -142,12 +142,13 @@ def test_find_empty_collections_respects_descendants_and_personal():
         {"id": 3, "name": "Vraiment vide", "location": "/"},
         {"id": 4, "name": "Perso vide", "location": "/", "personal_owner_id": 9},
         {"id": "root", "name": "Our analytics", "location": "/"},  # racine Metabase, à exclure
+        {"id": 6, "name": "Metrics", "location": "/", "type": "library-metrics"},  # système, non archivable
     ]
     cards = [{"id": 50, "collection_id": 2, "archived": False}]
     dashboards = []
     empty = audit_lib.find_empty_collections(collections, cards, dashboards)
     ids = {e["id"] for e in empty}
-    assert ids == {3}        # 1 a un descendant occupé ; 2 occupée ; 4 perso ; root exclue
+    assert ids == {3}        # 1 descendant occupé ; 2 occupée ; 4 perso ; root + 6 (système) exclues
 
 
 def test_find_junk_collections_matches_names():

--- a/tests/test_audit_report.py
+++ b/tests/test_audit_report.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Tests du rendu d'audit — script autonome. Usage : python3 tests/test_audit_report.py"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import audit_report
+
+
+def _findings():
+    return {
+        "empty_collections": {"count": 200, "items": [{"id": i, "name": f"col{i}"} for i in range(200)]},
+        "pure_dups": {"count": 2, "items": [[{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]]},
+        "template_drift": {"count": 0, "items": []},
+    }
+
+
+def test_report_is_short_and_caps_examples():
+    md = audit_report.render_report(_findings(), scanned_cards=5654, scanned_collections=868, date="2026-05-28")
+    assert "## Résumé" in md and "## Backlog" in md
+    # exemples plafonnés : au plus MAX_EXAMPLES lignes d'exemple type "  - `"
+    assert md.count("  - `") <= audit_report.MAX_EXAMPLES
+    assert "+195" in md  # 200 - 5 exemples
+    # un pattern à 0 n'apparaît pas dans le backlog
+    assert "template_drift" not in md.split("## Backlog")[1]
+
+
+def test_report_short_overall():
+    md = audit_report.render_report(_findings(), scanned_cards=5654, scanned_collections=868, date="2026-05-28")
+    assert len(md.splitlines()) < 60  # digest, pas un pavé
+
+
+TESTS = [test_report_is_short_and_caps_examples, test_report_short_overall]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_audit_report.py
+++ b/tests/test_audit_report.py
@@ -11,9 +11,18 @@ import audit_report
 def _findings():
     return {
         "empty_collections": {"count": 200, "items": [{"id": i, "name": f"col{i}"} for i in range(200)]},
+        "archived_backlog": {"count": 1803, "items": [{"archived_cards": 0, "archived_collections": 1803}]},
         "pure_dups": {"count": 2, "items": [[{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]]},
         "template_drift": {"count": 0, "items": []},
     }
+
+
+def test_archived_backlog_renders_clean_summary_line():
+    md = audit_report.render_report(_findings(), scanned_cards=5654, scanned_collections=868, date="2026-05-29")
+    assert "1803 collections + 0 cartes archivées" in md
+    # pas de dict brut ni de "+N" trompeur pour archived_backlog
+    assert "'archived_collections'" not in md
+    assert "+1798" not in md
 
 
 def test_report_is_short_and_caps_examples():
@@ -31,7 +40,8 @@ def test_report_short_overall():
     assert len(md.splitlines()) < 60  # digest, pas un pavé
 
 
-TESTS = [test_report_is_short_and_caps_examples, test_report_short_overall]
+TESTS = [test_report_is_short_and_caps_examples, test_report_short_overall,
+         test_archived_backlog_renders_clean_summary_line]
 
 
 def run():

--- a/tests/test_bascule_lib.py
+++ b/tests/test_bascule_lib.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Tests de bascule_lib (bascule du filtre temps category -> temporal-unit).
+Usage : python3 tests/test_bascule_lib.py"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import bascule_lib
+
+TIME_TARGET = ["dimension", ["template-tag", "time_period"]]
+
+def _dash():
+    return {
+        "id": 25567,
+        "parameters": [
+            {"id": "fc917174", "name": "Time period", "slug": "time_period", "type": "category",
+             "default": ["week"], "values_source_type": "static-list",
+             "values_source_config": {"values": ["week", "day", "month", "year"]}},
+            {"id": "759220c7", "name": "Date", "slug": "date", "type": "date/all-options"},
+        ],
+        "dashcards": [
+            # tuile sur ANCIEN mécanisme (tag dimension) câblée au filtre temps + date
+            {"id": 1, "card_id": 100, "parameter_mappings": [
+                {"parameter_id": "fc917174", "card_id": 100, "target": TIME_TARGET},
+                {"parameter_id": "759220c7", "card_id": 100, "target": ["dimension", ["template-tag", "date"]]}]},
+            # tuile migrée : câblage MORT (la carte n'a aucun tag time_period)
+            {"id": 2, "card_id": 200, "parameter_mappings": [
+                {"parameter_id": "fc917174", "card_id": 200, "target": TIME_TARGET}]},
+            # tuile temporal-unit PAS câblée au filtre temps -> à câbler
+            {"id": 3, "card_id": 300, "parameter_mappings": []},
+            # tuile sans rapport avec le temps
+            {"id": 4, "card_id": 400, "parameter_mappings": []},
+            # tuile texte (pas de carte)
+            {"id": 5, "card_id": None, "parameter_mappings": []},
+        ],
+    }
+
+TAGS = {
+    100: {"time_period": {"type": "dimension", "widget-type": "category"}, "date": {"type": "dimension"}},
+    200: {"date": {"type": "dimension"}},
+    300: {"time_period": {"type": "temporal-unit"}},
+    400: {"clients": {"type": "dimension"}},
+    1000: {"time_period": {"type": "temporal-unit"}, "date": {"type": "dimension"}},
+}
+
+# --- time_param_payload ---
+
+def test_payload_dimension_tag():
+    p = bascule_lib.time_param_payload(TAGS[100], "week")
+    assert p == {"type": "category", "value": ["week"], "target": TIME_TARGET}
+
+def test_payload_temporal_unit_tag():
+    p = bascule_lib.time_param_payload(TAGS[300], "month")
+    assert p == {"type": "temporal-unit", "value": "month", "target": TIME_TARGET}
+
+def test_payload_absent_or_text():
+    assert bascule_lib.time_param_payload(TAGS[200], "week") is None
+    assert bascule_lib.time_param_payload({"time_period": {"type": "text"}}, "week") is None
+
+# --- find_time_param / build_temporal_unit_param ---
+
+def test_find_time_param():
+    p = bascule_lib.find_time_param(_dash())
+    assert p and p["id"] == "fc917174"
+
+def test_find_time_param_ignores_temporal_unit():
+    d = _dash()
+    d["parameters"][0]["type"] = "temporal-unit"
+    assert bascule_lib.find_time_param(d) is None
+
+def test_build_temporal_unit_param_keeps_id_and_default():
+    new = bascule_lib.build_temporal_unit_param(_dash()["parameters"][0])
+    assert new["id"] == "fc917174" and new["type"] == "temporal-unit"
+    # le défaut category est une LISTE (['week']) -> temporal-unit veut une string
+    assert new["default"] == "week" and new["slug"] == "time_period"
+    assert new["temporal_units"] == ["day", "week", "month", "quarter", "year"]
+    assert new["sectionId"] == "temporal-unit"
+    assert "values_source_type" not in new and "values_source_config" not in new
+
+def test_build_temporal_unit_param_default_fallback():
+    assert bascule_lib.build_temporal_unit_param({"id": "x", "default": None})["default"] == "week"
+    assert bascule_lib.build_temporal_unit_param({"id": "x", "default": ["month"]})["default"] == "month"
+    assert bascule_lib.build_temporal_unit_param({"id": "x", "default": "day"})["default"] == "day"
+
+# --- bascule_plan ---
+
+def test_plan_classifies_everything():
+    plan = bascule_lib.bascule_plan(_dash(), TAGS)
+    assert plan["old_param"]["id"] == "fc917174"
+    assert [b["card_id"] for b in plan["blockers"]] == [100]
+    assert plan["dead_mappings"] == [(2, "fc917174")]
+    assert plan["to_wire"] == [(3, 300)]
+
+def test_plan_no_time_param():
+    d = _dash()
+    d["parameters"] = [d["parameters"][1]]
+    assert bascule_lib.bascule_plan(d, TAGS) is None
+
+def test_plan_blocker_resolved_by_swap():
+    plan = bascule_lib.bascule_plan(_dash(), TAGS, swaps={100: 1000})
+    assert plan["blockers"] == []
+    assert plan["swaps"] == {100: 1000}
+
+# --- apply_bascule ---
+
+def test_apply_rewrites_everything():
+    d = _dash()
+    plan = bascule_lib.bascule_plan(d, TAGS, swaps={100: 1000})
+    params, dcs = bascule_lib.apply_bascule(d, plan)
+    # paramètre remplacé sur place, même id
+    tp = [p for p in params if p["id"] == "fc917174"][0]
+    assert tp["type"] == "temporal-unit" and len(params) == 2
+    by_id = {dc["id"]: dc for dc in dcs}
+    # swap : card_id repointé, mappings suivent (card_id mis à jour, targets conservés)
+    assert by_id[1]["card_id"] == 1000
+    assert all(pm["card_id"] == 1000 for pm in by_id[1]["parameter_mappings"])
+    assert any(pm["target"] == TIME_TARGET for pm in by_id[1]["parameter_mappings"])
+    # câblage mort supprimé
+    assert by_id[2]["parameter_mappings"] == []
+    # carte temporal-unit non câblée -> câblée au param temps
+    wires = by_id[3]["parameter_mappings"]
+    assert wires == [{"parameter_id": "fc917174", "card_id": 300, "target": TIME_TARGET}]
+    # tuiles sans rapport : intactes
+    assert by_id[4]["parameter_mappings"] == []
+
+def test_apply_refuses_unresolved_blockers():
+    d = _dash()
+    plan = bascule_lib.bascule_plan(d, TAGS)
+    try:
+        bascule_lib.apply_bascule(d, plan)
+        assert False, "aurait dû refuser (blocker non résolu)"
+    except ValueError:
+        pass
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t(); print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1; print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_conv_lib.py
+++ b/tests/test_conv_lib.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Tests de conv_lib — script autonome. Usage : python3 tests/test_conv_lib.py"""
+import json, sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import conv_lib
+
+def _native(sql, tags=()):
+    return {"dataset_query": {"type": "native", "native": {"query": sql, "template-tags": {t: {} for t in tags}}}}
+
+def _staged(sql, tags=()):
+    return {"dataset_query": {"lib/type": "mbql/query",
+            "stages": [{"lib/type": "mbql.stage/native", "native": sql,
+                        "template-tags": {t: {} for t in tags}}]}}
+
+def _card(name, display, dims=(), sql="SELECT 1"):
+    return {"name": name, "display": display,
+            "visualization_settings": {"graph.dimensions": list(dims)},
+            "dataset_query": {"type": "native", "native": {"query": sql}}}
+
+def test_native_and_tags_legacy_format():
+    sql, tags = conv_lib.native_and_tags(_native("SELECT SUM(conversions_1)", ["clients", "date"]))
+    assert "conversions_1" in sql and tags.keys() == {"clients", "date"}
+
+def test_native_and_tags_stages_format():
+    sql, tags = conv_lib.native_and_tags(_staged("SELECT SUM(custom_conversions_1)", ["clients", "date"]))
+    assert "custom_conversions_1" in sql and set(tags) == {"clients", "date"}
+
+def test_native_and_tags_legacy_query_fallback():
+    card = {"legacy_query": json.dumps({"type": "native", "native": {"query": "SELECT 1", "template-tags": {"date": {}}}})}
+    sql, tags = conv_lib.native_and_tags(card)
+    assert sql == "SELECT 1" and set(tags) == {"date"}
+
+def test_old_columns_detects_positional_not_custom():
+    sql = "SELECT SUM(global.campaign_daily_metrics.conversions_1), SUM(custom_conversions_1) "
+    assert conv_lib.old_conversion_columns(sql) == {"CONVERSIONS_1"}
+
+def test_old_columns_base_not_matched_inside_positional():
+    assert conv_lib.old_conversion_columns("SELECT SUM(conversions_12)") == {"CONVERSIONS_12"}
+
+def test_old_columns_ignores_conversion_type_filter():
+    assert conv_lib.old_conversion_columns("WHERE conversion_type = 'x'") == set()
+
+def test_new_columns_named_and_custom():
+    sql = "SELECT SUM(purchases), SUM(custom_conversions_2_value)"
+    assert conv_lib.new_conversion_columns(sql) == {"PURCHASES", "CUSTOM_CONVERSIONS_2_VALUE"}
+
+def test_slot_old_columns():
+    assert conv_lib.slot_old_columns(0) == ("CONVERSIONS", "CONVERSION_VALUE")
+    assert conv_lib.slot_old_columns(3) == ("CONVERSIONS_3", "CONVERSION_3_VALUE")
+
+def test_type_to_slot():
+    assert conv_lib.TYPE_TO_SLOT["Main conversion"] == 0
+    assert conv_lib.TYPE_TO_SLOT["1st conversion"] == 1
+    assert conv_lib.TYPE_TO_SLOT["3rd conversion"] == 3
+    assert conv_lib.TYPE_TO_SLOT["19th conversion"] == 19
+
+def test_new_type_columns_custom_and_named():
+    assert conv_lib.new_type_columns("Custom 1") == ("CUSTOM_CONVERSIONS_1", "CUSTOM_CONVERSIONS_1_VALUE")
+    assert conv_lib.new_type_columns("Custom 2") == ("CUSTOM_CONVERSIONS_2", "CUSTOM_CONVERSIONS_2_VALUE")
+    assert conv_lib.new_type_columns("Purchases") == ("PURCHASES", "PURCHASES_VALUE")
+    assert conv_lib.new_type_columns("Sign ups") == ("SIGN_UPS", None)
+
+def test_build_client_mappings_resolves_consistent_and_flags_unmapped_conflict():
+    records = [
+        {"client": "Pro Nutrition", "type": "Main conversion", "new_type": "Purchases"},
+        {"client": "Pro Nutrition", "type": "Main conversion", "new_type": "Purchases"},
+        {"client": "Pro Nutrition", "type": "1st conversion", "new_type": "Custom 1"},
+        {"client": "Pro Nutrition", "type": "3rd conversion", "new_type": "Custom 2"},
+        {"client": "Pro Nutrition", "type": "1st conversion", "new_type": None},
+        {"client": "Acme", "type": "Main conversion", "new_type": None},
+        {"client": "Acme", "type": "2nd conversion", "new_type": "Leads"},
+        {"client": "Acme", "type": "2nd conversion", "new_type": "Purchases"},
+    ]
+    m = conv_lib.build_client_mappings(records)
+    assert m["Pro Nutrition"][0] == "Purchases"
+    assert m["Pro Nutrition"][1] == "Custom 1"
+    assert m["Pro Nutrition"][3] == "Custom 2"
+    assert m["Acme"][0] == conv_lib.UNMAPPED
+    assert m["Acme"][2] == conv_lib.CONFLICT
+
+def test_metric_kind():
+    assert conv_lib.metric_kind("Conversions 1") == "COUNT"
+    assert conv_lib.metric_kind("CR (conversions 1)") == "RATE"
+    assert conv_lib.metric_kind("CAC (Custom Conversion 1)") == "CAC"
+    assert conv_lib.metric_kind("ROAS (Custom Conversion 1)") == "ROAS"
+    assert conv_lib.metric_kind("Custom Conversion 1 value") == "VALUE"
+    assert conv_lib.metric_kind("Avg. custom 1 value") == "AVG"
+
+def test_card_shape():
+    s = conv_lib.card_shape(_card("Conversions 1 by date, campaign channel", "bar", ["date"]))
+    assert s == ("bar", "COUNT", ("channel", "date"))
+
+def test_card_shape_ignores_dims_on_scalar_displays():
+    # smartscalar cards carry inconsistent leftover graph.dimensions -> must be ignored
+    assert conv_lib.card_shape(_card("Custom Conversion 1", "smartscalar", ["date"])) == ("smartscalar", "COUNT", ())
+    # non-scalar displays still use dimensions as the breakdown signal
+    assert conv_lib.card_shape(_card("Conversions 1", "line", ["date"])) == ("line", "COUNT", ("date",))
+
+CDM = "global.campaign_daily_metrics"
+
+def test_conversion_source():
+    assert conv_lib.conversion_source(f"SELECT SUM(conversions_1) FROM {CDM} WHERE x") == CDM
+    ga4 = "analytics.google__analytics_per_location"
+    assert conv_lib.conversion_source(f"SELECT SUM({ga4}.conversions) FROM {ga4}") == ga4
+    assert conv_lib.conversion_source("SELECT 1") is None
+
+def _e(cid, kpis, display="smartscalar", brand=False, source=CDM):
+    return {"id": cid, "source": source, "display": display, "kpis": list(kpis), "brand": brand}
+
+def _chart(name, display, metrics, dims=("date",), sql=None):
+    return {"name": name, "display": display,
+            "visualization_settings": {"graph.metrics": list(metrics), "graph.dimensions": list(dims)},
+            "dataset_query": {"type": "native", "native": {"query": sql or f"SELECT SUM(conversions_1) FROM {CDM}"}}}
+
+def test_series_kind_cost_not_cos():
+    assert conv_lib.series_kind("COST") == "COST" and conv_lib.series_kind("Spend") == "COST"
+    assert conv_lib.series_kind("COS (Custom Conversion 1)") == "COS"
+    assert conv_lib.series_kind("CAC_CUSTOM_CONVERSIONS_1") == "CAC"
+    assert conv_lib.series_kind("CUSTOM_CONVERSIONS_1") == "CONV"
+
+def test_resolve_picks_by_metric_kind_on_scalar():
+    old = _card("Conversions 1", "smartscalar", sql=f"SELECT SUM(conversions_1) FROM {CDM}")
+    new_index = {("CUSTOM_CONVERSIONS_1", ()): [_e(42635, ["COUNT"]), _e(42631, ["CAC"])]}
+    res = conv_lib.resolve_new_card(old, {1: "Custom 1"}, new_index)
+    assert res["status"] == "ok" and res["new_card_id"] == 42635 and res["new_col"] == "CUSTOM_CONVERSIONS_1"
+
+def test_resolve_disambiguates_without_brand_smartscalar():
+    # TILE 1: old CAC tile has no hardcoded brand exclusion -> plain card 42631, not 42632
+    old = _card("CAC (conversions 1)", "smartscalar", sql=f"SELECT SUM(conversions_1) FROM {CDM}")
+    new_index = {("CUSTOM_CONVERSIONS_1", ()): [_e(42631, ["CAC"], brand=False), _e(42632, ["CAC"], brand=True)]}
+    res = conv_lib.resolve_new_card(old, {1: "Custom 1"}, new_index)
+    assert res["status"] == "ok" and res["new_card_id"] == 42631
+
+def test_resolve_disambiguates_by_kpi_set_chart():
+    # TILE 2: old combo shows {CONV, CAC}; pick the candidate with the same KPI set
+    old = _chart("CAC 1, conversions 1 by date", "combo", ["CONVERSIONS_1", "CAC_1"])
+    new_index = {("CUSTOM_CONVERSIONS_1", ("date",)): [
+        _e(42580, ["CAC", "CONV"], display="combo"), _e(42584, ["CAC", "COST"], display="combo")]}
+    res = conv_lib.resolve_new_card(old, {1: "Custom 1"}, new_index)
+    assert res["status"] == "ok" and res["new_card_id"] == 42580
+
+def test_resolve_is_display_agnostic():
+    # TILE 3: old is a BAR; only the KPI-matching COMBO candidate exists -> still matches
+    old = _chart("CAC 1, conversions 1, cost by date", "bar", ["CONVERSIONS_1", "CAC_1", "COST"])
+    new_index = {("CUSTOM_CONVERSIONS_1", ("date",)): [_e(42582, ["CAC", "CONV", "COST"], display="combo")]}
+    res = conv_lib.resolve_new_card(old, {1: "Custom 1"}, new_index)
+    assert res["status"] == "ok" and res["new_card_id"] == 42582
+
+def test_resolve_prefers_same_display_then_multi():
+    old = _chart("Conversions 1 by date", "line", ["CONVERSIONS_1"])
+    new_index = {("CUSTOM_CONVERSIONS_1", ("date",)): [_e(1, ["CONV"], "bar"), _e(2, ["CONV"], "line")]}
+    assert conv_lib.resolve_new_card(old, {1: "Custom 1"}, new_index)["new_card_id"] == 2
+    idx2 = {("CUSTOM_CONVERSIONS_1", ("date",)): [_e(1, ["CONV"], "bar"), _e(2, ["CONV"], "pie")]}
+    r2 = conv_lib.resolve_new_card(old, {1: "Custom 1"}, idx2)
+    assert r2["status"] == "multi" and set(r2["candidates"]) == {1, 2}
+
+def test_resolve_new_card_source_mismatch_goes_to_review():
+    ga4 = "analytics.google__analytics_per_location"
+    old = _card("Main conversions", "smartscalar", sql=f"SELECT SUM({ga4}.conversions) FROM {ga4}")
+    new_index = {("PURCHASES", ()): [_e(111, ["COUNT"], source=CDM)]}
+    res = conv_lib.resolve_new_card(old, {0: "Purchases"}, new_index)
+    assert res["status"] == "review" and res["source"] == ga4 and "source" in res["reason"]
+
+def test_resolve_new_card_multi_slot_combo_goes_to_review():
+    old = _card("Conversions + conversions 1 + conversions 3", "bar",
+                sql=f"SELECT SUM(conversions)+SUM(conversions_1)+SUM(conversions_3) FROM {CDM}")
+    res = conv_lib.resolve_new_card(old, {0: "Purchases", 1: "Custom 1", 3: "Custom 2"}, {})
+    assert res["status"] == "review" and res["slots"] == [0, 1, 3]
+
+def test_resolve_new_card_value_card_uses_value_columns():
+    old = _card("Conversions 1 value", "smartscalar", sql=f"SELECT SUM(conversion_1_value) FROM {CDM}")
+    new_index = {("CUSTOM_CONVERSIONS_1_VALUE", ()): [_e(42636, ["VALUE"])]}
+    res = conv_lib.resolve_new_card(old, {1: "Custom 1"}, new_index)
+    assert res["status"] == "ok" and res["new_card_id"] == 42636
+    assert res["old_col"] == "CONVERSION_1_VALUE" and res["new_col"] == "CUSTOM_CONVERSIONS_1_VALUE"
+
+def test_tag_rename_map_matches_by_field_id():
+    old = {"dataset_query": {"type": "native", "native": {"query": "x", "template-tags": {
+        "location": {"type": "dimension", "dimension": ["field", {}, 396836]},
+        "date": {"type": "dimension", "dimension": ["field", {}, 1]}}}}}
+    new = {"dataset_query": {"type": "native", "native": {"query": "x", "template-tags": {
+        "campaign_location": {"type": "dimension", "dimension": ["field", {}, 396836]},
+        "date": {"type": "dimension", "dimension": ["field", {}, 1]}}}}}
+    assert conv_lib.tag_rename_map(old, new) == {"location": "campaign_location"}
+
+def test_resolve_new_card_unmapped_slot():
+    old = _card("Conversions 2", "smartscalar", sql="SELECT SUM(conversions_2)")
+    res = conv_lib.resolve_new_card(old, {2: conv_lib.UNMAPPED}, {})
+    assert res["status"] == "unmapped"
+
+def test_resolve_new_card_no_shape_match_goes_to_review():
+    old = _card("Conversions 1 by URL", "table", ["url"], sql="SELECT SUM(conversions_1)")
+    res = conv_lib.resolve_new_card(old, {1: "Custom 1"}, {})
+    assert res["status"] == "review" and res["reason"]
+
+def test_literals_never_detected_nor_rewritten():
+    sql = "SELECT SUM(conversions_1) FROM t WHERE event = 'conversions_1' AND label = 'conversions'"
+    assert conv_lib.old_conversion_columns(sql) == {"CONVERSIONS_1"}
+    out = conv_lib.apply_substitution(sql, {"CONVERSIONS_1": "CUSTOM_CONVERSIONS_1"})
+    assert "SUM(custom_conversions_1)" in out
+    assert "event = 'conversions_1'" in out and "label = 'conversions'" in out  # littéraux intacts
+
+def test_metric_kind_french():
+    assert conv_lib.metric_kind("Taux de conversion 1") == "RATE"
+    assert conv_lib.metric_kind("Coût par conversion") == "CAC"
+    assert conv_lib.metric_kind("Panier moyen") == "AVG"
+    assert conv_lib.metric_kind("Valeur conversion 1") == "VALUE"
+    assert conv_lib.metric_kind("Ajouts au panier") == "COUNT"  # PAS un AVG
+
+def test_series_kind_avg_before_value():
+    assert conv_lib.series_kind("AVG_CONVERSION_1_VALUE") == "AVG"  # aligné avec metric_kind
+
+def test_conversion_source_deterministic_with_alias():
+    sql = ("SELECT SUM(a.conversions_1) FROM global.social_ad_daily_metrics a "
+           "JOIN global.social_adset_daily_metrics b ON a.x=b.x")
+    for _ in range(5):
+        assert conv_lib.conversion_source(sql) == "global.social_ad_daily_metrics"
+
+def test_has_opaque_refs():
+    assert conv_lib.has_opaque_refs("SELECT * FROM x WHERE {{snippet: conv filter}}")
+    assert conv_lib.has_opaque_refs("SELECT * FROM {{#1234-perf}} t")
+    assert not conv_lib.has_opaque_refs("SELECT SUM(conversions_1) FROM t WHERE {{date}}")
+
+def test_incompatible_wired_tags_temporal_unit():
+    old = {"dataset_query": {"type": "native", "native": {"query": "x", "template-tags": {
+        "time_period": {"type": "dimension", "dimension": ["field", {}, 99]},
+        "date": {"type": "dimension", "dimension": ["field", {}, 1]}}}}}
+    new = {"dataset_query": {"type": "native", "native": {"query": "x", "template-tags": {
+        "time_period": {"type": "temporal-unit", "dimension": ["field", {}, 99]},
+        "date": {"type": "dimension", "dimension": ["field", {}, 1]}}}}}
+    bad = conv_lib.incompatible_wired_tags(old, new, {"time_period", "date"})
+    assert bad == {"time_period": ("dimension", "temporal-unit")}
+
+def test_breakdown_conversion_type_vs_campaign_type():
+    assert conv_lib.card_shape(_card("Conversions by conversion type", "pie"))[2] == ("conversion_type",)
+    assert conv_lib.card_shape(_card("Conversions by campaign type", "pie"))[2] == ("type",)
+    assert conv_lib.card_shape(_card("Conversions 1 by campaign", "pie"))[2] == ("campaign",)
+
+def test_substitution_map():
+    mapping = {0: "Purchases", 1: "Custom 1", 3: "Custom 2", 2: conv_lib.UNMAPPED}
+    sub, unm = conv_lib.substitution_map(
+        {"CONVERSIONS", "CONVERSION_VALUE", "CONVERSIONS_1", "CONVERSION_1_VALUE", "CONVERSIONS_3", "CONVERSIONS_2"}, mapping)
+    assert sub["CONVERSIONS"] == "PURCHASES" and sub["CONVERSION_VALUE"] == "PURCHASES_VALUE"
+    assert sub["CONVERSIONS_1"] == "CUSTOM_CONVERSIONS_1" and sub["CONVERSION_1_VALUE"] == "CUSTOM_CONVERSIONS_1_VALUE"
+    assert sub["CONVERSIONS_3"] == "CUSTOM_CONVERSIONS_2"  # slot 3 -> Custom 2 (number differs!)
+    assert "CONVERSIONS_2" in unm
+
+def test_apply_substitution_whole_word_and_case():
+    sub = {"CONVERSIONS_1": "CUSTOM_CONVERSIONS_1", "CONVERSIONS": "PURCHASES"}
+    sql = "SUM(global.x.conversions_1) AS conversions_1, SUM(x.conversions) AS conversions, x.conversions_10"
+    out = conv_lib.apply_substitution(sql, sub)
+    assert out.count("custom_conversions_1") == 2
+    assert "purchases" in out and "purchases_1" not in out  # base didn't bleed into conversions_1
+    assert "conversions_10" in out  # different slot, not in map -> untouched
+
+def test_apply_substitution_uppercase_viz():
+    assert conv_lib.apply_substitution('["name","CONVERSIONS_1"]', {"CONVERSIONS_1": "CUSTOM_CONVERSIONS_1"}) \
+        == '["name","CUSTOM_CONVERSIONS_1"]'
+
+def test_series_display_map_masks_brand_excluded():
+    # cas réel 27976 -> 42582 : la 4e série hors-brand doit être écartée du mapping
+    old = ["CONVERSIONS_1", "CAC_1", "COST"]
+    new = ["CUSTOM_CONVERSIONS_1", "CAC_CUSTOM_CONVERSIONS_1", "COST",
+           "CAC_CUSTOM_CONVERSIONS_1_BRAND_EXCLUDED"]
+    assert conv_lib.series_display_map(old, new) == \
+        ["CUSTOM_CONVERSIONS_1", "CAC_CUSTOM_CONVERSIONS_1", "COST"]
+
+def test_series_display_map_brand_excluded_wanted():
+    # si l'ANCIENNE série est déjà hors-brand, on mappe vers la variante hors-brand
+    old = ["CAC_1_BRAND_EXCLUDED"]
+    new = ["CAC_CUSTOM_CONVERSIONS_1", "CAC_CUSTOM_CONVERSIONS_1_BRAND_EXCLUDED"]
+    assert conv_lib.series_display_map(old, new) == ["CAC_CUSTOM_CONVERSIONS_1_BRAND_EXCLUDED"]
+
+def test_series_display_map_refuses_ambiguous_or_missing():
+    # deux candidates CAC non hors-brand -> ambigu -> None
+    assert conv_lib.series_display_map(["CAC_1"], ["CAC_A", "CAC_B"]) is None
+    # nature absente de la nouvelle carte -> None
+    assert conv_lib.series_display_map(["ROAS"], ["CUSTOM_CONVERSIONS_1"]) is None
+    # deux anciennes séries qui tomberaient sur la même nouvelle -> None (non injectif)
+    assert conv_lib.series_display_map(["CONVERSIONS", "CONVERSIONS_1"], ["CUSTOM_CONVERSIONS_1"]) is None
+
+def test_fix_brand_clause_single_wrong_atom():
+    # règle finale (user 2026-06-12) : paire type LIKE '%brand%' + category == 'brand' STRICT
+    sql = "AND CASE WHEN b.brand_included = 'no' THEN LOWER(coalesce(reports.campaign_details.campaign_location,'')) NOT LIKE '%brand%' ELSE 1 = 1 END"
+    out = conv_lib.fix_brand_clause(sql)
+    assert "LOWER(coalesce(reports.campaign_details.campaign_type,'')) NOT LIKE '%brand%'" in out
+    assert "LOWER(TRIM(coalesce(reports.campaign_details.campaign_category,''))) != 'brand'" in out
+    assert "campaign_location" not in out
+    assert out.count("NOT LIKE '%brand%'") == 1 and out.count("!= 'brand'") == 1
+
+def test_fix_brand_clause_chain_collapses():
+    # cas réel cité par l'utilisateur : channel AND category(LIKE) -> UNE paire canonique
+    sql = ("CASE WHEN b.brand_included = 'no' THEN "
+           "LOWER(coalesce(reports.campaign_details.campaign_channel,'')) NOT LIKE '%brand%' "
+           "AND LOWER(coalesce(reports.campaign_details.campaign_category,'')) NOT LIKE '%brand%' "
+           "ELSE 1 = 1 END")
+    out = conv_lib.fix_brand_clause(sql)
+    assert out.count("NOT LIKE '%brand%'") == 1 and out.count("!= 'brand'") == 1
+    assert "campaign_channel" not in out and "campaign_category,'')) NOT LIKE" not in out
+
+def test_fix_brand_clause_category_plus_type_dedupes():
+    sql = ("THEN LOWER(coalesce(cd.campaign_category,'')) NOT LIKE '%brand%'\n"
+           "    AND LOWER(coalesce(cd.campaign_type,'')) NOT LIKE '%brand%' ELSE")
+    out = conv_lib.fix_brand_clause(sql)
+    assert out.count("NOT LIKE '%brand%'") == 1 and out.count("!= 'brand'") == 1
+    assert "LOWER(coalesce(cd.campaign_type,'')) NOT LIKE '%brand%'" in out
+    assert "LOWER(TRIM(coalesce(cd.campaign_category,''))) != 'brand'" in out
+
+def test_fix_brand_clause_idempotent_and_upgrades_v1():
+    # idempotent sur sa propre sortie, et la sortie v1 (type seul) est promue en paire
+    v1 = "THEN LOWER(coalesce(reports.campaign_details.campaign_type,'')) NOT LIKE '%brand%' ELSE"
+    out = conv_lib.fix_brand_clause(v1)
+    assert out.count("!= 'brand'") == 1
+    assert conv_lib.fix_brand_clause(out) == out
+
+def test_strip_brand_atoms_makes_clause_variants_equal():
+    # le gate du batch : stripped(old) == stripped(new) ssi seule la clause brand change
+    old = ("SELECT x FROM t WHERE 1=1 AND CASE WHEN b.brand_included = 'no' THEN "
+           "LOWER(coalesce(cd.campaign_channel,'')) NOT LIKE '%brand%' "
+           "AND LOWER(coalesce(cd.campaign_category,'')) NOT LIKE '%brand%' ELSE 1 = 1 END")
+    new = conv_lib.fix_brand_clause(old)
+    assert new != old
+    assert conv_lib.strip_brand_atoms(old) == conv_lib.strip_brand_atoms(new)
+
+def test_strip_brand_atoms_detects_collateral_change():
+    old = "THEN LOWER(coalesce(cd.campaign_type,'')) NOT LIKE '%brand%' ELSE SUM(cost) AS spend"
+    tampered = "THEN LOWER(coalesce(cd.campaign_type,'')) NOT LIKE '%brand%' ELSE SUM(revenue) AS spend"
+    assert conv_lib.strip_brand_atoms(old) != conv_lib.strip_brand_atoms(tampered)
+
+def test_strip_brand_atoms_idempotent_on_canonical_pair():
+    canon = ("THEN LOWER(coalesce(cd.campaign_type,'')) NOT LIKE '%brand%' "
+             "AND LOWER(TRIM(coalesce(cd.campaign_category,''))) != 'brand' ELSE")
+    bare = "THEN §B§ ELSE"
+    assert conv_lib.strip_brand_atoms(canon) == bare
+
+# --- swap de tableaux multi-slot : mapping de colonnes vers la famille mixte ---
+NEW49104 = {  # colonnes réelles (extrait) du tableau mixte « by date »
+    "CURRENT_TIME_PERIOD", "CURRENT_IMPRESSIONS", "CURRENT_CTR", "CURRENT_CLICKS", "CURRENT_CPC", "CURRENT_COST",
+    "CURRENT_PURCHASES", "CURRENT_PURCHASES_CR", "CURRENT_PURCHASES_CAC", "CURRENT_PURCHASES_VALUE",
+    "CURRENT_AVG_PURCHASES_VALUE", "CURRENT_PURCHASES_ROAS",
+    "CURRENT_CUSTOM_CONVERSIONS_1", "CURRENT_CUSTOM_CONVERSIONS_1_CR", "CURRENT_CUSTOM_CONVERSIONS_1_CAC",
+}
+PN = {0: "Purchases", 1: "Custom 1", 3: "Custom 2"}
+
+def test_table_column_map_main_slot_and_base():
+    old = ["DATE", "COST", "IMPRESSIONS", "CONVERSIONS", "CONV_RATE", "CAC",
+           "AVG_CONV_VALUE", "CONVERSION_VALUE", "ROAS"]
+    m, un = conv_lib.map_table_columns(old, PN, NEW49104, "CURRENT_TIME_PERIOD")
+    assert m["DATE"] == "CURRENT_TIME_PERIOD"
+    assert m["COST"] == "CURRENT_COST" and m["IMPRESSIONS"] == "CURRENT_IMPRESSIONS"
+    assert m["CONVERSIONS"] == "CURRENT_PURCHASES"
+    assert m["CONV_RATE"] == "CURRENT_PURCHASES_CR"
+    assert m["CAC"] == "CURRENT_PURCHASES_CAC"
+    assert m["AVG_CONV_VALUE"] == "CURRENT_AVG_PURCHASES_VALUE"
+    assert m["CONVERSION_VALUE"] == "CURRENT_PURCHASES_VALUE"
+    assert m["ROAS"] == "CURRENT_PURCHASES_ROAS"
+    assert un == []
+
+def test_table_column_map_positional_slot_via_client_mapping():
+    old = ["CONVERSIONS_1", "CR_1", "CAC_1"]
+    m, un = conv_lib.map_table_columns(old, PN, NEW49104, "CURRENT_TIME_PERIOD")
+    # slot 1 -> Custom 1 (PAS custom_conversions_1 par hasard : c'est le mapping Airtable)
+    assert m["CONVERSIONS_1"] == "CURRENT_CUSTOM_CONVERSIONS_1"
+    assert m["CR_1"] == "CURRENT_CUSTOM_CONVERSIONS_1_CR"
+    assert m["CAC_1"] == "CURRENT_CUSTOM_CONVERSIONS_1_CAC"
+    assert un == []
+
+def test_table_column_map_current_prefixed_source():
+    # carte 5710 : colonnes déjà préfixées CURRENT_
+    old = ["CURRENT_CONVERSIONS", "CURRENT_CAC_1", "CURRENT_COST"]
+    m, _ = conv_lib.map_table_columns(old, PN, NEW49104, "CURRENT_TIME_PERIOD")
+    assert m["CURRENT_CONVERSIONS"] == "CURRENT_PURCHASES"
+    assert m["CURRENT_CAC_1"] == "CURRENT_CUSTOM_CONVERSIONS_1_CAC"
+    assert m["CURRENT_COST"] == "CURRENT_COST"
+
+def test_table_column_map_alias_names_and_bare_dim():
+    # variantes de nommage rencontrées chez Goodiespub
+    new = NEW49104 | {"CURRENT_CAMPAIGN_CHANNEL"}
+    old = ["CHANNEL", "CONVERSION_RATE", "REVENUE", "AVG_REVENUE"]
+    m, un = conv_lib.map_table_columns(old, PN, new, "CURRENT_CAMPAIGN_CHANNEL")
+    assert m["CHANNEL"] == "CURRENT_CAMPAIGN_CHANNEL"          # dimension nue
+    assert m["CONVERSION_RATE"] == "CURRENT_PURCHASES_CR"      # alias de CONV_RATE
+    assert m["REVENUE"] == "CURRENT_PURCHASES_VALUE"           # alias de CONVERSION_VALUE
+    assert m["AVG_REVENUE"] == "CURRENT_AVG_PURCHASES_VALUE"   # alias de AVG_CONV_VALUE
+    assert un == []
+
+def test_table_column_map_evolution_columns():
+    # tableaux « KPIs evolution » : colonnes _EVOLUTION (sans préfixe CURRENT_ côté neuf)
+    new = NEW49104 | {"COST_EVOLUTION", "PURCHASES_EVOLUTION", "PURCHASES_CAC_EVOLUTION",
+                      "AVG_PURCHASES_VALUE_EVOLUTION", "CUSTOM_CONVERSIONS_1_CR_EVOLUTION"}
+    old = ["COST_EVOLUTION", "CONVERSIONS_EVOLUTION", "CAC_EVOLUTION",
+           "AVG_CONV_VALUE_EVOLUTION", "CR_1_EVOLUTION"]
+    m, un = conv_lib.map_table_columns(old, PN, new, "CURRENT_TIME_PERIOD")
+    assert m["COST_EVOLUTION"] == "COST_EVOLUTION"
+    assert m["CONVERSIONS_EVOLUTION"] == "PURCHASES_EVOLUTION"
+    assert m["CAC_EVOLUTION"] == "PURCHASES_CAC_EVOLUTION"
+    assert m["AVG_CONV_VALUE_EVOLUTION"] == "AVG_PURCHASES_VALUE_EVOLUTION"
+    assert m["CR_1_EVOLUTION"] == "CUSTOM_CONVERSIONS_1_CR_EVOLUTION"
+    assert un == []
+
+def test_table_column_map_unmapped_slot_and_missing_target():
+    # slot 2 non mappé chez PN (new_type absent) -> unmapped ; cible inexistante -> unmapped
+    old = ["CONVERSIONS_2", "CONVERSIONS_3"]  # slot2=∅, slot3=Custom 2 mais absent de NEW49104
+    m, un = conv_lib.map_table_columns(old, PN, NEW49104, "CURRENT_TIME_PERIOD")
+    assert "CONVERSIONS_2" in un  # pas de mapping client
+    assert "CONVERSIONS_3" in un  # mappé Custom 2 mais colonne absente de la carte cible
+
+def test_displayed_cells_restricts_and_sorts():
+    cols = ["DATE", "CONVERSIONS_1", "CAC_1", "EXTRA"]
+    rows = [["2026-05-04", 10.0, 2.5, 99.0], ["2026-05-11", 20.0, 1.25, 99.0]]
+    assert conv_lib.displayed_cells(cols, rows, ["conversions_1", "CAC_1"]) == [1.25, 2.5, 10.0, 20.0]
+    # sans restriction : toutes les cellules numériques
+    assert 99.0 in conv_lib.displayed_cells(cols, rows, None)
+
+
+TESTS = [test_native_and_tags_legacy_format, test_native_and_tags_stages_format,
+         test_native_and_tags_legacy_query_fallback, test_old_columns_detects_positional_not_custom,
+         test_old_columns_base_not_matched_inside_positional, test_old_columns_ignores_conversion_type_filter,
+         test_new_columns_named_and_custom, test_slot_old_columns, test_type_to_slot,
+         test_new_type_columns_custom_and_named, test_build_client_mappings_resolves_consistent_and_flags_unmapped_conflict,
+         test_metric_kind, test_card_shape, test_card_shape_ignores_dims_on_scalar_displays,
+         test_conversion_source, test_series_kind_cost_not_cos, test_resolve_picks_by_metric_kind_on_scalar,
+         test_resolve_disambiguates_without_brand_smartscalar, test_resolve_disambiguates_by_kpi_set_chart,
+         test_resolve_is_display_agnostic, test_resolve_prefers_same_display_then_multi,
+         test_resolve_new_card_source_mismatch_goes_to_review,
+         test_resolve_new_card_multi_slot_combo_goes_to_review, test_resolve_new_card_value_card_uses_value_columns,
+         test_tag_rename_map_matches_by_field_id,
+         test_resolve_new_card_unmapped_slot, test_resolve_new_card_no_shape_match_goes_to_review,
+         test_substitution_map, test_apply_substitution_whole_word_and_case, test_apply_substitution_uppercase_viz,
+         test_literals_never_detected_nor_rewritten, test_metric_kind_french, test_series_kind_avg_before_value,
+         test_conversion_source_deterministic_with_alias, test_has_opaque_refs,
+         test_incompatible_wired_tags_temporal_unit, test_breakdown_conversion_type_vs_campaign_type,
+         test_series_display_map_masks_brand_excluded, test_series_display_map_brand_excluded_wanted,
+         test_series_display_map_refuses_ambiguous_or_missing, test_displayed_cells_restricts_and_sorts,
+         test_fix_brand_clause_single_wrong_atom, test_fix_brand_clause_chain_collapses,
+         test_fix_brand_clause_category_plus_type_dedupes, test_fix_brand_clause_idempotent_and_upgrades_v1,
+         test_strip_brand_atoms_makes_clause_variants_equal, test_strip_brand_atoms_detects_collateral_change,
+         test_strip_brand_atoms_idempotent_on_canonical_pair, test_table_column_map_main_slot_and_base,
+         test_table_column_map_positional_slot_via_client_mapping, test_table_column_map_current_prefixed_source,
+         test_table_column_map_evolution_columns, test_table_column_map_alias_names_and_bare_dim,
+         test_table_column_map_unmapped_slot_and_missing_target]
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t(); print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1; print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_conv_tracker.py
+++ b/tests/test_conv_tracker.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests de conv_tracker — script autonome. Usage : python3 tests/test_conv_tracker.py"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import conv_tracker as T
+
+
+# ─── tag (ancre de campagne) ─────────────────────────────────────────
+
+def test_apply_tag_appends_when_absent():
+    assert T.apply_tag("[TEST conv] Home") == "[TEST conv] Home [conv-2026-06]"
+
+def test_apply_tag_idempotent():
+    once = T.apply_tag("Home")
+    assert T.apply_tag(once) == once  # ne re-tague pas
+
+def test_is_tagged_detects_anchor():
+    assert T.is_tagged("Home [conv-2026-06]") is True
+    assert T.is_tagged("Home") is False
+    assert T.is_tagged(None) is False
+
+
+# ─── registre / tracker (upsert sans doublon) ────────────────────────
+
+def test_upsert_entry_appends_new():
+    tr = T.upsert_entry([], {"copy_id": 25764, "client": "Goodiespub", "status": "migré"})
+    assert len(tr) == 1 and tr[0]["copy_id"] == 25764
+
+def test_upsert_entry_merges_existing_no_dup_keeps_order():
+    tr = [{"copy_id": 25764, "client": "Goodiespub", "status": "migré", "notes": "x"},
+          {"copy_id": 25765, "client": "Goodiespub", "status": "migré"}]
+    tr = T.upsert_entry(tr, {"copy_id": 25764, "status": "validé"})
+    assert len(tr) == 2                      # pas de doublon
+    assert tr[0]["copy_id"] == 25764         # ordre préservé
+    assert tr[0]["status"] == "validé"       # champ mis à jour
+    assert tr[0]["notes"] == "x"             # autres champs préservés (merge)
+
+
+# ─── prédicat d'archivage : OPT-IN EXPLICITE obligatoire ─────────────
+
+def test_archivable_requires_explicit_optin_and_known_original():
+    tr = [
+        {"copy_id": 1, "original_id": 100, "archive_old": True,  "old_archived": False},  # ✅
+        {"copy_id": 2, "original_id": 200, "archive_old": False, "old_archived": False},  # pas d'opt-in
+        {"copy_id": 3, "original_id": None, "archive_old": True, "old_archived": False},  # pas d'original connu
+        {"copy_id": 4, "original_id": 400, "archive_old": True,  "old_archived": True},   # déjà archivé
+    ]
+    assert T.archivable_originals(tr) == [100]
+
+def test_archivable_empty_when_nothing_opted_in():
+    tr = [{"copy_id": 1, "original_id": 100, "status": "validé", "archive_old": False, "old_archived": False}]
+    assert T.archivable_originals(tr) == []
+
+
+# ─── rendu markdown (vue humaine) ────────────────────────────────────
+
+def test_render_markdown_has_row_per_entry():
+    tr = [{"client": "Goodiespub", "dashboard": "Home", "copy_id": 25764, "original_id": None,
+           "tagged": False, "status": "migré", "archive_old": False, "old_archived": False, "notes": ""}]
+    md = T.render_markdown(tr)
+    assert "25764" in md and "Goodiespub" in md and "Home" in md
+
+def test_render_markdown_escapes_pipes_in_values():
+    # un nom comme "Ecomm | Home" ne doit PAS casser les colonnes de la table
+    tr = [{"client": "X", "dashboard": "Ecomm | Home", "copy_id": 1, "original_id": 2,
+           "tagged": False, "status": "migré", "archive_old": False, "old_archived": False, "notes": ""}]
+    md = T.render_markdown(tr)
+    assert "Ecomm \\| Home" in md
+
+
+TESTS = [test_apply_tag_appends_when_absent, test_apply_tag_idempotent, test_is_tagged_detects_anchor,
+         test_upsert_entry_appends_new, test_upsert_entry_merges_existing_no_dup_keeps_order,
+         test_archivable_requires_explicit_optin_and_known_original, test_archivable_empty_when_nothing_opted_in,
+         test_render_markdown_has_row_per_entry, test_render_markdown_escapes_pipes_in_values]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t(); print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1; print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_swap_lib.py
+++ b/tests/test_swap_lib.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Tests de swap_lib — script autonome. Usage : python3 tests/test_swap_lib.py"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import swap_lib
+
+
+def _card(cid, tags, db=2, archived=False, sql="SELECT 1"):
+    return {
+        "id": cid, "archived": archived, "database_id": db, "display": "line",
+        "visualization_settings": {},
+        "legacy_query": json.dumps({"type": "native", "database": db,
+                                    "native": {"query": sql, "template-tags": {t: {} for t in tags}}}),
+    }
+
+
+def test_referenced_template_tags():
+    dashcards = [
+        {"card_id": 58, "parameter_mappings": [
+            {"parameter_id": "p1", "card_id": 58, "target": ["dimension", ["template-tag", "date"], {"stage-number": 0}]},
+            {"parameter_id": "p2", "card_id": 58, "target": ["variable", ["template-tag", "client"]]},
+        ]},
+        {"card_id": 99, "parameter_mappings": [
+            {"parameter_id": "p3", "card_id": 99, "target": ["dimension", ["template-tag", "autre"]]}]},
+    ]
+    assert swap_lib.referenced_template_tags(dashcards, 58) == {"date", "client"}
+
+
+def test_rewrite_dashcards_swaps_card_and_mappings_not_target():
+    dashcards = [
+        {"id": 1, "card_id": 58, "series": [],
+         "parameter_mappings": [{"parameter_id": "p1", "card_id": 58,
+                                 "target": ["dimension", ["template-tag", "date"]]}]},
+        {"id": 2, "card_id": 99, "series": [], "parameter_mappings": []},
+    ]
+    out, n = swap_lib.rewrite_dashcards(dashcards, 58, 1000)
+    assert n == 1
+    assert out[0]["card_id"] == 1000
+    assert out[0]["parameter_mappings"][0]["card_id"] == 1000
+    assert out[0]["parameter_mappings"][0]["target"] == ["dimension", ["template-tag", "date"]]  # inchangé
+    assert out[1]["card_id"] == 99  # autre carte intacte
+    assert dashcards[0]["card_id"] == 58  # entrée non mutée
+
+
+def test_rewrite_handles_series():
+    dashcards = [{"id": 1, "card_id": 10, "parameter_mappings": [], "series": [{"id": 58, "name": "x"}]}]
+    out, n = swap_lib.rewrite_dashcards(dashcards, 58, 1000)
+    assert n == 1 and out[0]["series"][0]["id"] == 1000
+
+
+def test_card_template_tags():
+    assert swap_lib.card_template_tags(_card(1, ["date", "client"])) == {"date", "client"}
+
+
+def test_swap_safety_check_passes_for_identical():
+    old = _card(1, ["date", "client"])
+    new = _card(2, ["date", "client"])
+    assert swap_lib.swap_safety_check(old, new, {"date", "client"}) == []
+
+
+def test_swap_safety_check_blocks_missing_filter_tag():
+    old = _card(1, ["date", "client"])
+    new = _card(2, ["date"])  # même SQL/rendu mais ne couvre pas 'client'
+    problems = swap_lib.swap_safety_check(old, new, {"date", "client"})
+    assert any("client" in p for p in problems)
+
+
+def test_swap_safety_check_blocks_different_database():
+    old = _card(1, ["date"], db=2)
+    new = _card(2, ["date"], db=9)
+    assert any("base" in p.lower() for p in swap_lib.swap_safety_check(old, new, {"date"}))
+
+
+def test_swap_safety_check_blocks_different_fingerprint():
+    old = _card(1, ["date"], sql="SELECT a")
+    new = _card(2, ["date"], sql="SELECT b")  # requête différente -> empreinte différente
+    assert any("empreinte" in p.lower() for p in swap_lib.swap_safety_check(old, new, {"date"}))
+
+
+TESTS = [
+    test_referenced_template_tags,
+    test_rewrite_dashcards_swaps_card_and_mappings_not_target,
+    test_rewrite_handles_series,
+    test_card_template_tags,
+    test_swap_safety_check_passes_for_identical,
+    test_swap_safety_check_blocks_missing_filter_tag,
+    test_swap_safety_check_blocks_different_database,
+    test_swap_safety_check_blocks_different_fingerprint,
+]
+
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -109,3 +109,22 @@ def test_check_differential():
     assert any(f.level == "warn" and "sum(v)" in f.message for f in fs)
     fs2 = V.check_differential("t", before, drift, mode="identical")
     assert any(f.level == "error" for f in fs2)
+
+
+def test_gate_and_guarded_apply():
+    # gate: a structurally broken unit short-circuits (no execution attempted)
+    broken = V.CardUnit("c/bad", {"type": "native", "native": {"query": "x"}})
+    g = V.gate(ExecClient(), [broken], execute=True)
+    assert not g.ok() and [f.check for f in g.findings] == ["structure"]
+
+    # guarded_apply: gate errors -> mutate_fn NOT called
+    calls = []
+    rep = V.guarded_apply(ExecClient(), [broken], lambda: calls.append(1),
+                          differential="off", force=False, execute=False)
+    assert calls == [] and not rep.ok()
+
+    # force=True runs mutate_fn despite errors
+    calls2 = []
+    V.guarded_apply(ExecClient(), [broken], lambda: calls2.append(1),
+                    differential="off", force=True, execute=False)
+    assert calls2 == [1]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -69,3 +69,27 @@ def test_check_refs():
         "query": "SELECT 1", "template-tags": {
             "x": {"values_source_config": {"card_id": 99}}}}})
     assert any(f.level == "error" for f in V.check_refs(client, ff_bad))
+
+
+class ExecClient:
+    def __init__(self, dataset_result=None, card_rows=None):
+        self._ds = dataset_result; self._rows = card_rows
+    def run_query(self, dq, parameters=None): return self._ds
+    def get_card_data(self, card_id=None, data_format="json"): return self._rows
+
+def test_check_execution():
+    good = ExecClient(dataset_result={"status": "completed",
+        "data": {"cols": [{"name": "n"}], "rows": [[1], [2]]}})
+    u = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "SELECT n"}})
+    f = V.check_execution(good, u)
+    assert f.level == "ok" and "2 rows" in f.message
+
+    failed = ExecClient(dataset_result={"status": "failed", "error": "SQL compilation error"})
+    assert V.check_execution(failed, u).level == "error"
+
+    empty = ExecClient(dataset_result={"status": "completed", "data": {"cols": [], "rows": []}})
+    assert V.check_execution(empty, u).level == "warn"
+
+    saved = ExecClient(card_rows=[{"n": 1}])
+    su = V.CardUnit("card#5", {"database": 1, "type": "native", "native": {"query": "x"}}, live_card_id=5)
+    assert V.check_execution(saved, su).level == "ok"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -93,3 +93,19 @@ def test_check_execution():
     saved = ExecClient(card_rows=[{"n": 1}])
     su = V.CardUnit("card#5", {"database": 1, "type": "native", "native": {"query": "x"}}, live_card_id=5)
     assert V.check_execution(saved, su).level == "ok"
+
+
+def test_check_differential():
+    before = [{"k": "a", "v": 10}, {"k": "b", "v": 20}]
+    same = [{"k": "a", "v": 10}, {"k": "b", "v": 20}]
+    assert all(f.level == "ok" for f in V.check_differential("t", before, same, mode="identical"))
+
+    dropped = [{"k": "a", "v": 10}]
+    fs = V.check_differential("t", before, dropped, mode="identical")
+    assert any(f.level == "error" and "row count" in f.message for f in fs)
+
+    drift = [{"k": "a", "v": 10}, {"k": "b", "v": 25}]
+    fs = V.check_differential("t", before, drift, mode="monitor")
+    assert any(f.level == "warn" and "sum(v)" in f.message for f in fs)
+    fs2 = V.check_differential("t", before, drift, mode="identical")
+    assert any(f.level == "error" for f in fs2)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -11,3 +11,36 @@ def test_report_collects_and_renders():
     out = r.render()
     assert "c/B" in out and "query failed" in out
     assert "1 error" in r.summary()
+
+
+def test_units_from_spec_and_payload():
+    from spark_metabase_api import iac
+    spec = iac.spec_from_dict({
+        "name": "Acme",
+        "cards": [{"name": "Rev", "definition": {
+            "dataset_query": {"database": 2, "type": "native",
+                              "native": {"query": "SELECT 1"}},
+            "display": "table"}}],
+    })
+    units = V.units_from_spec(spec)
+    assert len(units) == 1
+    assert units[0].target == "Acme/Rev"
+    assert units[0].dataset_query["database"] == 2
+    assert units[0].live_card_id is None
+
+    u = V.unit_from_payload("c/X", {"dataset_query": {"database": 1, "type": "query",
+                                                      "query": {"source-table": 5}}})
+    assert u.dataset_query["type"] == "query"
+
+class FakeClient:
+    def __init__(self, cards): self._cards = cards
+    def get(self, ep, *a, **k):
+        cid = int(ep.rstrip("/").split("/")[-1])
+        return self._cards.get(cid, False)
+
+def test_unit_from_card_id():
+    client = FakeClient({7: {"dataset_query": {"database": 1, "type": "native",
+                                               "native": {"query": "SELECT 1"}},
+                             "display": "scalar"}})
+    u = V.unit_from_card_id(client, 7)
+    assert u.live_card_id == 7 and u.dataset_query["database"] == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -128,3 +128,21 @@ def test_gate_and_guarded_apply():
     V.guarded_apply(ExecClient(), [broken], lambda: calls2.append(1),
                     differential="off", force=True, execute=False)
     assert calls2 == [1]
+
+
+def test_iac_apply_gate_aborts(monkeypatch):
+    from spark_metabase_api import iac, validate as V
+    spec = iac.spec_from_dict({"name": "Acme", "cards": [{"name": "Bad",
+        "definition": {"dataset_query": {"type": "native", "native": {"query": "x"}}}}]})  # no database -> structure error
+
+    called = {"executed": False}
+    monkeypatch.setattr(iac, "_execute_collection",
+                        lambda *a, **k: called.__setitem__("executed", True))
+    monkeypatch.setattr(iac, "plan", lambda *a, **k: iac.Plan())
+
+    try:
+        iac.apply(object(), spec, validate=True)
+        assert False, "expected ValidationError"
+    except V.ValidationError:
+        pass
+    assert called["executed"] is False  # gate aborted before mutation

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -95,6 +95,29 @@ def test_check_execution():
     assert V.check_execution(saved, su).level == "ok"
 
 
+# FIX 1: saved-card path must detect query failure (dict result, not list)
+def test_check_execution_saved_card_failure():
+    """get_card_data returning a dict (failed query) must surface as an error, not ok."""
+    class FailedCardClient:
+        def get_card_data(self, card_id=None, data_format="json"):
+            return {"status": "failed", "error": "SQL compilation error"}
+    su = V.CardUnit("card#5", {"database": 1, "type": "native", "native": {"query": "x"}}, live_card_id=5)
+    f = V.check_execution(FailedCardClient(), su)
+    assert f.level == "error", "expected error level, got {!r}".format(f.level)
+    assert "SQL compilation error" in f.message, "expected error text in message: {!r}".format(f.message)
+
+
+# FIX 2: check_refs must not raise on malformed source-table refs
+def test_check_refs_malformed_source_table():
+    """Malformed 'card__abc' ref must emit a refs error, not raise ValueError/IndexError."""
+    client = FakeClient({})
+    unit = V.CardUnit("c/X", {"database": 1, "type": "query",
+                               "query": {"source-table": "card__abc"}})
+    findings = V.check_refs(client, unit)
+    assert any(f.level == "error" and "refs" == f.check for f in findings), \
+        "expected a refs error finding for malformed ref"
+
+
 def test_check_differential():
     before = [{"k": "a", "v": 10}, {"k": "b", "v": 20}]
     same = [{"k": "a", "v": 10}, {"k": "b", "v": 20}]
@@ -145,6 +168,76 @@ def test_resolve_cli_target_card_id():
                                                "native": {"query": "x"}}}})
     units = V.resolve_cli_target(client, "4")
     assert units[0].live_card_id == 4
+
+
+# FIX 3a: guarded_apply differential path
+def test_guarded_apply_differential_monitor():
+    """guarded_apply with differential='monitor' emits a warn finding when results change."""
+    call_count = {"n": 0}
+    baseline_rows = [{"v": 10}]
+    after_rows = [{"v": 20}]
+
+    class DiffClient:
+        def get(self, ep, *a, **k):
+            return {"archived": False}
+        def get_card_data(self, card_id=None, data_format="json"):
+            # first call: baseline; second call (post-mutate): different
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return baseline_rows
+            return after_rows
+        def run_query(self, dq, parameters=None):
+            return {"status": "completed", "data": {"cols": [{"name": "v"}], "rows": [[10]]}}
+
+    # A live unit with a well-formed dataset_query so structure/refs/execution all pass
+    live_unit = V.CardUnit(
+        target="c/A",
+        dataset_query={"database": 1, "type": "native", "native": {"query": "SELECT v"}},
+        live_card_id=42,
+    )
+
+    mutated = []
+    report = V.guarded_apply(
+        DiffClient(),
+        [live_unit],
+        lambda: mutated.append(1),
+        differential="monitor",
+        execute=True,
+    )
+
+    assert mutated == [1], "mutate_fn should have been called"
+    diff_findings = [f for f in report.findings if f.check == "differential"]
+    assert diff_findings, "expected differential findings"
+    assert any(f.level == "warn" for f in diff_findings), \
+        "expected a warn in monitor mode for changed results"
+
+
+# FIX 3b: iac.apply(validate=True) happy path
+def test_iac_apply_validate_happy_path(monkeypatch):
+    """iac.apply(validate=True) with a clean spec calls _execute_collection (no ValidationError)."""
+    from spark_metabase_api import iac, validate as V
+
+    spec = iac.spec_from_dict({"name": "Clean", "cards": [{"name": "Card1", "definition": {
+        "dataset_query": {"database": 1, "type": "native", "native": {"query": "SELECT 1"}},
+        "display": "scalar",
+    }}]})
+
+    # Client that passes execution gate
+    class HappyClient:
+        def get(self, ep, *a, **k):
+            return {"archived": False}
+        def run_query(self, dq, parameters=None):
+            return {"status": "completed",
+                    "data": {"cols": [{"name": "n"}], "rows": [[1]]}}
+
+    called = {"executed": False}
+    monkeypatch.setattr(iac, "plan", lambda *a, **k: iac.Plan())
+    monkeypatch.setattr(iac, "_execute_collection",
+                        lambda *a, **k: called.__setitem__("executed", True))
+
+    # Should NOT raise; gate passes cleanly
+    iac.apply(HappyClient(), spec, validate=True)
+    assert called["executed"] is True, "_execute_collection should have been called"
 
 
 def test_iac_apply_gate_aborts(monkeypatch):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -130,6 +130,23 @@ def test_gate_and_guarded_apply():
     assert calls2 == [1]
 
 
+def test_resolve_cli_target_spec(tmp_path):
+    from spark_metabase_api import iac, validate as V
+    spec_file = tmp_path / "s.json"
+    iac.dump(iac.spec_from_dict({"name": "Acme", "cards": [{"name": "R",
+        "definition": {"dataset_query": {"database": 1, "type": "native",
+                                         "native": {"query": "SELECT 1"}}}}]}), str(spec_file))
+    units = V.resolve_cli_target(object(), str(spec_file))
+    assert len(units) == 1 and units[0].target == "Acme/R"
+
+def test_resolve_cli_target_card_id():
+    from spark_metabase_api import validate as V
+    client = FakeClient({4: {"dataset_query": {"database": 1, "type": "native",
+                                               "native": {"query": "x"}}}})
+    units = V.resolve_cli_target(client, "4")
+    assert units[0].live_card_id == 4
+
+
 def test_iac_apply_gate_aborts(monkeypatch):
     from spark_metabase_api import iac, validate as V
     spec = iac.spec_from_dict({"name": "Acme", "cards": [{"name": "Bad",

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -55,3 +55,17 @@ def test_check_structure():
     assert V.check_structure(empty).level == "error"
     bad_type = V.CardUnit("c/D", {"database": 1, "type": "weird"})
     assert V.check_structure(bad_type).level == "error"
+
+
+def test_check_refs():
+    client = FakeClient({9: {"archived": False}})  # card 9 exists; 99 does not
+    src_ok = V.CardUnit("c/A", {"database": 1, "type": "query",
+                                "query": {"source-table": "card__9"}})
+    assert all(f.level != "error" for f in V.check_refs(client, src_ok))
+    src_bad = V.CardUnit("c/B", {"database": 1, "type": "query",
+                                 "query": {"source-table": "card__99"}})
+    assert any(f.level == "error" for f in V.check_refs(client, src_bad))
+    ff_bad = V.CardUnit("c/C", {"database": 1, "type": "native", "native": {
+        "query": "SELECT 1", "template-tags": {
+            "x": {"values_source_config": {"card_id": 99}}}}})
+    assert any(f.level == "error" for f in V.check_refs(client, ff_bad))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -44,3 +44,14 @@ def test_unit_from_card_id():
                              "display": "scalar"}})
     u = V.unit_from_card_id(client, 7)
     assert u.live_card_id == 7 and u.dataset_query["database"] == 1
+
+
+def test_check_structure():
+    ok = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "SELECT 1"}})
+    assert V.check_structure(ok).level == "ok"
+    no_db = V.CardUnit("c/B", {"type": "native", "native": {"query": "SELECT 1"}})
+    assert V.check_structure(no_db).level == "error"
+    empty = V.CardUnit("c/C", {"database": 1, "type": "native", "native": {"query": ""}})
+    assert V.check_structure(empty).level == "error"
+    bad_type = V.CardUnit("c/D", {"database": 1, "type": "weird"})
+    assert V.check_structure(bad_type).level == "error"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,13 @@
+from spark_metabase_api import validate as V
+
+def test_report_collects_and_renders():
+    r = V.Report()
+    r.add(V.Finding("c/A", "structure", "ok", "well-formed"))
+    r.add(V.Finding("c/B", "execution", "error", "query failed: boom"))
+    assert [f.level for f in r.findings] == ["ok", "error"]
+    assert r.ok() is False
+    assert len(r.errors()) == 1
+    assert r.exit_code() == 1
+    out = r.render()
+    assert "c/B" in out and "query failed" in out
+    assert "1 error" in r.summary()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -256,3 +256,64 @@ def test_iac_apply_gate_aborts(monkeypatch):
     except V.ValidationError:
         pass
     assert called["executed"] is False  # gate aborted before mutation
+
+
+# --- Adversarial-review fixes (2026-06-20) ---
+
+def test_differential_identical_numeric_to_null():
+    """[#1] A numeric column going all-NULL (same name + row count) is a delta in identical mode."""
+    before = [{"id": 1, "amount": 100}, {"id": 2, "amount": 200}]
+    after = [{"id": 1, "amount": None}, {"id": 2, "amount": None}]
+    fs = V.check_differential("c/rev", before, after, mode="identical")
+    assert any(f.level == "error" for f in fs), \
+        "numeric->all-null must error in identical mode, got {}".format([f.message for f in fs])
+
+
+def test_differential_identical_numeric_to_string():
+    """[#1] A numeric column turning into a string is a delta in identical mode."""
+    before = [{"revenue": 100, "name": "x"}]
+    after = [{"revenue": "N/A", "name": "x"}]
+    fs = V.check_differential("t", before, after, mode="identical")
+    assert any(f.level == "error" for f in fs)
+
+
+def test_execution_unsaved_run_query_raises_is_collected():
+    """[#2] A network error in run_query becomes an error Finding, never crashes the gate."""
+    class RaisingClient:
+        def run_query(self, dq, parameters=None):
+            raise ConnectionError("boom")
+    u = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "SELECT 1"}})
+    f = V.check_execution(RaisingClient(), u)
+    assert f.level == "error" and "boom" in f.message
+    rep = V.gate(RaisingClient(), [u], execute=True)  # must not raise
+    assert not rep.ok()
+
+
+def test_execution_unsaved_non_completed_status_is_error():
+    """[#2] A non-'completed' status or an error body is an error, not a 0-rows warn."""
+    stuck = ExecClient(dataset_result={"status": "running"})
+    u = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "SELECT 1"}})
+    assert V.check_execution(stuck, u).level == "error"
+    errbody = ExecClient(dataset_result={"message": "Bad request"})  # 4xx body, no status
+    assert V.check_execution(errbody, u).level == "error"
+
+
+def test_check_structure_invalid_database_and_blank_sql():
+    """[#3] database None/0 and whitespace-only native SQL fail structure."""
+    assert V.check_structure(V.CardUnit("c/A", {"database": None, "type": "native",
+        "native": {"query": "SELECT 1"}})).level == "error"
+    assert V.check_structure(V.CardUnit("c/B", {"database": 0, "type": "native",
+        "native": {"query": "SELECT 1"}})).level == "error"
+    assert V.check_structure(V.CardUnit("c/C", {"database": 1, "type": "native",
+        "native": {"query": "   \n  "}})).level == "error"
+
+
+def test_resolve_cli_target_bad_spec_file(tmp_path):
+    """[#5] A spec-looking path that is missing or not a valid spec raises a clear ValueError."""
+    import pytest
+    with pytest.raises(ValueError):
+        V.resolve_cli_target(object(), str(tmp_path / "nope.json"))
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"not": "a spec"}')
+    with pytest.raises(ValueError):
+        V.resolve_cli_target(object(), str(bad))


### PR DESCRIPTION
## Quoi
Nouvelle **couche de validation pré-apply** pour le wrapper Metabase — synthèse « best of » de 3 skills `metabase/agent-skills`, rebâtie en natif (live/REST, **sans JAR Enterprise**) :
- `semantic-checker` → checks **refs** + **execution**
- `representation-format` → check **structure** (+ identité `entity_id`, déjà présente)
- `metabase-cli` → commande `spark-metabase validate`

## Phase 1 — `spark_metabase_api/validate.py`
- `Finding`/`Report` (rendu façon `iac.Plan`, exit code) ; `CardUnit` + builders (spec / payload / carte live)
- 4 checks fail-fast cheap→cher : `structure → refs → execution → differential`
- **exécution = source de vérité** via `/api/dataset` (ou `get_card_data` pour les cartes sauvegardées)
- différentiel `identical` (refactor doit préserver les chiffres) | `monitor` (migration les change) — métrique auto (nb lignes + jeu de colonnes + sommes par colonne numérique)
- `gate` + `guarded_apply` (baseline → gate → mutate → diff ; **ne mute JAMAIS si le gate erreure**, sauf `force`)
- intégration `iac.apply(validate=True, force=False)` + CLI `spark-metabase validate <spec|collection|card> [--no-execute]`
- nouveau `Metabase_API.run_query` (POST `/api/dataset`)

## Phase 0 — ménage léger (préservation)
Le triage a révélé que manucurist / conv-migration / quiz-room sont des **campagnes actives** → décision : **préserver en place, zéro suppression/déplacement**.
- commit des libs durables non suivies (conv/bascule/tracker) + tests
- commit des 54 scripts de campagne + 12 docs (fin du local-only)
- `gitignore migration/` (donnée runtime) en gardant les 8 fichiers source + la map Airtable

## Tests & revue
- **142 tests verts**
- Exécution subagent-driven : 10 tâches TDD, review spec+qualité après chaque, **review whole-branch (Opus)** finale
- 2 bugs **Important** trouvés & corrigés puis re-revus : détection d'échec sur carte live (faux « ok ») ; ref `card__` malformée qui faisait planter tout le batch

## Limites connues (v1, différées)
- `run_query` ne dérive pas les valeurs par défaut des template-tags natifs (spec §7) → une carte native à params requis sort en erreur d'exécution
- `metric_override` / `expected_columns` = hooks réservés non câblés (le métrique auto suffit en v1)

## Specs / plans
- `docs/superpowers/specs/2026-06-20-metabase-pre-apply-validation-design.md`
- `docs/superpowers/plans/2026-06-20-{repo-menage-leger,pre-apply-validation-layer}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)