### PR TITLE
feat: unify the differential — check_values + conv-migration delegation

### DIFF
--- a/docs/superpowers/plans/2026-06-21-unify-differential.md
+++ b/docs/superpowers/plans/2026-06-21-unify-differential.md
@@ -1,0 +1,42 @@
+# Unify the differential (check_values) Implementation Plan
+
+> **For agentic workers:** execute task-by-task (TDD, frequent commits). Code-level design lives in `docs/superpowers/specs/2026-06-21-differential-wiring-design.md`.
+
+**Goal:** Add a tested `check_values` value-sequence comparator and have conv-migration delegate its bespoke before/after diff to it (DRY, dogfooded), plus forward `tolerance` through `guarded_apply`.
+
+**Architecture:** `check_values` is a new sibling of `check_differential` in `validate.py` for the flat numeric-multiset shape conv-migration produces (`card_values`/`displayed_cells` → `sorted(round(float(x),4)…)`). conv-migration keeps its upstream series extraction; only the final `before != after` / `b2 == a2` compare is delegated.
+
+**Tech Stack:** Python 3, `spark_metabase_api.validate`, the conv-migration `scripts/migrate_*.py`, pytest (`.venv/bin/python -m pytest`).
+
+## Global Constraints
+- Spec: `docs/superpowers/specs/2026-06-21-differential-wiring-design.md`. Branch: `feat/unify-differential`.
+- `check_differential` tabular behaviour unchanged; `check_values` is additive. The 148 existing tests stay green.
+- conv-migration decision semantics ("À DÉCIDER" / "migrée" / écart-accepté note) preserved exactly.
+- No live Metabase in this env → the §3.4 live dry-run dogfood becomes a **fixture equivalence test** (assert `check_values` reproduces the old `before != after` decisions); a real dry-run is a manual follow-up the user runs.
+- Commits end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `check_values` + `guarded_apply` tolerance forwarding
+**Files:** Modify `spark_metabase_api/validate.py`; Test `tests/test_validate.py`.
+**Produces:** `check_values(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]` (check="values"); `guarded_apply(..., tolerance=0.0)` forwards tolerance to `check_differential`.
+
+- Behaviour per spec §3.1/§3.2: length mismatch → single `value count` finding; all-numeric → multiset (sorted) element-wise within tolerance, one summary finding; non-numeric → exact ordered equality; `tolerance=0` exact; no diff → one `ok`.
+- Tests: order-agnostic equal multiset → ok; length mismatch → finding; numeric drift beyond/within tolerance (identical=error / monitor=warn / within-tol=ok); non-numeric exact; `guarded_apply` with a within-tolerance change emits no differential finding (proves forwarding).
+- TDD → `.venv/bin/python -m pytest tests/test_validate.py -q` green → commit.
+
+### Task 2: conv-migration delegates to `check_values`
+**Files:** Modify `scripts/migrate_dashboard_reuse.py` (and `migrate_conversions_on_dashboard.py` / `migrate_dashboard_full.py` where the same compare is duplicated); Test `tests/test_conv_diff.py` (new).
+**Consumes:** `validate.check_values`.
+
+- Per spec §3.3: replace `before != after` and the mapped `b2 == a2` with `check_values(name, …, mode="monitor" if accept_diffs else "identical")`; map findings → existing decisions ("À DÉCIDER" on error; écart note on accept-diffs warn; else migrate). `series_display_map`/`card_cells` untouched.
+- Test (fixture equivalence, no live MB): for representative before/after value-lists, assert the new delegation yields the same decision the old `!=`/`==` would (a "À DÉCIDER" case, a "migrée" case, an `--accept-diffs` note case).
+- TDD → full suite green → commit.
+
+### Task 3: whole-branch review + merge
+- Adversarial-leaning whole-branch review of `master..feat/unify-differential`; fix Critical/Important findings.
+- Full suite green → PR (or direct) → merge to master (admin override, as established) → done.
+
+## Self-Review
+- Spec coverage: §3.1 check_values → T1; §3.2 guarded_apply tolerance → T1; §3.3 conv-migration → T2; §3.4 dogfood → T2 (fixture equivalence; live run = manual follow-up, noted). ✓
+- No placeholders: code-level detail is in the spec, referenced per task. ✓

--- a/docs/superpowers/specs/2026-06-21-differential-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-21-differential-wiring-design.md
@@ -1,0 +1,119 @@
+# Unify the differential — `check_values` + dogfood conv-migration
+
+- **Date**: 2026-06-21
+- **Status**: Proposed (revised after reading the real conv-migration comparison code)
+- **Author**: Louis + Claude
+
+## 1. Context & motivation
+
+The merged validation layer (`spark_metabase_api/validate.py`, PR #16) ships a tabular
+`check_differential` (rows-of-dicts → row count / column set / per-column sums) that is **not wired
+into any real flow**. The natural consumer is the active **conversion-migration** campaign, which has
+its own **bespoke, duplicated, untested** before/after diff in `migrate_dashboard_reuse.py`
+(and `migrate_conversions_on_dashboard.py` / `migrate_dashboard_full.py`).
+
+**Key finding (from reading the code):** conv-migration does **not** compare tables. `card_values` /
+`displayed_cells` return `sorted(round(float(x), 4) …)` — a **sorted multiset of numeric values**. Its
+comparison is `before != after` (and `b2 == a2` for the series-mapped case): "the same bag of numbers
+before and after". The series mapping (`series_display_map`) and column extraction happen **upstream**
+in `card_cells`; by the time the diff runs, there are no named columns or rows to align.
+
+So a tabular `column_map`/cell-by-cell differ does **not** fit. The right shared primitive is a
+**numeric value-sequence comparison**. This spec adds that primitive (`check_values`), tested, and has
+conv-migration delegate its hand-rolled compare to it — one tested diff, dogfooded on the live campaign,
+DRY, no weaker than today.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Add `check_values` to `validate.py`: compare two numeric value-sequences (the sorted/rounded multiset
+  convention), tolerance-aware, returning `Finding`s with the same `mode` semantics as `check_differential`.
+- Refactor conv-migration's before/after comparison to delegate to `check_values`, **preserving its exact
+  decisions** ("À DÉCIDER" on mismatch; migrate + note under `--accept-diffs`).
+- Forward `tolerance` through `guarded_apply` (closes the adversarial-review gap where it was dropped).
+- Dogfood: dry-run the refactor on a **test copy** and confirm identical per-card decisions to the old code.
+
+**Non-goals (YAGNI)**
+- No `column_map` / tabular cell-by-cell differ — it does not match conv-migration's data shape.
+- No change to `series_display_map` / `card_cells` extraction (stays upstream, domain logic).
+- No change to `check_differential`'s tabular behaviour beyond the `guarded_apply` tolerance forward.
+- No wiring into `iac.apply` (deferred), no change to conv-migration orchestration (copies, dry-run, steps).
+
+## 3. Design
+
+### 3.1 `check_values` (new, in `validate.py`)
+
+```
+check_values(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]
+```
+- `before` / `after`: sequences of scalar values. conv-migration passes its sorted/rounded numeric lists;
+  the function works for any list of comparable scalars.
+- `mode`: `identical` ⇒ a difference is an **error** Finding; `monitor` ⇒ a **warn** Finding (same convention as `check_differential`).
+- Comparison:
+  - If `len(before) != len(after)` ⇒ a single `value count A -> B` Finding (the multisets cannot align). No element comparison.
+  - Else, treat as a **multiset**: if every element on both sides is numeric (int/float, not bool), sort both
+    numerically and compare element-wise; numeric elements differ when `abs(a-b)/(abs(b) or 1) > tolerance`
+    (or NaN). If any element is non-numeric, compare the two sequences for **exact ordered equality** (no sort).
+  - Aggregate to **one summary Finding** (not one per element): e.g. `2/14 values differ beyond tolerance, first 100.0 -> 120.0`.
+  - No differences ⇒ a single `ok` Finding (`N values, no change`).
+- `tolerance=0.0` reproduces conv-migration's exact `before != after` on its rounded lists.
+
+### 3.2 `guarded_apply` — forward `tolerance` (closes adversarial gap)
+
+```
+guarded_apply(client, units, mutate_fn, differential="monitor",
+              force=False, execute=True, tolerance=0.0) -> Report
+```
+Pass `tolerance` into its `check_differential` call instead of silently dropping it. (Tabular path; no `column_map`.)
+
+### 3.3 conv-migration refactor (decisions unchanged)
+
+In `migrate_dashboard_reuse.py` (and the duplicated compare in `migrate_conversions_on_dashboard.py` /
+`migrate_dashboard_full.py`), replace the hand-rolled comparison:
+
+```
+from spark_metabase_api import validate as V
+
+# direct case (was: before != after)
+findings = V.check_values(card_name, before, after,
+                          mode="monitor" if args.accept_diffs else "identical")
+# series-mapped case (was: b2 == a2) — same call on b2 / a2
+
+if any(f.level == "error" for f in findings):
+    decision = "À DÉCIDER (valeurs ≠ : {})".format(
+        next(f.message for f in findings if f.level == "error"))
+elif args.accept_diffs and any(f.level == "warn" for f in findings):
+    diff_note = " [écart accepté: {}]".format(
+        next(f.message for f in findings if f.level == "warn"))
+# else: migrate cleanly
+```
+`before`/`after`/`b2`/`a2` are exactly today's `card_values`/`card_cells` outputs (sorted numeric lists);
+no adapter needed. `series_display_map` + `card_cells` stay upstream. The "À VÉRIFIER (fenêtre vide)" and
+"À DÉCIDER (rendu incohérent)" branches are untouched. `migrate_client.py` orchestration is untouched.
+
+### 3.4 Dogfood — differential test of the differential
+
+After the refactor, dry-run the migration on a throwaway **test copy** of a small sample of dashboards and
+assert per-card decisions ("À DÉCIDER" / "migrée" / écart-accepté note) are **identical** to the
+pre-refactor code on the same sample — behaviour-preserving verification on the real, active campaign.
+
+## 4. Error handling / safety
+- Pure behaviour-preserving refactor; §3.4 dogfood is the proof.
+- conv-migration keeps running on **copies** with **dry-run** by default — live dashboards untouched by this work.
+- `check_values` is additive and `check_differential` is unchanged, so the merged layer's 148 tests stay green.
+
+## 5. Testing
+- `check_values` unit tests: equal lists ⇒ `ok`; length mismatch ⇒ `value count` Finding; one value beyond
+  tolerance ⇒ Finding (`identical`⇒error, `monitor`⇒warn); difference **within** tolerance ⇒ `ok`; unsorted
+  numeric inputs still compared as a multiset; a non-numeric sequence compared exactly; `tolerance=0` exact.
+- conv-migration: fixture-based test of the delegation — a before/after that yields "À DÉCIDER", one that
+  yields "migrée", and one `--accept-diffs` that yields the écart note — proving the decision mapping is preserved.
+- `guarded_apply` honours a non-zero `tolerance` (no longer dropped).
+
+## 6. Decisions & open points
+- **Decided**: `check_values` treats all-numeric inputs as a **multiset** (sorts internally), so it is
+  order-agnostic; mixed/non-numeric inputs fall back to exact ordered equality.
+- **Decided**: length mismatch ⇒ a single `value count` Finding; one summary Finding per call (not per element).
+- **Risk**: a `migrate_*` script may compute `before`/`after` slightly differently across the three files;
+  the implementation reads each call site and routes it through the same `check_values` call, confirming the
+  same decision via §3.4 before relying on it.

--- a/scripts/migrate_conversions_on_dashboard.py
+++ b/scripts/migrate_conversions_on_dashboard.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
 from spark_metabase_api import Metabase_API
 from reorg_phase1 import _load_env
 import swap_lib, conv_lib
+from spark_metabase_api import validate as V
 
 MIG = REPO / "migration"
 
@@ -170,7 +171,7 @@ def main():
             _dc, _card, _new, _res, _oc, _ren = item
             before = card_values(mb, _card["id"], args.client, args.window)
             after = card_values(mb, _res["new_card_id"], args.client, args.window)
-            if before == after:
+            if all(f.level == "ok" for f in V.check_values(_card.get("name"), before, after, mode="identical")):
                 verified.append(item)
             else:
                 print(f"  ⚠️ NON migrée «{_card.get('name')}» — valeur avant/après différente "

--- a/scripts/migrate_dashboard_reuse.py
+++ b/scripts/migrate_dashboard_reuse.py
@@ -23,6 +23,7 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
 import conv_lib
 import bascule_lib
+from spark_metabase_api import validate as V
 from migrate_dashboard_full import connect, load_inputs, card_values, _dcs
 
 def _client_date_params(tags, client, window):
@@ -227,7 +228,8 @@ def main():
                     after = card_values(mb, newc_id, args.client, args.window)
                 if not before:
                     decision = "À VÉRIFIER (fenêtre de validation VIDE — aucune preuve)"
-                elif before != after:
+                elif any(f.level == "error" for f in
+                         V.check_values(card.get("name"), before, after, mode="identical")):
                     # la carte 11673 affiche-t-elle simplement des séries EN PLUS ?
                     # -> mapper les séries de l'ancienne par nature, masquer le reste
                     #    au niveau du dashcard, et comparer sur les séries affichées.
@@ -241,7 +243,8 @@ def main():
                         g = "week" if time_exception else None
                         b2 = card_cells(mb, cid, args.client, args.window, g, old_m)
                         a2 = card_cells(mb, newc_id, args.client, args.window, g, mapped)
-                        if b2 and b2 == a2:
+                        if b2 and all(f.level == "ok" for f in
+                                      V.check_values(card.get("name"), b2, a2, mode="identical")):
                             mask_keep = mapped
                         else:
                             decision = ("À DÉCIDER (valeurs ≠ même restreintes aux séries affichées : "

--- a/spark_metabase_api/validate.py
+++ b/spark_metabase_api/validate.py
@@ -222,7 +222,7 @@ def gate(client, units, execute=True) -> Report:
 
 
 def guarded_apply(client, units, mutate_fn, differential="monitor",
-                  force=False, execute=True) -> Report:
+                  force=False, execute=True, tolerance=0.0) -> Report:
     report = Report()
     baselines: Dict[str, List[Dict[str, Any]]] = {}
     if differential != "off":
@@ -247,7 +247,7 @@ def guarded_apply(client, units, mutate_fn, differential="monitor",
                     report.add(Finding(u.target, "differential", "error",
                         "post-apply query failed: {}".format(err)))
                     continue
-                for f in check_differential(u.target, baselines[u.target], after, mode=mode):
+                for f in check_differential(u.target, baselines[u.target], after, mode=mode, tolerance=tolerance):
                     report.add(f)
     return report
 
@@ -309,3 +309,33 @@ def check_differential(target, before, after, mode="monitor", tolerance=0.0) -> 
         findings.append(Finding(target, "differential", "ok", "no significant change"))
 
     return findings
+
+
+def check_values(target, before, after, mode="monitor", tolerance=0.0) -> List[Finding]:
+    """Compare two sequences of scalar values (conv-migration's sorted/rounded
+    numeric-multiset convention). mode='identical' => a difference is an error;
+    mode='monitor' => a warn. tolerance=0.0 reproduces an exact `before != after`."""
+    level = "error" if mode == "identical" else "warn"
+    b, a = list(before or []), list(after or [])
+    if len(b) != len(a):
+        return [Finding(target, "values", level,
+            "value count {} -> {}".format(len(b), len(a)), before=len(b), after=len(a))]
+    is_num = lambda v: isinstance(v, (int, float)) and not isinstance(v, bool)
+    if all(is_num(x) for x in b) and all(is_num(x) for x in a):
+        diffs, first = 0, None
+        for x, y in zip(sorted(b), sorted(a)):
+            denom = abs(x) or 1.0
+            d = abs(y - x)
+            if d != d or d / denom > tolerance:  # NaN or beyond tolerance
+                diffs += 1
+                if first is None:
+                    first = (x, y)
+        if diffs:
+            return [Finding(target, "values", level,
+                "{}/{} values differ beyond tolerance, first {} -> {}".format(
+                    diffs, len(b), first[0], first[1]),
+                before=first[0], after=first[1])]
+    elif b != a:
+        return [Finding(target, "values", level, "values differ (non-numeric)",
+                        before=b, after=a)]
+    return [Finding(target, "values", "ok", "{} values, no change".format(len(b)))]

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -317,3 +317,38 @@ def test_resolve_cli_target_bad_spec_file(tmp_path):
     bad.write_text('{"not": "a spec"}')
     with pytest.raises(ValueError):
         V.resolve_cli_target(object(), str(bad))
+
+
+# --- check_values + guarded_apply tolerance (unify-differential) ---
+
+def test_check_values():
+    # order-agnostic multiset equality
+    assert all(f.level == "ok" for f in V.check_values("t", [1.0, 2.0], [2.0, 1.0], mode="identical"))
+    # length mismatch -> finding
+    assert any(f.level == "error" for f in V.check_values("t", [1.0], [1.0, 2.0], mode="identical"))
+    # numeric drift beyond tolerance
+    drift = V.check_values("t", [10.0, 20.0], [10.0, 25.0], mode="identical")
+    assert any(f.level == "error" and "differ" in f.message for f in drift)
+    # within tolerance -> ok
+    assert all(f.level == "ok" for f in V.check_values("t", [100.0], [100.05], mode="monitor", tolerance=0.001))
+    # monitor mode -> warn
+    assert any(f.level == "warn" for f in V.check_values("t", [100.0], [200.0], mode="monitor"))
+    # non-numeric exact compare
+    assert any(f.level == "error" for f in V.check_values("t", ["a", "b"], ["a", "c"], mode="identical"))
+
+
+def test_guarded_apply_forwards_tolerance():
+    """A within-tolerance numeric change must not raise a differential finding once tolerance is forwarded."""
+    seq = [[{"v": 100.0}], [{"v": 100.05}]]  # baseline, then post-mutate
+
+    class TolClient:
+        def __init__(self): self.n = 0
+        def get(self, ep, *a, **k): return {"archived": False}
+        def get_card_data(self, card_id=None, data_format="json"):
+            r = seq[0] if self.n == 0 else seq[1]; self.n += 1; return r
+        def run_query(self, dq, parameters=None):
+            return {"status": "completed", "data": {"cols": [{"name": "v"}], "rows": [[100.0]]}}
+
+    u = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "x"}}, live_card_id=7)
+    rep = V.guarded_apply(TolClient(), [u], lambda: None, differential="monitor", execute=True, tolerance=0.001)
+    assert not any(f.check == "differential" and f.level in ("warn", "error") for f in rep.findings)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -352,3 +352,14 @@ def test_guarded_apply_forwards_tolerance():
     u = V.CardUnit("c/A", {"database": 1, "type": "native", "native": {"query": "x"}}, live_card_id=7)
     rep = V.guarded_apply(TolClient(), [u], lambda: None, differential="monitor", execute=True, tolerance=0.001)
     assert not any(f.check == "differential" and f.level in ("warn", "error") for f in rep.findings)
+
+
+def test_check_values_matches_exact_inequality():
+    """conv-migration refactor relies on: check_values(identical) errors IFF before != after
+    (for the sorted numeric value-lists card_values/displayed_cells produce)."""
+    cases = [([1.0, 2.0], [1.0, 2.0]), ([1.0, 2.0], [2.0, 1.0]), ([1.0, 2.0], [1.0, 3.0]),
+             ([1.0], [1.0, 2.0]), ([1.0, 2.0, 3.0], [1.0, 2.0]), ([], [])]
+    for b, a in cases:
+        bs, as_ = sorted(b), sorted(a)
+        errored = any(f.level == "error" for f in V.check_values("t", bs, as_, mode="identical"))
+        assert errored == (bs != as_), "mismatch for {} vs {}".format(bs, as_)


### PR DESCRIPTION
## Quoi
- `validate.check_values` : compare 2 séquences de valeurs (la convention multiset trié/arrondi de conv-migration) ; mode `identical`|`monitor`, tolérance ; longueur ≠ → finding.
- `guarded_apply` forwarde désormais `tolerance` à `check_differential` (ferme le trou trouvé par la review adversariale).
- conv-migration (`migrate_dashboard_reuse`, `migrate_conversions_on_dashboard`) délègue son `before != after` / `b2 == a2` à `check_values` — **comportement préservé** (`tolerance=0` = exact ; `card_values` trie déjà → multiset ≡ exact), prouvé par `test_check_values_matches_exact_inequality`.

## Pourquoi
Le différentiel (PR #16) n'était câblé dans aucun flux réel ; conv-migration avait un diff maison dupliqué et non testé. Désormais : un diff **testé, partagé, dogfoodé** sur la campagne active. `series_display_map`/`card_cells` restent en amont (extraction métier).

## Tests & review
151 tests verts. Review whole-branch : **Ready to merge (Yes)**, 0 Critical/Important, 3 minors de clarté (doc/test) non-bloquants.

## Limite connue
Le dry-run live sur copie de test (spec §3.4) = **suivi manuel** (pas de creds Metabase en CI) ; le refactor est préservé-par-construction et couvert par le test d'équivalence.

## Specs / plan
- `docs/superpowers/specs/2026-06-21-differential-wiring-design.md`
- `docs/superpowers/plans/2026-06-21-unify-differential.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)