### PR TITLE
chore: outillage WIP — conv-migration, corpus SEO, quiz room, chatbot

### DIFF
--- a/docs/conversion-migration-HANDOFF-LUCAS.md
+++ b/docs/conversion-migration-HANDOFF-LUCAS.md
@@ -1,0 +1,168 @@
+# Handoff conversions → Lucas (team lead)
+
+**But du doc :** la migration des conversions (positionnel → nommé) est faite à **76 % au niveau carte**
+(scan complet des 370 paires de dashboards : **3104 / 4077 tuiles migrées, 973 restantes**).
+Le reste, ce sont les décisions **qui demandent un regard humain**. Tu es le point de centralisation : tu
+**routes** vers les bonnes personnes et tu **arbitres** le point stratégique. On ne contacte personne en direct,
+tout passe par toi.
+
+> Source live des chiffres : `migration/HANDOFF-consultants.csv`, `migration/CONVERSIONS-A-REVOIR-valeur.csv`.
+> État global du chantier : `docs/conversion-migration-PROGRESS.md`.
+
+---
+
+## Ce que tu as à faire (vue d'ensemble)
+
+| # | Décision | Volume | Tu routes vers | Fichier à transmettre |
+|---|----------|--------|----------------|------------------------|
+| **A** | Conversions ambiguës (quel nom ?) | **80 décisions / 33 clients** | les **consultants** (par client) | `HANDOFF-consultants.csv` |
+| **B** | Écarts de valeur (chiffre suspect) | **21 lignes / 8 clients** | l'**équipe data** | `CONVERSIONS-A-REVOIR-valeur.csv` |
+| **C** | Modèle de mise en prod (liens Nanga) | **1 arbitrage** | **toi + Louis** | ce doc, §C |
+
+**Pas pour toi (info seulement) :** la **couverture technique** (189 cartes « tables larges » / KPIs-evolution)
+= notre **dette d'outillage**, on la traite en interne, ça n'attend aucune réponse humaine.
+
+```
+76 % des tuiles conversion migrées (3104/4077)
+└── 24 % restant (973 tuiles) = ce doc
+      ├── A  consultants   80 décisions / 33 clients   ← le gros
+      ├── B  équipe data   21 écarts / 8 clients
+      └── C  arbitrage prod (toi + Louis)
+   (+ couverture technique 189 cartes = NOUS, hors handoff)
+```
+
+---
+
+## A. Conversions à trancher → CONSULTANTS
+
+Les anciens dashboards comptaient les conversions **par position** (1ʳᵉ, 2ᵉ…). On passe à des conversions
+**nommées** (Purchases, Leads, Sign ups, Custom n…). Pour certaines positions, le nom n'est pas déductible
+automatiquement : **seul le consultant qui gère le compte sait**. Deux types de questions :
+
+| Type | Sens | Réponse attendue |
+|------|------|------------------|
+| **nom?** | la position est utilisée mais **aucune** conversion nommée ne lui correspond | écrire le nom de la conversion |
+| **choix** | **plusieurs** noms possibles selon le compte pub | choisir la bonne option |
+| **OR** | un « X OR Y » a été saisi dans Airtable, non tranché | choisir X ou Y |
+
+**Comment ça marche :** chaque consultant remplit **seulement les lignes de ses marques** dans
+`HANDOFF-consultants.csv` (colonne `client`), écrit sa réponse dans **« ✍️ TA RÉPONSE »**, renvoie le fichier.
+On parse en automatique (`parse_consultant_answers.py`) → on re-migre ses dashboards. **2 min par client.**
+
+**Priorité = nombre de dashboards débloqués** (colonne `priorité`). Commencer par le haut.
+
+### Par client (trié par impact)
+
+> 🔥 = ≥ 10 dashboards impactés · 🔸 = 4 à 9 · ▫️ = 1 à 3
+> `slots` = nombre de conversions à trancher pour ce client · `dash` = dashboards débloqués
+
+| Client | slots | dash | type |
+|--------|:-----:|:----:|------|
+| 🔥 Welcome to the Jungle | 3 | 21 | nom? |
+| 🔥 24S | 1 | 19 | nom? |
+| 🔥 Quitoque | 7 | 16 | nom? |
+| 🔥 Lunii | 4 | 16 | nom? |
+| 🔥 900.care | 1 | 15 | nom? |
+| 🔥 Rivadouce | 3 | 12 | choix |
+| 🔥 Jerome Dreyfuss | 1 | 10 | nom? |
+| 🔸 Shopinvest | 2 | 9 | nom? |
+| 🔸 Les petits culottés | 15 | 8 | nom? |
+| 🔸 Quiz Room | 2 | 8 | choix |
+| 🔸 Dougs | 2 | 7 | nom? |
+| 🔸 Enlaps | 1 | 7 | choix |
+| 🔸 U2P | 4 | 6 | choix + nom? |
+| 🔸 En Voiture Simone (EVS) | 2 | 6 | nom? |
+| 🔸 BeneBono | 1 | 6 | choix |
+| 🔸 Father and Sons | 1 | 6 | choix |
+| 🔸 Zenchef | 4 | 5 | nom? |
+| 🔸 BYmyCAR | 1 | 5 | choix |
+| 🔸 Cirque du Soleil | 1 | 5 | nom? |
+| 🔸 HomeExchange | 3 | 4 | choix + nom? |
+| 🔸 Reputation | 1 | 4 | OR + choix |
+| ▫️ Distingo Bank | 3 | 3 | choix + nom? |
+| ▫️ Yooji | 3 | 3 | OR + choix + nom? |
+| ▫️ CapCar | 1 | 3 | choix |
+| ▫️ Goodiespub | 1 | 2 | choix |
+| ▫️ Arrago | 2 | 1 | choix |
+| ▫️ Be Radiance | 2 | 1 | nom? |
+| ▫️ Ecopia | 2 | 1 | choix + nom? |
+| ▫️ Richardson | 2 | 1 | nom? |
+| ▫️ Absolut Cashmere | 1 | 1 | nom? |
+| ▫️ Braxton | 1 | 1 | nom? |
+| ▫️ Gamin Tout Terrain | 1 | 1 | choix |
+| ▫️ Redesk | 1 | 1 | nom? |
+
+**Total : 80 conversions à trancher, 33 clients.** Les 7 du haut (🔥) débloquent à eux seuls ~100 dashboards.
+**Cas le plus lourd : Les petits culottés (15 slots)** mais sur 8 dashboards. Détail ligne à ligne = le CSV.
+
+---
+
+## B. Écarts de valeur → ÉQUIPE DATA
+
+Ici le mapping **existe**, mais notre garde-fou a détecté que la conversion **nommée ≠ le positionnel** qu'elle
+remplace. On a **gardé ces tuiles sur l'ancien** (jamais poussé une valeur douteuse). Question pour la data :
+**l'écart est-il normal** (le nommé est la « bonne » nouvelle définition → on migre) **ou un bug** de table ?
+
+| Client | Colonne | Positionnel → Nommé | Écart |
+|--------|---------|---------------------|:-----:|
+| BYmyCAR | CONVERSIONS_5 | 1907,8 → 218 | **−89 %** |
+| Lutèce Cosmetics | CONVERSIONS → PURCHASES | 16,6 → 5,3 | **−68 %** |
+| Yooji | CONVERSIONS_3 (current) | 9674 → 3744 | **−61 %** |
+| Yooji | CONVERSIONS_3 (previous) | 11208 → 4932 | **−56 %** |
+| Comptastar | CONVERSIONS → LEADS | 1257,5 → 618 | **−51 %** |
+| BYmyCAR | CAC_5 | 2134,8 → 1189 | −44 % |
+| Comptastar | CONV_RATE (×8 lignes) | ~0,14 → ~0,08 | −36 à −52 % |
+| Comptastar | CAC | 237,9 → 139,7 | −41 % |
+| Toploc | CONVERSIONS_1 → CURRENT_LEADS | 38 → 25 | −34 % (systématique) |
+| HomeExchange | CONVERSIONS_3 / CR_3 | −7 % | faible |
+| TuneCore | CONVERSIONS → PURCHASES | 12381 → 11961 | −3 % (quasi nul) |
+| Distingo Bank | CAC_6 | 0 → 284,9 | positionnel **vide** |
+
+**Lectures utiles pour la data (pour ne pas traiter 21 problèmes là où il y en a moins) :**
+- **Comptastar = ~1 cause, pas 10.** Ses CONV_RATE / CAC sont **dérivés** du compte de conversions. Si
+  `CONVERSIONS → LEADS` est faux (−51 %), tous les ratios suivent mécaniquement. **Trancher LEADS d'abord.**
+- **BYmyCAR** : pareil, `CAC_5` découle de `CONVERSIONS_5`. Un seul sujet.
+- **Distingo `CAC_6`** : le positionnel valait **0** (slot vide). La valeur nommée n'est pas un « écart »,
+  probablement un **faux positif** → à confirmer puis migrer.
+- **TuneCore (−3 %) et HomeExchange (−7 %)** : écarts faibles, sans doute attribution/arrondi → migrables.
+- **Les gros (BYmyCAR −89 %, Lutèce −68 %, Yooji −56/61 %)** = vrais sujets à creuser avant migration.
+
+> ⚠️ Si la data conclut « ce n'est pas un bug, c'est un **mapping slot→nom faux** », alors la ligne **bascule
+> vers le consultant** (panier A) pour re-choisir le bon nom.
+
+---
+
+## C. Arbitrage à trancher (toi + Louis) — mise en prod
+
+Tout est migré sur des **copies** (collection 14016). Une fois 100 % propre, on les **passe en prod**. Deux voies,
+une seule à choisir :
+
+| Option | Avantage | Coût |
+|--------|----------|------|
+| **1. Déplacer les copies** dans les collections clients | aucune retouche des dashboards, propre | **nouveaux ids** → les liens / partages **Nanga** (qui pointent sur les anciens) sont à **re-partager à la main par les GM** |
+| **2. Écraser le contenu des originaux** (garde les ids, donc les liens Nanga) | rien à re-partager | = **« refaire »** le contenu sur les originaux — **écarté par Louis** |
+
+➡️ **Décision attendue :** valide-t-on **l'option 1 + re-partage manuel GM** ? (C'est la voie privilégiée ;
+le re-partage Nanga reste de toute façon une action GM manuelle, par responsabilisation.)
+
+---
+
+## Hors périmètre (pour info, rien à faire)
+
+- 🔧 **Couverture technique — 189 cartes** (tables « performances » larges + KPIs-evolution + benchmark).
+  C'est **notre dette d'outillage** (cascade plus robuste ou carte générique dédiée). **N'attend aucune
+  réponse humaine.** Détail : `migration/coverage-cards.json`.
+- 🚫 **Exclus du chantier :** 21 clients **inactifs**, + **Vestiaire Collective / Polène / Ray Studios**
+  (gérés à la main par Louis), + 11 clients « tout-Gaby » (0 slot mappé).
+
+---
+
+## Fichiers à transmettre
+
+| Destinataire | Fichier | Notice |
+|--------------|---------|--------|
+| Consultants | `migration/HANDOFF-consultants.csv` | `migration/HANDOFF-consultants-LISEZMOI.md` |
+| Équipe data | `migration/CONVERSIONS-A-REVOIR-valeur.csv` | `migration/CONVERSIONS-A-REVOIR-valeur-LISEZMOI.md` |
+
+Round-trip consultant : CSV rempli → `parse_consultant_answers.py` → `consultant-decisions.json` → re-run des
+dashboards du client = débloqués.

--- a/run_chatbot.sh
+++ b/run_chatbot.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Lance l'interface Streamlit du chatbot (autorat de dashboards Metabase).
+#
+# Usage :  ./run_chatbot.sh
+# Puis ouvre http://localhost:8501 (le navigateur s'ouvre tout seul).
+# Ctrl+C pour arrêter.
+set -euo pipefail
+
+# Toujours travailler depuis le dossier du repo, peu importe d'où on lance.
+cd "$(dirname "$0")"
+
+# Premier lancement (ou venv supprimé) : on (re)crée tout automatiquement.
+if [ ! -x .venv/bin/streamlit ]; then
+  echo "→ Création du venv et installation des dépendances (une seule fois)..."
+  python3 -m venv .venv
+  .venv/bin/python -m pip install --quiet --upgrade pip
+  .venv/bin/python -m pip install -e ".[streamlit,iac]"
+fi
+
+# Pré-remplit les identifiants Metabase depuis .env (domaine + session id).
+if [ -f .env ]; then
+  set -a; . ./.env; set +a
+fi
+
+echo "→ Interface : http://localhost:8501  (Ctrl+C pour arrêter)"
+exec .venv/bin/streamlit run streamlit_app.py --browser.gatherUsageStats false

--- a/scripts/annotate_visibility.py
+++ b/scripts/annotate_visibility.py
@@ -1,0 +1,112 @@
+"""Annotate every conv-targets tile with the EFFECTIVE visibility of each conversion slot,
+accounting for dashcard-level overrides (which win over the card's own settings).
+
+Outputs:
+  migration/conv-visibility-by-slot.json  -> per (client, slot): tile counts + verdict
+      verdict = VISIBLE  (shown in >=1 tile)   -> genuine consultant/mapping question
+              | AMBIGUOUS (never provably shown, but not provably hidden either)
+              | HIDDEN    (provably hidden in EVERY tile) -> false positive, auto-droppable
+
+Read-only against Metabase. Caches to migration/_viz_cache.json (resumable).
+"""
+import sys, json, os
+from collections import defaultdict
+sys.path.insert(0, "scripts")
+from archive_collections import connect_resilient
+import conv_lib, conv_visibility as cv
+
+mb = connect_resilient()
+CACHE = "migration/_viz_cache.json"
+cache = json.load(open(CACHE)) if os.path.exists(CACHE) else {"cards": {}, "dashboards": {}}
+
+def card_info(cid):
+    k = str(cid)
+    if k not in cache["cards"]:
+        c = mb.get(f"/api/card/{cid}") or {}
+        vs = c.get("visualization_settings") or {}
+        names = set()
+        for col in (vs.get("table.columns") or []):
+            names.add((col.get("name") or "").upper())
+        for m in (vs.get("graph.metrics") or []):
+            if m:
+                names.add(m.upper())
+        if vs.get("scalar.field"):
+            names.add(vs["scalar.field"].upper())
+        for rc in (c.get("result_metadata") or []):
+            names.add((rc.get("name") or "").upper())
+        cache["cards"][k] = {"display": c.get("display"), "vs": vs, "cols": sorted(n for n in names if n)}
+    return cache["cards"][k]
+
+def dashcard_overrides(did):
+    k = str(did)
+    if k not in cache["dashboards"]:
+        d = mb.get(f"/api/dashboard/{did}") or {}
+        ov = {}
+        for dc in (d.get("dashcards") or d.get("ordered_cards") or []):
+            ov[str(dc.get("id"))] = dc.get("visualization_settings") or {}
+        cache["dashboards"][k] = ov
+    return cache["dashboards"][k]
+
+tg = json.load(open("migration/conv-targets.json"))
+agg = {}  # (client, slot) -> tile-status counts
+vis_dash = defaultdict(set)   # (client, slot) -> {dashboard_id where a tile is VISIBLE}
+shown_dash = defaultdict(set) # (client, slot) -> {dashboard_id where NOT hidden (visible|ambiguous)}
+all_dash = defaultdict(set)   # (client, slot) -> {dashboard_id where present at all}
+dash_name = {}                # dashboard_id -> name
+n = 0
+for d in tg:
+    client = d.get("client")
+    did = d["dashboard_id"]
+    dash_name[did] = d.get("dashboard_name", "")
+    overrides = dashcard_overrides(did)
+    for t in d.get("tiles", []):
+        try:
+            ci = card_info(t["card_id"])
+            # union of every column name we know about, plus the SQL old_cols
+            result_cols = set(ci["cols"]) | {c.upper() for c in t.get("old_cols", [])}
+            dcvs = overrides.get(str(t.get("dashcard_id")), {})
+            # add dashcard-override column names too (they may list columns the card didn't)
+            for col in (dcvs.get("table.columns") or []):
+                result_cols.add((col.get("name") or "").upper())
+            slots = {conv_lib._slot_of(c) for c in t.get("old_cols", [])}
+            slots.discard(None)
+            for s in slots:
+                status = cv.tile_slot_status(ci["display"], ci["vs"], dcvs, result_cols, s)
+                a = agg.setdefault((client, s), defaultdict(int))
+                a[status] += 1
+                all_dash[(client, s)].add(did)
+                if status == "visible":
+                    vis_dash[(client, s)].add(did)
+                if status in ("visible", "ambiguous"):
+                    shown_dash[(client, s)].add(did)
+        except Exception as e:
+            print(f"  !! skip tile card {t.get('card_id')} dash {did}: {e!r}", flush=True)
+    n += 1
+    if n % 50 == 0:
+        json.dump(cache, open(CACHE, "w"))
+        print(f"...{n}/{len(tg)} dashboards", flush=True)
+
+json.dump(cache, open(CACHE, "w"))
+
+out = []
+for (client, slot), c in sorted(agg.items()):
+    visible = c.get("visible", 0); amb = c.get("ambiguous", 0); hid = c.get("hidden", 0)
+    verdict = "VISIBLE" if visible else ("AMBIGUOUS" if amb else "HIDDEN")
+    vdash = sorted(vis_dash[(client, slot)])
+    sdash = sorted(shown_dash[(client, slot)])
+    out.append({"client": client, "slot": slot, "verdict": verdict,
+                "visible_dashboards": len(vdash), "shown_dashboards": len(sdash),
+                "total_dashboards": len(all_dash[(client, slot)]),
+                "visible": visible, "ambiguous": amb, "hidden": hid, "absent": c.get("absent", 0),
+                "visible_dash_names": [dash_name.get(i, "") for i in vdash],
+                "shown_dash_names": [dash_name.get(i, "") for i in sdash]})
+json.dump(out, open("migration/conv-visibility-by-slot.json", "w"), ensure_ascii=False, indent=1)
+
+byv = defaultdict(int)
+for r in out:
+    byv[r["verdict"]] += 1
+print(f"\nSlots (client,slot) classés : {len(out)}")
+print(f"  VISIBLE   : {byv['VISIBLE']}")
+print(f"  AMBIGUOUS : {byv['AMBIGUOUS']}")
+print(f"  HIDDEN    : {byv['HIDDEN']}  (masqués partout -> faux positifs)")
+print("-> migration/conv-visibility-by-slot.json")

--- a/scripts/build_seo_corpus_dashboard.py
+++ b/scripts/build_seo_corpus_dashboard.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""NOUVEAU dashboard corpus-driven | Manucurist.
+- carte synthèse à plat (dernier mois, tri par clics) : Marché/Catégorie/Mot-clé/Volume/Position/Δ M-1/Clics/Impressions
+- carte inversée (mois × mot-clé × Volume/Rank/Impr/Clics)
+- filtres : Corpus (valeurs DYNAMIQUES depuis le modèle -> autonomie), Marché, Catégorie (dynamique),
+  Top N par clics (nombre, défaut 25, mappé sur RANG_CLICS), Mot-clé contient/exact, Période.
+Plages de couleurs discrètes validées (vert = rank, bleu = clics). #26061 et #25137 non touchés.
+"""
+from __future__ import annotations
+import json, sys, time, uuid
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+
+DB=144; COLL=13752; TMO=600
+MODEL_NAME="SEO Corpus Monitoring — Manucurist (model)"
+SYNTH_NAME="SEO Corpus — synthèse du dernier mois (tri par clics) | Manucurist"
+INV_NAME="SEO Corpus — évolution par mot-clé (mois en lignes) | Manucurist"
+DASH_NAME="Suivi mots-clés par corpus | Manucurist"
+DEFAULT_CORPUS="Mots-clés suivis FR"  # défaut = 1 seul corpus ; tous restent sélectionnables
+u=lambda: str(uuid.uuid4())
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex: print("retry",repr(ex)[:80],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def fl(name,bt,extra=None):
+    o={"base-type":bt,"lib/uuid":u()}
+    if extra:o.update(extra)
+    return ["field",o,name]
+def fr(name,bt,extra=None):
+    o={"base-type":bt}
+    if extra:o.update(extra)
+    return ["field",name,o]
+def cs(name,opts): return {json.dumps(["name",name]):opts}
+def dec0(t): return {"column_title":t,"number_style":"decimal","decimals":0}
+def bands(col,kind):
+    if kind=="rank":
+        steps=[(3,"#0B5226"),(10,"#2E7D32"),(20,"#66BB6A"),(50,"#A5D6A7"),(100,"#E8F5E9")]; op="<="
+    else:
+        steps=[(100,"#2E6CA8"),(50,"#5B8DC0"),(25,"#9CC0E0"),(10,"#DCE9F5")]; op=">="
+    return [{"columns":[col],"type":"single","operator":op,"value":v,"color":c} for v,c in steps]
+
+def find(mb,kind,name):
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")==kind and it.get("name")==name: return it["id"]
+    return None
+def upsert_card(mb,name,payload):
+    cid=find(mb,"card",name)
+    if cid: mb.put(f"/api/card/{cid}","raw",json=payload,timeout=TMO); return cid,"maj"
+    b=mb.post("/api/card","raw",json=payload,timeout=TMO).json(); return b.get("id"),"créé"
+
+def main():
+    mb=connect(); print("connected",flush=True)
+    MID=find(mb,"dataset",MODEL_NAME)
+    if not MID: sys.exit("modèle corpus introuvable, lancer build_seo_corpus_model.py --apply d'abord")
+    print("modèle #",MID,flush=True)
+
+    # ---- carte synthèse (table plate, dernier mois complet, tri clics desc) ----
+    synth_q={"database":DB,"type":"query","query":{"source-table":f"card__{MID}",
+        "fields":[fr("MARCHE","type/Text"),fr("CATEGORY","type/Text"),fr("KEYWORD","type/Text"),
+                  fr("SEARCH_VOLUME","type/Float"),fr("POSITION","type/Float"),fr("DELTA_M1","type/Float"),
+                  fr("CLICKS","type/Float"),fr("IMPRESSIONS","type/Float")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),-1,"month"],
+        "order-by":[["desc",fr("CLICKS","type/Float")]]}}
+    synth_viz={"column_settings":{
+            **cs("MARCHE",{"column_title":"Marché"}),**cs("CATEGORY",{"column_title":"Catégorie"}),
+            **cs("KEYWORD",{"column_title":"Mot-clé"}),**cs("SEARCH_VOLUME",dec0("Volume rech.")),
+            **cs("POSITION",dec0("Position")),**cs("DELTA_M1",dec0("Évolution M-1")),
+            **cs("CLICKS",dec0("Clics GSC")),**cs("IMPRESSIONS",dec0("Impressions"))},
+        "table.column_formatting": bands("POSITION","rank")+bands("CLICKS","clics")}
+    SYNTH,how=upsert_card(mb,SYNTH_NAME,{"name":SYNTH_NAME,"collection_id":COLL,"dataset_query":synth_q,
+        "display":"table","visualization_settings":synth_viz,
+        "description":"Synthèse du dernier mois complet pour le corpus et le marché choisis, classée du mot-clé le plus cliqué au moins cliqué. Position en vert (foncé = bonne position), clics en bleu."})
+    print(f"synthèse {how} #{SYNTH}",flush=True)
+    jr=mb.post("/api/dataset","raw",json=synth_q,timeout=TMO).json()
+    if not jr.get("error"): mb.put(f"/api/card/{SYNTH}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+
+    # ---- carte inversée (pivot MLv2) ----
+    inv_dq={"database":DB,"lib/type":"mbql/query","stages":[{
+        "lib/type":"mbql.stage/mbql","source-card":MID,
+        "aggregation":[
+            ["sum",{"lib/uuid":u()}, fl("SEARCH_VOLUME","type/Number")],
+            ["avg",{"lib/uuid":u()}, fl("POSITION","type/Number")],
+            ["sum",{"lib/uuid":u()}, fl("IMPRESSIONS","type/Number")],
+            ["sum",{"lib/uuid":u()}, fl("CLICKS","type/Number")]],
+        "breakout":[ fl("MONTH_DATE","type/Date",{"temporal-unit":"month"}), fl("KEYWORD","type/Text") ]}]}
+    inv_viz={"pivot_table.column_split":{
+            "rows":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"})],
+            "columns":[fr("KEYWORD","type/Text")],
+            "values":[["aggregation",0],["aggregation",1],["aggregation",2],["aggregation",3]]},
+        "pivot.show_row_totals":False,"pivot.show_column_totals":False,
+        "column_settings":{
+            json.dumps(["name","MONTH_DATE"]):{"column_title":"Mois"},
+            json.dumps(["name","KEYWORD"]):{"column_title":"Mot-clé"},
+            json.dumps(["name","sum"]):{"column_title":"Volume","number_style":"decimal","decimals":0},
+            json.dumps(["name","avg"]):{"column_title":"Rank","number_style":"decimal","decimals":0},
+            json.dumps(["name","sum_2"]):{"column_title":"Impressions","number_style":"decimal","decimals":0},
+            json.dumps(["name","sum_3"]):{"column_title":"Clics","number_style":"decimal","decimals":0}},
+        "table.column_formatting": bands("avg","rank")+bands("sum_3","clics")}
+    INV,how=upsert_card(mb,INV_NAME,{"name":INV_NAME,"collection_id":COLL,"dataset_query":inv_dq,
+        "display":"pivot","visualization_settings":inv_viz,
+        "description":"Les mois en lignes, les mots-clés en colonnes, et pour chacun son volume, son rank, ses impressions et ses clics. Filtré par corpus, marché et Top N par clics."})
+    print(f"inversée {how} #{INV}",flush=True)
+    legacy={"database":DB,"type":"query","query":{"source-table":f"card__{MID}",
+        "aggregation":[["sum",fr("SEARCH_VOLUME","type/Number")],["avg",fr("POSITION","type/Number")],
+                       ["sum",fr("IMPRESSIONS","type/Number")],["sum",fr("CLICKS","type/Number")]],
+        "breakout":[fr("MONTH_DATE","type/Date",{"temporal-unit":"month"}),fr("KEYWORD","type/Text")]}}
+    jr=mb.post("/api/dataset","raw",json=legacy,timeout=TMO).json()
+    if not jr.get("error"): mb.put(f"/api/card/{INV}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+
+    # ---- dashboard ----
+    did=find(mb,"dashboard",DASH_NAME)
+    if not did:
+        b=mb.post("/api/dashboard","raw",json={"name":DASH_NAME,"collection_id":COLL,
+            "description":"Suivi mensuel des mots-clés par corpus Nanga. Choisis un corpus et un marché, le tableau montre les mots-clés les plus cliqués (Top N réglable) et leur évolution mois par mois. Les nouveaux corpus créés dans Nanga apparaissent automatiquement."}).json()
+        did=b.get("id"); print("dashboard créé #",did,flush=True)
+    else: print("dashboard existant #",did,flush=True)
+
+    def dyn(field):
+        return {"values_query_type":"list","values_source_type":"card",
+                "values_source_config":{"card_id":MID,"value_field":["field",field,{"base-type":"type/Text"}]}}
+    # filtre Marché retiré (2026-07-02, décision Thibaut) : 1 corpus = 1 langue = 1 marché,
+    # le nom du corpus porte déjà le marché.
+    P=[
+      {"id":"corpus01","name":"Corpus","slug":"corpus","type":"string/=","sectionId":"string",
+       "default":[DEFAULT_CORPUS], **dyn("CORPUS_NAME")},
+      {"id":"categ01","name":"Catégorie","slug":"categorie","type":"string/=","sectionId":"string", **dyn("CATEGORY")},
+      {"id":"topn01","name":"Top mots-clés (par clics)","slug":"top_n","type":"number/<=","sectionId":"number","default":[25]},
+      {"id":"pat01","name":"Mot-clé (contient)","slug":"pattern_keyword","type":"string/contains","sectionId":"string"},
+      {"id":"exact01","name":"Mot-clé (exact)","slug":"exact_keyword","type":"string/=","sectionId":"string"},
+      {"id":"date01","name":"Période","slug":"date","type":"date/all-options","sectionId":"date","default":"past6months"},
+    ]
+    CO=fr("CORPUS_NAME","type/Text"); MA=fr("MARCHE","type/Text"); CA=fr("CATEGORY","type/Text")
+    KW=fr("KEYWORD","type/Text"); RN=fr("RANG_CLICS","type/Number"); MO=fr("MONTH_DATE","type/Date")
+    def m(pid,cid,field): return {"parameter_id":pid,"card_id":cid,"target":["dimension",field]}
+    def maps(cid,with_date):
+        l=[m("corpus01",cid,CO),m("categ01",cid,CA),
+           m("topn01",cid,RN),m("pat01",cid,KW),m("exact01",cid,KW)]
+        if with_date: l.append(m("date01",cid,MO))
+        return l
+    def txt(t): return {"text":t,"virtual_card":{"name":None,"display":"text","visualization_settings":{},"dataset_query":{},"archived":False},
+        "text.align_vertical":"middle","text.align_horizontal":"left","dashcard.background":False}
+    dashcards=[
+      {"id":-1,"card_id":None,"row":0,"col":0,"size_x":24,"size_y":2,"series":[],"parameter_mappings":[],
+       "visualization_settings":txt("## 📈 Vue d'ensemble du corpus\nLes mots-clés du corpus choisi sur le dernier mois complet, classés du plus au moins cliqué. Le filtre Top limite aux mots-clés les plus cliqués.")},
+      {"id":-2,"card_id":SYNTH,"row":2,"col":0,"size_x":24,"size_y":9,"series":[],"parameter_mappings":maps(SYNTH,False),
+       "visualization_settings":{"card.title":"Synthèse du dernier mois complet, triée par clics"}},
+      {"id":-3,"card_id":None,"row":11,"col":0,"size_x":24,"size_y":2,"series":[],"parameter_mappings":[],
+       "visualization_settings":txt("## 📊 Évolution par mot-clé\nLes mois en lignes, les mots-clés en colonnes, et pour chacun son volume, son rank, ses impressions et ses clics. Le rank est en vert (foncé = bonne position), les clics en bleu. Scrolle vers la droite pour voir tous les mots-clés.")},
+      {"id":-4,"card_id":INV,"row":13,"col":0,"size_x":24,"size_y":12,"series":[],"parameter_mappings":maps(INV,True),
+       "visualization_settings":{"card.title":"Évolution de chaque mot-clé mois après mois"}},
+    ]
+    r=mb.put(f"/api/dashboard/{did}","raw",json={"parameters":P,"dashcards":dashcards},timeout=TMO)
+    bb=r.json() if hasattr(r,"json") else r
+    print("dashboard PUT:",getattr(r,"status_code","?"),"| dashcards:",len(bb.get("dashcards",[])) if isinstance(bb,dict) else "?",
+          "| filtres:",[p.get("slug") for p in (bb.get("parameters") or [])] if isinstance(bb,dict) else "?",flush=True)
+    dom=_load_env()["METABASE_DOMAIN"].rstrip("/")
+    print(f"\n>>> DASHBOARD CORPUS #{did} : {dom}/dashboard/{did}",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_corpus_model.py
+++ b/scripts/build_seo_corpus_model.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Modèle CORPUS-DRIVEN complet — généralise le V3 #48633.
+Piloté par google_serp.serp_requests PAR EXCLUSION (informationnel/blog/brand/transactionnels bruts exclus)
+-> tout nouveau corpus Nanga (couleurs, saisons, futurs) remonte automatiquement.
+Jointures : SERP (position, dédup) + GSC (clics/impr, DÉSACCENTÉ des 2 côtés) + KP (volume, désaccenté).
+Ajouts vs validation : DELTA_M1 / DELTA_CLICKS_M1 (LAG) + RANG_CLICS (rang par clics dans corpus×marché, pour filtre Top N).
+Gate : valide le run complet (comptages par corpus) AVANT le PUT du modèle.
+Usage : --apply pour créer/mettre à jour le modèle, sinon dry-run.
+"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; COLL=13752; TMO=600
+MODEL_NAME="SEO Corpus Monitoring — Manucurist (model)"
+
+EXCLUDE=["Corpus informationnel FR","Corpus informationnel US",
+         "Roadmap blog FR","Roadmap blog US","Manucurist - Brand keywords",
+         "Corpus transactionnel FR","Corpus transactionnel US","Corpus transactionnel UK"]
+def esc(s): return s.replace("'","''")
+EXCL_IN=",".join("'"+esc(c)+"'" for c in EXCLUDE)
+def UA(c): return f"TRANSLATE(LOWER({c}),'àâäéèêëîïôöùûüçœ','aaaeeeeiioouuuce')"
+
+SQL=f"""
+WITH corpus_kw AS (
+  SELECT DISTINCT sr.corpus_name, LOWER(sr.keyword) AS keyword, {UA('sr.keyword')} AS keyword_ua,
+         NULLIF(TRIM(sr.category),'') AS category, sr.zone, sr.language,
+         CASE sr.zone WHEN 'France' THEN 'FR' WHEN 'United States' THEN 'US'
+              WHEN 'United Kingdom' THEN 'UK' ELSE 'AUTRES' END AS marche
+  FROM google_serp.serp_requests sr JOIN utils.clients c ON sr.client_id=c.id
+  WHERE c.name='Manucurist' AND sr.corpus_name NOT IN ({EXCL_IN})
+),
+months AS (
+  SELECT DISTINCT DATE_TRUNC('month',date) AS month_date FROM utils.calendar
+  WHERE date >= DATEADD('month',-13,CURRENT_DATE) AND date <= CURRENT_DATE
+),
+gcd AS (
+  SELECT sr.zone, LOWER(skm.keyword) AS keyword, skm.url, skm.request_date, sr.domain AS client_domain,
+         CASE WHEN skm.type='featured_snippet' AND skm.rank_group=1 THEN 0 ELSE skm.rank_absolute END AS rank_absolute
+  FROM utils.clients c
+    JOIN google_serp.serp_requests sr ON sr.client_id=c.id
+    JOIN google_serp.serp_history sh ON (sh.keyword=sr.keyword AND sh.language=sr.language AND sh.zone=sr.zone)
+    JOIN google_serp.serp__keyword_metrics skm ON (skm.keyword=sh.keyword AND skm.language=sh.language AND skm.zone=sh.zone)
+  WHERE c.name='Manucurist' AND sr.corpus_name NOT IN ({EXCL_IN})
+    AND skm.request_date >= DATEADD('month',-13,CURRENT_DATE)
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY sr.client_id, sr.corpus_name, sh.keyword, sh.language, sh.zone, skm.url, skm.request_date ORDER BY rank_absolute)=1
+),
+client_pos AS (
+  SELECT zone, keyword, request_date, rank_absolute
+  FROM gcd WHERE url ILIKE '%'||client_domain||'%'
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY zone, keyword, request_date ORDER BY rank_absolute)=1
+),
+pos AS (
+  SELECT zone, keyword, DATE_TRUNC('month',request_date) AS month_date, AVG(rank_absolute) AS position
+  FROM client_pos GROUP BY 1,2,3
+),
+vol AS (
+  SELECT zone, keyword_ua, search_volume FROM (
+    SELECT zone, {UA('keyword')} AS keyword_ua,
+           COALESCE(adjusted_avg_searches, avg_monthly_searches) AS search_volume,
+           ROW_NUMBER() OVER (PARTITION BY zone, {UA('keyword')} ORDER BY month DESC) rn
+    FROM google_keyword_planner.kp__keyword_monthly_metrics
+    WHERE zone IN (SELECT DISTINCT zone FROM corpus_kw)
+      AND {UA('keyword')} IN (SELECT keyword_ua FROM corpus_kw)
+  ) WHERE rn=1
+),
+gsc AS (
+  SELECT {UA('keyword')} AS keyword_ua, DATE_TRUNC('month',date) AS month_date,
+         SUM(clicks) AS clicks, SUM(impressions) AS impressions,
+         SUM(position*impressions)/NULLIF(SUM(impressions),0) AS gsc_position
+  FROM google_search_console.gsc__page_keyword_daily_metrics
+  WHERE client_name='Manucurist' AND date >= DATEADD('month',-13,CURRENT_DATE)
+    AND {UA('keyword')} IN (SELECT keyword_ua FROM corpus_kw)
+  GROUP BY 1,2
+),
+assembled AS (
+  SELECT m.month_date, ck.corpus_name, ck.marche, ck.category, ck.keyword,
+         LEAST(COALESCE(pos.position, g.gsc_position, 100),100) AS position,
+         pos.position AS position_serp, g.gsc_position AS position_gsc,
+         v.search_volume, g.clicks, g.impressions
+  FROM corpus_kw ck CROSS JOIN months m
+    LEFT JOIN pos ON pos.zone=ck.zone AND pos.keyword=ck.keyword AND pos.month_date=m.month_date
+    LEFT JOIN gsc g ON g.keyword_ua=ck.keyword_ua AND g.month_date=m.month_date
+    LEFT JOIN vol v ON v.zone=ck.zone AND v.keyword_ua=ck.keyword_ua
+),
+kw_rank AS (
+  SELECT corpus_name, marche, keyword,
+         ROW_NUMBER() OVER (PARTITION BY corpus_name, marche ORDER BY SUM(COALESCE(clicks,0)) DESC, keyword) AS rang_clics
+  FROM assembled GROUP BY 1,2,3
+)
+SELECT a.month_date, a.corpus_name, a.marche, a.category, a.keyword,
+       a.position, a.position_serp, a.position_gsc, a.search_volume, a.clicks, a.impressions,
+       LAG(a.position) OVER (PARTITION BY a.corpus_name, a.marche, a.keyword ORDER BY a.month_date) - a.position AS delta_m1,
+       a.clicks - LAG(a.clicks) OVER (PARTITION BY a.corpus_name, a.marche, a.keyword ORDER BY a.month_date) AS delta_clicks_m1,
+       r.rang_clics
+FROM assembled a JOIN kw_rank r
+  ON r.corpus_name=a.corpus_name AND r.marche=a.marche AND r.keyword=a.keyword
+ORDER BY a.corpus_name, a.marche, r.rang_clics, a.keyword, a.month_date DESC
+"""
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex: print("retry",repr(ex)[:80],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def upsert_model(mb,payload):
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")=="dataset" and it.get("name")==MODEL_NAME:
+            mb.put(f"/api/card/{it['id']}","raw",json=payload,timeout=TMO); return it["id"],"maj"
+    b=mb.post("/api/card","raw",json=payload,timeout=TMO).json(); return b.get("id"),"créé"
+
+def main():
+    apply="--apply" in sys.argv
+    mb=connect(); print("connected | mode:","APPLY" if apply else "dry-run",flush=True)
+    t0=time.monotonic()
+    # validation par agrégat côté Snowflake (l'API /api/dataset tronque à 2000 lignes)
+    VSQL=f"""SELECT corpus_name, marche, COUNT(*) AS n_rows, COUNT(DISTINCT keyword) AS n_kw,
+             SUM(COALESCE(clicks,0)) AS clicks_13m, COUNT(DISTINCT category) AS n_cat,
+             SUM(CASE WHEN rang_clics<=25 THEN COALESCE(clicks,0) ELSE 0 END) AS clicks_top25
+             FROM ({SQL}) GROUP BY 1,2 ORDER BY 1,2"""
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":VSQL}},timeout=TMO).json()
+    if r.get("error"): print("ÉCHEC SQL:",str(r["error"])[:800],flush=True); sys.exit(1)
+    cols=[c["name"] for c in r["data"]["cols"]]; rows=r["data"]["rows"]; ci={n:i for i,n in enumerate(cols)}
+    print(f"run: {time.monotonic()-t0:.0f}s | {len(rows)} groupes corpus×marché",flush=True)
+    print("\ncorpus × marché | lignes | kw | clics 13m (top25) | catégories:",flush=True)
+    tot_rows=0
+    for row in rows:
+        tot_rows+=row[ci["N_ROWS"]]
+        print(f"  {str(row[ci['CORPUS_NAME']])[:46]:46} | {row[ci['MARCHE']]:6} | {row[ci['N_ROWS']]:5} | "
+              f"{row[ci['N_KW']]:4} kw | {int(row[ci['CLICKS_13M']]):7} ({int(row[ci['CLICKS_TOP25']]):6}) | {row[ci['N_CAT']]} cat",flush=True)
+    names=" || ".join(str(row[ci["CORPUS_NAME"]]).lower() for row in rows)
+    print(f"\ntotal lignes modèle: {tot_rows} | groupes: {len(rows)}",flush=True)
+    if tot_rows<5000 or len(rows)<5 or "couleurs" not in names or "saisons" not in names or "stratégiques" not in names:
+        print("⚠️ gate ÉCHOUÉE (volumétrie ou corpus manquant), PAS de PUT.",flush=True); sys.exit(1)
+    if not apply:
+        print("\nDONE dry-run (relancer avec --apply pour créer le modèle)",flush=True); return
+    DESC=("Suivi corpus-driven Nanga. Tous les corpus pertinents (stratégique, couleurs, saisons et les prochains créés dans Nanga) "
+          "par marché et par mois. Position SERP avec repli GSC (100 = non classé), volume Keyword Planner, clics et impressions GSC "
+          "avec rapprochement insensible aux accents. RANG_CLICS classe les mots-clés par clics dans chaque corpus et marché (sert au filtre Top N). "
+          "Corpus exclus : informationnel, blog, brand, transactionnels bruts.")
+    MID,how=upsert_model(mb,{"name":MODEL_NAME,"type":"model","collection_id":COLL,
+        "dataset_query":{"database":DB,"type":"native","native":{"query":SQL}},
+        "display":"table","visualization_settings":{},"description":DESC})
+    print(f"\nmodèle {how} #{MID}",flush=True)
+    rm=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":f"SELECT * FROM ({SQL}) LIMIT 40"}},timeout=TMO).json()
+    if not rm.get("error"):
+        mb.put(f"/api/card/{MID}","raw",json={"result_metadata":rm["data"]["cols"]},timeout=120)
+        print("result_metadata posé",flush=True)
+    print(f"\n>>> MODÈLE CORPUS #{MID}",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/build_seo_global_dashboard.py
+++ b/scripts/build_seo_global_dashboard.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Phase 1 — NOUVEAU dashboard global de suivi mots-clés stratégiques | Manucurist.
-- bloc synthèse = snapshot #48635 (kw + volume + position + Δ + clics, dernier mois complet)
-- tableau détaillé inversé = #49557 (mois × kw × Rank/Impr/Clics)
-- filtres : Marché (FR/US, défaut FR), Gamme, Catégorie, Mot-clé (contient/exact), Période (6 mois)
-- le toggle Marché filtre synthèse + détail.
-Crée/maj le dashboard dans la collection Manucurist #13752 (idempotent par nom)."""
+"""Phase 1 — dashboard global de suivi mots-clés stratégiques | Manucurist (#26061).
+- bloc synthèse DÉDIÉ (carte triée par CLICS décroissants, couleurs monochromes vert/bleu)
+  -> ne touche pas le snapshot #48635 partagé avec le dashboard #25137.
+- tableau détaillé inversé = #49557 (mois × kw × Volume/Rank/Impr/Clics), colonnes alphabétiques.
+- filtres : Marché (FR/US, défaut FR), Gamme, Catégorie, Mot-clé (contient/exact), Période (6 mois).
+Idempotent par nom (carte synthèse + dashboard)."""
 from __future__ import annotations
-import sys, time
+import json, sys, time
 from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
@@ -14,8 +14,11 @@ from spark_metabase_api import Metabase_API
 from reorg_phase1 import _load_env
 
 DB=144; COLL=13752; HTTP_TIMEOUT=300
-SNAP=48635; INV=49557
+MODEL=48633; INV=49557
+SYNTH_NAME="SEO — Synthèse mots-clés (dernier mois, tri par clics) | Manucurist"
 DASH_NAME="Suivi mots-clés stratégiques (global) | Manucurist"
+GREEN=["#176D3A","#E8F4EA"]   # 1 = vert foncé -> 100 = clair
+BLUE =["#EAF1F8","#4A6FA5"]   # faible = clair -> élevé = bleu pastel foncé
 
 def connect():
     e=_load_env()
@@ -31,6 +34,40 @@ def fr(name,bt,extra=None):
     o={"base-type":bt}
     if extra:o.update(extra)
     return ["field",name,o]
+def bands(col,kind):
+    """Plages discrètes (single-color). Ordre serré->large (1ère règle qui matche gagne)."""
+    if kind=="rank":
+        steps=[(3,"#0B5226"),(10,"#2E7D32"),(20,"#66BB6A"),(50,"#A5D6A7"),(100,"#E8F5E9")]; op="<="
+    else:
+        steps=[(100,"#2E6CA8"),(50,"#5B8DC0"),(25,"#9CC0E0"),(10,"#DCE9F5")]; op=">="
+    return [{"columns":[col],"type":"single","operator":op,"value":v,"color":c} for v,c in steps]
+def cs(name,opts): return {json.dumps(["name",name]):opts}
+def dec0(t): return {"column_title":t,"number_style":"decimal","decimals":0}
+
+def upsert_card(mb,name,payload):
+    for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
+        if it.get("model")=="card" and it.get("name")==name:
+            mb.put(f"/api/card/{it['id']}","raw",json=payload,timeout=HTTP_TIMEOUT); return it["id"],"maj"
+    b=mb.post("/api/card","raw",json=payload,timeout=HTTP_TIMEOUT).json(); return b.get("id"),"créé"
+
+def build_synth(mb):
+    q={"database":DB,"type":"query","query":{"source-table":f"card__{MODEL}",
+        "fields":[fr("MARCHE","type/Text"),fr("GAMME","type/Text"),fr("CATEGORIE","type/Text"),fr("KEYWORD","type/Text"),
+                  fr("SEARCH_VOLUME","type/Float"),fr("POSITION","type/Float"),fr("DELTA_M1","type/Float"),fr("CLICKS","type/Float")],
+        "filter":["time-interval",fr("MONTH_DATE","type/Date"),-1,"month"],
+        "order-by":[["desc",fr("CLICKS","type/Float")]]}}
+    viz={"column_settings":{
+            **cs("MARCHE",{"column_title":"Marché"}),**cs("GAMME",{"column_title":"Gamme"}),**cs("CATEGORIE",{"column_title":"Catégorie"}),
+            **cs("KEYWORD",{"column_title":"Mot-clé"}),**cs("SEARCH_VOLUME",dec0("Volume rech.")),
+            **cs("POSITION",dec0("Position")),**cs("DELTA_M1",dec0("Δ M-1")),**cs("CLICKS",dec0("Clics GSC"))},
+        "table.column_formatting": bands("POSITION","rank") + bands("CLICKS","clics")}
+    cid,how=upsert_card(mb,SYNTH_NAME,{"name":SYNTH_NAME,"collection_id":COLL,"dataset_query":q,"display":"table",
+        "visualization_settings":viz,
+        "description":"Synthèse mots-clés stratégiques (dernier mois complet), triée par CLICS décroissants. Position vert monochrome (1=foncé), Clics bleu monochrome. Pour repérer les kw à fort trafic. Filtrable Marché/Gamme/Catégorie/Mot-clé."})
+    print(f"synthèse {how} #{cid}",flush=True)
+    jr=mb.post("/api/dataset","raw",json=q,timeout=HTTP_TIMEOUT).json()
+    if not jr.get("error"): mb.put(f"/api/card/{cid}","raw",json={"result_metadata":jr["data"]["cols"]},timeout=120)
+    return cid
 
 def find_dash(mb):
     for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
@@ -40,10 +77,11 @@ def find_dash(mb):
 
 def main():
     mb=connect(); print("connected",flush=True)
+    SYNTH=build_synth(mb)
     did=find_dash(mb)
     if not did:
         b=mb.post("/api/dashboard","raw",json={"name":DASH_NAME,"collection_id":COLL,
-            "description":"Suivi mensuel des mots-clés stratégiques. Synthèse (kw+volume+position) + tableau inversé (mois × kw × Rank/Impr/Clics) pour lire l'évolution et corréler ranking/impressions/clics. Toggle Marché FR/US."}).json()
+            "description":"Suivi mensuel des mots-clés stratégiques. Synthèse triée par clics + tableau inversé (mois × kw × Volume/Rank/Impr/Clics). Couleurs monochromes (vert=Rank, bleu=Clics). Toggle Marché FR/US."}).json()
         did=b.get("id"); print("dashboard créé #",did,flush=True)
     else:
         print("dashboard existant #",did,flush=True)
@@ -59,19 +97,19 @@ def main():
     ]
     KW=fr("KEYWORD","type/Text"); MAR=fr("MARCHE","type/Text"); GAM=fr("GAMME","type/Text"); CAT=fr("CATEGORIE","type/Text"); MO=fr("MONTH_DATE","type/Date")
     def m(pid,cid,field): return {"parameter_id":pid,"card_id":cid,"target":["dimension",field]}
-    snap_maps=[m("marche01",SNAP,MAR),m("gamme01",SNAP,GAM),m("categ01",SNAP,CAT),m("pat01",SNAP,KW),m("exact01",SNAP,KW)]
+    synth_maps=[m("marche01",SYNTH,MAR),m("gamme01",SYNTH,GAM),m("categ01",SYNTH,CAT),m("pat01",SYNTH,KW),m("exact01",SYNTH,KW)]
     inv_maps=[m("marche01",INV,MAR),m("gamme01",INV,GAM),m("categ01",INV,CAT),m("pat01",INV,KW),m("exact01",INV,KW),m("date01",INV,MO)]
     def txt(t): return {"text":t,"virtual_card":{"name":None,"display":"text","visualization_settings":{},"dataset_query":{},"archived":False},
         "text.align_vertical":"middle","text.align_horizontal":"left","dashcard.background":False}
     dashcards=[
       {"id":-1,"card_id":None,"row":0,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],
-       "visualization_settings":txt("## 📈 Synthèse — sur quel mot-clé monter ?\nMot-clé · volume de recherche · position (dernier mois complet). Filtrable par marché.")},
-      {"id":-2,"card_id":SNAP,"row":1,"col":0,"size_x":24,"size_y":9,"series":[],"parameter_mappings":snap_maps,
-       "visualization_settings":{"card.title":"Synthèse — mot-clé · volume · position · clics (dernier mois complet)"}},
+       "visualization_settings":txt("## 📈 Vue d'ensemble des mots-clés\nLe mot-clé, son volume de recherche, sa position et ses clics sur le dernier mois complet, classés du plus au moins cliqué. Filtrable par marché.")},
+      {"id":-2,"card_id":SYNTH,"row":1,"col":0,"size_x":24,"size_y":9,"series":[],"parameter_mappings":synth_maps,
+       "visualization_settings":{"card.title":"Synthèse des mots-clés classés par clics (dernier mois complet)"}},
       {"id":-3,"card_id":None,"row":10,"col":0,"size_x":24,"size_y":1,"series":[],"parameter_mappings":[],
-       "visualization_settings":txt("## 📊 Détail inversé — évolution par mot-clé\nMois en lignes, mot-clé en colonnes ; sous chaque kw **Rank · Impressions · Clics**. Rank en heatmap (vert = bon) — lu de haut en bas = trajectoire. Scroll horizontal pour parcourir les mots-clés.")},
+       "visualization_settings":txt("## 📊 Évolution par mot-clé\nLes mois en lignes, les mots-clés en colonnes, et pour chacun son volume, son rank, ses impressions et ses clics. Le rank est en vert (foncé = bonne position), les clics en bleu (foncé = beaucoup de clics). Scrolle vers la droite pour voir tous les mots-clés.")},
       {"id":-4,"card_id":INV,"row":11,"col":0,"size_x":24,"size_y":12,"series":[],"parameter_mappings":inv_maps,
-       "visualization_settings":{"card.title":"Évolution Rank · Impressions · Clics par mot-clé (mois en lignes)"}},
+       "visualization_settings":{"card.title":"Évolution de chaque mot-clé mois après mois"}},
     ]
     body={"parameters":P,"dashcards":dashcards}
     r=mb.put(f"/api/dashboard/{did}","raw",json=body,timeout=HTTP_TIMEOUT)

--- a/scripts/build_seo_inverted.py
+++ b/scripts/build_seo_inverted.py
@@ -34,6 +34,14 @@ def fr(name,bt,extra=None):
     if extra:o.update(extra)
     return ["field",name,o]
 
+def bands(col,kind):
+    """Plages discrètes (single-color). Ordre serré->large (1ère règle qui matche gagne)."""
+    if kind=="rank":  # vert, foncé = bonne position (basse)
+        steps=[(3,"#0B5226"),(10,"#2E7D32"),(20,"#66BB6A"),(50,"#A5D6A7"),(100,"#E8F5E9")]; op="<="
+    else:             # clics, bleu, foncé = beaucoup
+        steps=[(100,"#2E6CA8"),(50,"#5B8DC0"),(25,"#9CC0E0"),(10,"#DCE9F5")]; op=">="
+    return [{"columns":[col],"type":"single","operator":op,"value":v,"color":c} for v,c in steps]
+
 def upsert(mb,name,payload):
     for it in mb.get(f"/api/collection/{COLL}/items?limit=2000").get("data",[]):
         if it.get("model")=="card" and it.get("name")==name:
@@ -62,9 +70,7 @@ def main():
             json.dumps(["name","avg"]):{"column_title":"Rank","number_style":"decimal","decimals":0},
             json.dumps(["name","sum_2"]):{"column_title":"Impressions","number_style":"decimal","decimals":0},
             json.dumps(["name","sum_3"]):{"column_title":"Clics","number_style":"decimal","decimals":0}},
-        "table.column_formatting":[
-            {"columns":["avg"],"type":"range","colors":["#84BB4C","#ED6E6E"],
-             "min_type":"custom","min_value":1,"max_type":"custom","max_value":100}]}
+        "table.column_formatting": bands("avg","rank") + bands("sum_3","clics")}
     CID,how=upsert(mb,CARD_NAME,{"name":CARD_NAME,"collection_id":COLL,
         "dataset_query":dq,"display":"pivot","visualization_settings":viz,
         "description":"Suivi inversé : mois en lignes, mots-clés en colonnes ; sous chaque kw Volume (kp, ~constant car dernier connu) / Rank (avg POSITION, heatmap 1→100) / Impressions / Clics (GSC, échantillonné). Filtrable Marché/Gamme/Catégorie/Mot-clé/Période. Source modèle #48633."})

--- a/scripts/conv_visibility.py
+++ b/scripts/conv_visibility.py
@@ -1,0 +1,91 @@
+"""Effective visibility of a result column on a dashboard tile.
+
+A Metabase dashcard can override its card's visualization_settings. To know whether a
+conversion column is actually shown to a user, the dashcard-level override must win over
+the card-level setting.
+
+effective_column_status(display, card_vs, dashcard_vs, col) -> 'visible' | 'hidden' | 'ambiguous'
+
+Policy: only return 'hidden' when the column is PROVABLY hidden. When we cannot prove it
+(no metric list, unlisted table column, unknown display type), return 'ambiguous' — never
+guess 'visible'. Callers decide what to do with ambiguous vs proven-hidden.
+"""
+
+import re
+
+_CARTESIAN = {"line", "bar", "area", "combo", "row", "scatter", "waterfall"}
+_SCALAR = {"scalar", "smartscalar", "gauge", "progress"}
+
+# A positional-conversion metric column: conversions / value / rate (CR) / CAC, for a given
+# slot number, optionally prefixed for KPIs-evolution cards (current/previous/evolution).
+_CONV_METRIC_RX = re.compile(
+    r"^(CURRENT_|PREVIOUS_|EVOLUTION_)?(CONVERSIONS?|CONVERSION_RATE|CONV_RATE|CR|CAC)(_\d+)?(_VALUE)?$"
+)
+
+
+def is_conversion_metric(name):
+    """True if `name` is a positional-conversion metric (count, value, rate or CAC)."""
+    return bool(_CONV_METRIC_RX.match((name or "").upper()))
+
+
+def slot_of(name):
+    """Slot index a conversion column belongs to (0 = the base CONVERSIONS), else None."""
+    up = (name or "").upper()
+    if up in ("CONVERSIONS", "CONVERSION_VALUE", "CONVERSION_RATE", "CONV_RATE", "CR", "CAC"):
+        return 0
+    m = re.search(r"(\d+)", up)
+    return int(m.group(1)) if m else None
+
+
+def tile_slot_status(display, card_vs, dashcard_vs, result_cols, slot):
+    """Effective visibility of a conversion *slot* on one tile, considering every conversion
+    column tied to that slot (base + derived cr/cac/value, incl. current/previous variants).
+
+    Returns 'visible' | 'ambiguous' | 'hidden' | 'absent' (slot has no conversion column here).
+    A slot is 'visible' as soon as ANY of its columns is shown, so a hidden `conversions_n`
+    that still feeds a visible `cr_n`/`cac_n` correctly counts as visible.
+    """
+    candidates = [c for c in result_cols if is_conversion_metric(c) and slot_of(c) == slot]
+    if not candidates:
+        return "absent"
+    statuses = [effective_column_status(display, card_vs, dashcard_vs, c) for c in candidates]
+    if "visible" in statuses:
+        return "visible"
+    if "ambiguous" in statuses:
+        return "ambiguous"
+    return "hidden"
+
+
+def _pick(card_vs, dashcard_vs, key):
+    """Dashcard override wins over the card for a given viz key."""
+    dashcard_vs = dashcard_vs or {}
+    if key in dashcard_vs and dashcard_vs[key] is not None:
+        return dashcard_vs[key]
+    return (card_vs or {}).get(key)
+
+
+def effective_column_status(display, card_vs, dashcard_vs, col):
+    up = col.upper()
+
+    if display == "table":
+        cols = _pick(card_vs, dashcard_vs, "table.columns")
+        if not cols:
+            return "visible"  # no explicit list -> all query columns are shown
+        by_name = {(c.get("name") or "").upper(): c.get("enabled", True) for c in cols}
+        if up in by_name:
+            return "visible" if by_name[up] else "hidden"
+        return "ambiguous"  # listed table but this column absent -> version-dependent, can't prove
+
+    if display in _CARTESIAN:
+        metrics = _pick(card_vs, dashcard_vs, "graph.metrics")
+        if not metrics:
+            return "ambiguous"
+        return "visible" if up in {m.upper() for m in metrics if m} else "hidden"
+
+    if display in _SCALAR:
+        field = _pick(card_vs, dashcard_vs, "scalar.field")
+        if not field:
+            return "ambiguous"
+        return "visible" if field.upper() == up else "hidden"
+
+    return "ambiguous"

--- a/scripts/optimize_player_cards.py
+++ b/scripts/optimize_player_cards.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Optimise les 2 cartes "joueurs" (29452, 46988) : remplace la boucle per-place
+(SUM sur ~100 appels API) par UN SEUL appel passant LISTAGG(DISTINCT place).
+
+Le préfixe d'origine (CTE dates/filtres/map_place_parameter) est conservé verbatim ;
+seule la partie qui bouclait est réécrite. Garde-fou `pl.n > 0` : si le filtre ville
+ne matche aucun slug -> 0 ligne (jamais "tous les centres" par erreur).
+
+  python3 scripts/optimize_player_cards.py            # dry-run (diff)
+  python3 scripts/optimize_player_cards.py --yes      # applique + backup
+"""
+import sys, json, copy, argparse, difflib
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+MIG = REPO / "migration"
+
+TAIL_29452 = """places_list AS (
+
+    SELECT
+        LISTAGG(DISTINCT place, ',') AS places,
+        COUNT(*) AS n
+
+    FROM map_place_parameter
+
+),
+
+final AS (
+
+    (
+    SELECT
+        current_max_date AS display_date,
+        client_data.fetch_quiz_room_player_nb(
+            current_min_date,
+            current_max_date,
+            pl.places
+        ):player_count::INT AS player_count
+
+    FROM places_list pl, get_current_dates
+
+    WHERE pl.n > 0
+    )
+
+    UNION ALL
+
+    (
+    SELECT
+        previous_max_date AS display_date,
+        client_data.fetch_quiz_room_player_nb(
+            previous_min_date,
+            previous_max_date,
+            pl.places
+        ):player_count::INT AS player_count
+
+    FROM places_list pl, get_previous_dates
+
+    WHERE pl.n > 0
+    )
+
+)
+
+SELECT * FROM final
+ORDER BY display_date ASC"""
+
+TAIL_46988 = """places_list AS (
+    SELECT
+        LISTAGG(DISTINCT place, ',') AS places,
+        COUNT(*) AS n
+    FROM map_place_parameter
+),
+current_year AS (
+    SELECT
+        m.month_label,
+        m.month_start AS display_date,
+        m.offset,
+        'N' AS year_group,
+        client_data.fetch_quiz_room_player_nb(
+            m.month_start,
+            m.month_end,
+            pl.places
+        ):player_count::INT AS player_count
+    FROM months m, places_list pl
+    WHERE pl.n > 0
+),
+previous_year AS (
+    SELECT
+        m.month_label,
+        DATEADD(year, -1, m.month_start) AS display_date,
+        m.offset,
+        'N-1' AS year_group,
+        client_data.fetch_quiz_room_player_nb(
+            DATEADD(year, -1, m.month_start),
+            DATEADD(year, -1, m.month_end),
+            pl.places
+        ):player_count::INT AS player_count
+    FROM months m, places_list pl
+    WHERE pl.n > 0
+),
+final AS (
+    SELECT * FROM current_year
+    UNION ALL
+    SELECT * FROM previous_year
+)
+SELECT
+    month_label,
+    year_group,
+    player_count
+FROM final
+ORDER BY offset DESC, year_group DESC"""
+
+CARDS = {
+    29452: {"split": "\n\nfinal AS (", "join": "\n\n", "tail": TAIL_29452},
+    46988: {"split": "\ncurrent_year AS (", "join": "\n", "tail": TAIL_46988},
+}
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def native_stage(dq):
+    for st in dq.get("stages") or []:
+        if st.get("native"):
+            return st
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    for cid, cfg in CARDS.items():
+        c = mb.get(f"/api/card/{cid}")
+        dq = copy.deepcopy(c["dataset_query"])
+        st = native_stage(dq)
+        old = st["native"]
+        assert cfg["split"] in old, f"split marker not found in {cid}"
+        prefix = old.split(cfg["split"])[0]
+        new = prefix + cfg["join"] + cfg["tail"]
+        # sanity: no more SUM( player calls, places_list present, n>0 guard present
+        assert "SUM(" not in new, f"{cid}: SUM still present"
+        assert "places_list" in new and "pl.n > 0" in new, f"{cid}: guard missing"
+        print(f"========== card {cid} DIFF ==========")
+        for line in difflib.unified_diff(old.splitlines(), new.splitlines(),
+                                         lineterm="", n=2):
+            print(line)
+        print()
+        if args.yes:
+            (MIG / f"player-card-{cid}-snapshot-{ts}.json").write_text(
+                json.dumps(c["dataset_query"], ensure_ascii=False, indent=2))
+            st["native"] = new
+            import requests
+            r = requests.put(mb.domain + f"/api/card/{cid}", headers=mb.header,
+                             auth=mb.auth, json={"dataset_query": dq}, timeout=120)
+            print(f"PUT card {cid}: {r.status_code}")
+            r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch_handoff_priority.py
+++ b/scripts/patch_handoff_priority.py
@@ -1,0 +1,57 @@
+"""Corrige la priorité 'dashboards concernés' des handoffs conversions pour ne compter que
+les dashboards où le slot est RÉELLEMENT montré (visible ou plausiblement visible), en
+excluant les tuiles qui le masquent (override-aware). Source : conv-visibility-by-slot.json.
+
+- Patche migration/CONVERSIONS-A-TRANCHER.csv (colonne dashboards_concernes).
+- Régénère migration/HANDOFF-consultants.csv via build_consultant_handoff.py (priorité re-dérivée).
+Backups .PRE-VIS.csv écrits avant modification.
+"""
+import csv, json, re, subprocess, sys, shutil
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+MIG = REPO / "migration"
+
+vis = {(r["client"], r["slot"]): r for r in json.loads((MIG / "conv-visibility-by-slot.json").read_text())}
+
+
+def slot_num(slot_label):
+    m = re.search(r"\((conversions?)_?(\d*)\)", slot_label)
+    return int(m.group(2)) if (m and m.group(2)) else (0 if m else None)
+
+
+def dashes(names):
+    names = sorted(names)
+    if not names:
+        return "0 dash"
+    head = ", ".join(n[:30] for n in names[:3])
+    return f"{len(names)} dash : {head}" + ("…" if len(names) > 3 else "")
+
+
+src = MIG / "CONVERSIONS-A-TRANCHER.csv"
+shutil.copy(src, MIG / "CONVERSIONS-A-TRANCHER.PRE-VIS.csv")
+rows = list(csv.DictReader(open(src, encoding="utf-8-sig")))
+patched = dropped = 0
+for r in rows:
+    s = slot_num(r["slot"])
+    if s is None:
+        continue  # PAIRING_AMBIGU etc. — pas de slot
+    v = vis.get((r["client"], s))
+    if not v:
+        continue
+    new = dashes(v.get("shown_dash_names", []))
+    if new != r["dashboards_concernes"]:
+        patched += 1
+    r["dashboards_concernes"] = new
+    if v.get("shown_dashboards", 0) == 0:
+        dropped += 1
+
+with open(src, "w", newline="", encoding="utf-8-sig") as fh:
+    w = csv.DictWriter(fh, fieldnames=["client", "type_probleme", "slot", "valeur_actuelle",
+                                       "contexte", "dashboards_concernes", "a_trancher"])
+    w.writeheader(); w.writerows(rows)
+print(f"à-trancher : {patched} lignes re-priorisées ; {dropped} slots à shown=0 (masqués partout)")
+
+# regénère le handoff consultant filtré
+shutil.copy(MIG / "HANDOFF-consultants.csv", MIG / "HANDOFF-consultants.PRE-VIS.csv")
+subprocess.run([sys.executable, str(REPO / "scripts" / "build_consultant_handoff.py"),
+                str(src), "--blockers", str(MIG / "residual-blockers-REAL.json")], check=True)

--- a/scripts/probe_accents.py
+++ b/scripts/probe_accents.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Sujet ACCENTS : comment GSC stocke les requêtes accentuées vs corpus SERP désaccentué,
+et est-ce qu'un matching accent-insensible (TRANSLATE unaccent) récupère bien les clics ?"""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; TMO=420
+UNACC="TRANSLATE(LOWER({c}),'àâäéèêëîïôöùûüçœ','aaaeeeeiioouuuce')"  # œ->e approx
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex: print("retry",repr(ex)[:80],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql,label):
+    print(f"\n=== {label} ===",flush=True)
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=TMO).json()
+    if r.get("error"): print("ERR:",str(r["error"])[:400],flush=True); return
+    cols=[c["name"] for c in r["data"]["cols"]]
+    print(" | ".join(cols),flush=True)
+    for row in r["data"]["rows"]: print("  "+" | ".join(str(x) for x in row),flush=True)
+
+def main():
+    mb=connect(); print("connected",flush=True)
+    ua_g=UNACC.format(c="g.keyword")
+
+    run(mb,"""
+SELECT keyword, SUM(clicks) clicks, SUM(impressions) impr
+FROM google_search_console.gsc__page_keyword_daily_metrics
+WHERE client_name ILIKE '%manucurist%' AND date >= DATEADD('month',-6,CURRENT_DATE)
+  AND REGEXP_LIKE(keyword, '.*[éèêàâîïôùûçäöü].*')
+GROUP BY keyword ORDER BY clicks DESC LIMIT 25
+""","1) GSC stocke-t-il les accents ? (top requêtes accentuées Manucurist)")
+
+    run(mb,f"""
+WITH targets AS (
+  SELECT * FROM (VALUES
+    ('vernis dore'),('vernis argente'),('couleur ongle ete'),('couleur manucure ete'),
+    ('manucure francaise'),('ongles printemps'),('vernis rose poudre')
+  ) t(kw_corpus_desaccentue)
+)
+SELECT t.kw_corpus_desaccentue, g.keyword AS gsc_reel,
+       SUM(g.clicks) clicks, SUM(g.impressions) impr
+FROM targets t
+JOIN google_search_console.gsc__page_keyword_daily_metrics g
+  ON {ua_g} = t.kw_corpus_desaccentue
+ AND g.client_name ILIKE '%manucurist%' AND g.date >= DATEADD('month',-6,CURRENT_DATE)
+GROUP BY 1,2 ORDER BY 1, clicks DESC
+""","2) FIX : corpus désaccentué -> clics GSC récupérés via unaccent (montre la forme réelle GSC)")
+
+    run(mb,"""
+SELECT sr.keyword
+FROM google_serp.serp_requests sr JOIN utils.clients c ON sr.client_id=c.id
+WHERE c.name ILIKE '%manucurist%' AND REGEXP_LIKE(sr.keyword,'.*[éèêàâîïôùûç].*')
+GROUP BY 1 LIMIT 15
+""","3) google_serp stocke-t-il les accents ? (kw corpus existants accentués)")
+
+    run(mb,"""
+SELECT DISTINCT sr.corpus_name
+FROM google_serp.serp_requests sr JOIN utils.clients c ON sr.client_id=c.id
+WHERE c.name ILIKE '%manucurist%'
+  AND (LOWER(sr.corpus_name) LIKE '%couleur%' OR LOWER(sr.corpus_name) LIKE '%season%'
+       OR LOWER(sr.corpus_name) LIKE '%saison%' OR LOWER(sr.corpus_name) LIKE '%color%')
+""","4) corpus Couleurs/Saisons déjà présents dans google_serp ?")
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/probe_corpus.py
+++ b/scripts/probe_corpus.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Sonde la structure des CORPUS Manucurist dans google_serp.serp_requests :
+- liste corpus_name × language × zone × n_keywords
+- détecte si un corpus_name s'étale sur PLUSIEURS marchés (zone/language) -> réponse à 'filtre corpus vs marché'.
+Lecture seule."""
+from __future__ import annotations
+import sys, time
+from pathlib import Path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT/"scripts")); sys.path.insert(0, str(ROOT))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+DB=144; TMO=400
+
+def connect():
+    e=_load_env()
+    for a in range(6):
+        try:
+            mb=Metabase_API(domain=e["METABASE_DOMAIN"],email=e["METABASE_EMAIL"],password=e["METABASE_PASSWORD"])
+            mb.get("/api/user/current",timeout=60); return mb
+        except Exception as ex: print("retry",repr(ex)[:80],flush=True); time.sleep(8)
+    sys.exit("conn failed")
+
+def run(mb,sql,label):
+    print(f"\n=== {label} ===",flush=True)
+    r=mb.post("/api/dataset","raw",json={"database":DB,"type":"native","native":{"query":sql}},timeout=TMO).json()
+    if r.get("error"): print("ERR:",str(r["error"])[:400],flush=True); return None
+    cols=[c["name"] for c in r["data"]["cols"]]; rows=r["data"]["rows"]
+    print(" | ".join(cols),flush=True)
+    for row in rows: print("  "+" | ".join(str(x) for x in row),flush=True)
+    return rows
+
+def main():
+    mb=connect(); print("connected",flush=True)
+    # 0) résoudre le client
+    run(mb,"SELECT id, name FROM utils.clients WHERE name ILIKE '%manucurist%'","client Manucurist (utils.clients)")
+    # 1) corpus landscape
+    run(mb,"""
+SELECT sr.corpus_name, sr.language, sr.zone, COUNT(DISTINCT sr.keyword) AS n_kw
+FROM google_serp.serp_requests sr
+JOIN utils.clients c ON sr.client_id = c.id
+WHERE c.name ILIKE '%manucurist%'
+GROUP BY 1,2,3
+ORDER BY 1,3
+""","corpus_name × language × zone × n_kw")
+    # 2) un corpus s'étale-t-il sur plusieurs marchés ?
+    run(mb,"""
+SELECT sr.corpus_name,
+       COUNT(DISTINCT sr.zone) AS n_zones,
+       COUNT(DISTINCT sr.language) AS n_langs,
+       LISTAGG(DISTINCT sr.zone, ', ') AS zones
+FROM google_serp.serp_requests sr
+JOIN utils.clients c ON sr.client_id = c.id
+WHERE c.name ILIKE '%manucurist%'
+GROUP BY 1
+ORDER BY n_zones DESC, 1
+""","multi-marché par corpus (n_zones>1 = corpus multi-marché)")
+    print("\nDONE",flush=True)
+
+if __name__=="__main__":
+    main()

--- a/scripts/probe_handoff_visibility.py
+++ b/scripts/probe_handoff_visibility.py
@@ -1,0 +1,115 @@
+"""Phase-1 diagnostic v2: are consultant-handoff slots DISPLAYED (strict) or only in SQL?
+
+Per tile, classify how the slot's column appears:
+  explicit  = table column with enabled=True  |  chart metric in graph.metrics  |  scalar.field match
+  default   = table with table.columns present but column NOT listed (Metabase shows unlisted -> visible, but weaker signal)
+  hidden    = table column enabled=False  |  chart with metrics present but column absent
+  ambiguous = scalar w/o field, chart w/o metrics, pie/funnel/object/unknown (can't tell)
+
+Per (client, slot) decision:
+  STRICT displayed = at least one tile is 'explicit'      (airtight: someone sees it)
+  LOOSE  displayed = at least one tile is explicit/default/ambiguous (not provably hidden)
+  HIDDEN-ONLY      = every tile is 'hidden'                (safe to drop -> FALSE consultant question)
+
+Read-only. Card viz-settings cached to migration/_card_viz_cache.json.
+"""
+import sys, json, csv, os
+from collections import defaultdict
+sys.path.insert(0, "scripts")
+from archive_collections import connect_resilient
+import conv_lib
+
+mb = connect_resilient()
+CACHE = "migration/_card_viz_cache.json"
+cache = json.load(open(CACHE)) if os.path.exists(CACHE) else {}
+
+def viz(cid):
+    k = str(cid)
+    if k not in cache:
+        c = mb.get(f"/api/card/{cid}") or {}
+        cache[k] = {"display": c.get("display"), "vs": c.get("visualization_settings") or {}}
+    return cache[k]
+
+decisions = {}
+with open("migration/HANDOFF-consultants.csv", encoding="utf-8-sig") as f:
+    for r in csv.DictReader(f):
+        p = r["ref"].split("§")
+        if len(p) < 3 or "PAIRING" in p[2]:
+            continue
+        try:
+            decisions[(r["client"], int(p[1]))] = p[2].split()[0]
+        except ValueError:
+            pass
+
+tg = json.load(open("migration/conv-targets.json"))
+tiles_by_client = defaultdict(list)
+for d in tg:
+    for t in d.get("tiles", []):
+        tiles_by_client[d.get("client")].append(t)
+
+ORDER = {"explicit": 3, "default": 2, "ambiguous": 1, "hidden": 0}
+
+def classify(colname, cid):
+    v = viz(cid); disp = v["display"]; vs = v["vs"]; up = colname.upper()
+    if disp == "table":
+        cols = vs.get("table.columns")
+        if not cols:
+            return "default"  # no explicit list -> shown, but weak signal
+        d = {c.get("name", "").upper(): c.get("enabled", True) for c in cols}
+        if up in d:
+            return "explicit" if d[up] else "hidden"
+        return "default"
+    if disp in ("line", "bar", "area", "combo", "row", "scatter"):
+        m = [x.upper() for x in (vs.get("graph.metrics") or [])]
+        if not m:
+            return "ambiguous"
+        return "explicit" if up in m else "hidden"
+    if disp in ("scalar", "smartscalar", "gauge", "progress"):
+        f = vs.get("scalar.field")
+        if f:
+            return "explicit" if f.upper() == up else "hidden"
+        return "ambiguous"
+    return "ambiguous"
+
+out = []
+for (client, slot), kind in sorted(decisions.items()):
+    counts = defaultdict(int); explicit_cards = []
+    for t in tiles_by_client.get(client, []):
+        cols = [c for c in t.get("old_cols", []) if conv_lib._slot_of(c) == slot]
+        if not cols:
+            continue
+        best = "hidden"
+        for c in cols:
+            cl = classify(c, t["card_id"])
+            if ORDER[cl] > ORDER[best]:
+                best = cl
+        counts[best] += 1
+        if best == "explicit":
+            explicit_cards.append((t["card_id"], t.get("card_name")))
+    n = sum(counts.values())
+    strict = counts["explicit"] > 0
+    loose = (counts["explicit"] + counts["default"] + counts["ambiguous"]) > 0
+    verdict = "STRICT-DISPLAYED" if strict else ("LOOSE-ONLY" if loose else "HIDDEN-ONLY")
+    out.append({"client": client, "slot": slot, "kind": kind, "tiles": n,
+                "counts": dict(counts), "verdict": verdict,
+                "proof_card": explicit_cards[0] if explicit_cards else None})
+
+json.dump(cache, open(CACHE, "w"))
+json.dump(out, open("migration/handoff-visibility-probe.json", "w"), ensure_ascii=False, indent=1)
+
+strict = [r for r in out if r["verdict"] == "STRICT-DISPLAYED"]
+loose = [r for r in out if r["verdict"] == "LOOSE-ONLY"]
+hidden = [r for r in out if r["verdict"] == "HIDDEN-ONLY"]
+print(f"Total decisions        : {len(out)}")
+print(f"STRICT-DISPLAYED (real): {len(strict)}   (>=1 tile shows it with an explicit flag)")
+print(f"LOOSE-ONLY (uncertain) : {len(loose)}    (only default/ambiguous tiles - need eyeball)")
+print(f"HIDDEN-ONLY (FALSE)    : {len(hidden)}   (every tile provably hides it -> droppable)")
+print()
+if hidden:
+    print("=== HIDDEN-ONLY (real false positives) ===")
+    for r in sorted(hidden, key=lambda r: -r["tiles"]):
+        print(f"  {r['client']:<22} slot {r['slot']:<2} {r['kind']:<16} tuiles={r['tiles']} counts={r['counts']}")
+if loose:
+    print("\n=== LOOSE-ONLY (no explicit display - inspect) ===")
+    for r in sorted(loose, key=lambda r: -r["tiles"]):
+        print(f"  {r['client']:<22} slot {r['slot']:<2} {r['kind']:<16} tuiles={r['tiles']} counts={r['counts']}")

--- a/scripts/read_corpus_xlsx.py
+++ b/scripts/read_corpus_xlsx.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Lit les 2 Excel de corpus (couleurs + blog/saisonnalité) : sheets, en-têtes, nb lignes,
+échantillon, et détecte les mots-clés avec accents (pour le sujet GSC)."""
+import sys
+PATHS=[
+ "/Users/louismonier/Downloads/Keywords couleurs Dash nanga Business.xlsx",
+ "/Users/louismonier/Downloads/KW_Saisonnalite_Manucurist Blog.xlsx",
+]
+ACC="àâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇœæ"
+def has_accent(s): return isinstance(s,str) and any(ch in s for ch in ACC)
+
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    print("NO_OPENPYXL"); sys.exit(2)
+
+for p in PATHS:
+    print("\n================ ", p.split("/")[-1], " ================")
+    try:
+        wb=load_workbook(p, read_only=True, data_only=True)
+    except Exception as e:
+        print("  ERREUR ouverture:", repr(e)[:200]); continue
+    print("  sheets:", wb.sheetnames)
+    for ws in wb.worksheets:
+        rows=list(ws.iter_rows(values_only=True))
+        rows=[r for r in rows if any(c is not None for c in r)]  # drop empty rows
+        print(f"\n  -- sheet '{ws.title}' : {len(rows)} lignes non vides --")
+        if not rows: continue
+        hdr=rows[0]
+        print("     HEADERS:", hdr)
+        for r in rows[1:13]:
+            print("      ", r)
+        if len(rows)>13: print(f"      ... (+{len(rows)-13} lignes)")
+        acc=[r for r in rows[1:] if any(has_accent(c) for c in r)]
+        print(f"     >>> lignes avec accents: {len(acc)} / {len(rows)-1}")
+        for r in acc[:10]: print("        ACC:", r)
+print("\nDONE")

--- a/scripts/regen_handoff_strict.py
+++ b/scripts/regen_handoff_strict.py
@@ -1,0 +1,77 @@
+"""Régénère les handoffs conversions en définition STRICTE de visibilité :
+un dashboard ne compte pour un slot QUE si une colonne de ce slot est explicitement
+affichée (enabled=true, override-aware) — 'absent de la liste' = NON affiché (vérifié à
+la main par l'user sur 900.care). Les slots affichés sur 0 dashboard = FAUX POSITIFS,
+retirés du handoff consultant.
+
+Source de vérité : migration/conv-visibility-by-slot.json (champ visible_dashboards / visible_dash_names).
+Backups .PRE-STRICT.csv. Ne touche pas aux .PRE-VIS.csv (originaux bruts).
+"""
+import csv, json, re, subprocess, sys, shutil
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+MIG = REPO / "migration"
+
+vis = {(r["client"], r["slot"]): r for r in json.loads((MIG / "conv-visibility-by-slot.json").read_text())}
+
+
+def slot_num(label):
+    m = re.search(r"\((conversions?)_?(\d*)\)", label)
+    return (int(m.group(2)) if m.group(2) else 0) if m else None
+
+
+def dashes(names):
+    names = sorted(names)
+    if not names:
+        return "0 dash"
+    return f"{len(names)} dash : " + ", ".join(n[:30] for n in names[:3]) + ("…" if len(names) > 3 else "")
+
+
+def visible_names(client, slot):
+    v = vis.get((client, slot))
+    return v.get("visible_dash_names", []) if v else []
+
+
+# 1) à-trancher : dashboards_concernes = visibles uniquement (référence complète, on garde tout)
+src = MIG / "CONVERSIONS-A-TRANCHER.csv"
+shutil.copy(src, MIG / "CONVERSIONS-A-TRANCHER.PRE-STRICT.csv")
+rows = list(csv.DictReader(open(src, encoding="utf-8-sig")))
+for r in rows:
+    s = slot_num(r["slot"])
+    if s is None:
+        continue
+    r["dashboards_concernes"] = dashes(visible_names(r["client"], s))
+with open(src, "w", newline="", encoding="utf-8-sig") as fh:
+    w = csv.DictWriter(fh, fieldnames=["client", "type_probleme", "slot", "valeur_actuelle",
+                                       "contexte", "dashboards_concernes", "a_trancher"])
+    w.writeheader(); w.writerows(rows)
+
+# 2) régénère le handoff consultant depuis l'à-trancher patché
+subprocess.run([sys.executable, str(REPO / "scripts" / "build_consultant_handoff.py"),
+                str(src), "--blockers", str(MIG / "residual-blockers-REAL.json")],
+               check=True, capture_output=True)
+
+# 3) filtre STRICT : on retire les décisions affichées sur 0 dashboard (faux positifs)
+hc = MIG / "HANDOFF-consultants.csv"
+shutil.copy(hc, MIG / "HANDOFF-consultants.PRE-STRICT.csv")
+crows = list(csv.DictReader(open(hc, encoding="utf-8-sig")))
+kept, removed = [], []
+for r in crows:
+    p = r["ref"].split("§")
+    if "PAIRING" in r["ref"]:
+        kept.append(r); continue
+    client, slot = p[0], int(p[1])
+    v = vis.get((client, slot), {})
+    if v.get("visible_dashboards", 0) > 0:
+        kept.append(r)
+    else:
+        removed.append((client, slot, p[2]))
+cols = list(crows[0].keys())
+with hc.open("w", newline="", encoding="utf-8-sig") as fh:
+    w = csv.DictWriter(fh, fieldnames=cols); w.writeheader(); w.writerows(kept)
+
+nclients = len({r["client"] for r in kept})
+print(f"HANDOFF consultant STRICT : {len(kept)} lignes / {nclients} clients")
+print(f"Retiré (faux positifs, affichés 0 dashboard) : {len({(c,s) for c,s,_ in removed})} slots")
+for c, s, k in sorted(set(removed)):
+    print(f"   - {c} slot {s} ({k})")

--- a/scripts/remove_quizroom_disclaimer.py
+++ b/scripts/remove_quizroom_disclaimer.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Retire la note disclaimer Quiz Room (données revenues) + remet les hauteurs + reflow.
+Inverse de add_quizroom_disclaimer.py. Snapshot + réversible.
+
+  python3 scripts/remove_quizroom_disclaimer.py --dashboard 24576         # dry-run
+  python3 scripts/remove_quizroom_disclaimer.py --dashboard 24576 --yes
+"""
+import argparse, json, sys, copy, requests
+from datetime import datetime
+from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts")); sys.path.insert(0, str(REPO))
+from spark_metabase_api import Metabase_API
+from reorg_phase1 import _load_env
+MIG = REPO / "migration"
+
+MARK = "\n\n_ℹ️"  # début de la note appondue
+
+# (tab, prefix, hauteur d'origine sans la note)
+TARGETS = [
+    ("Global", "Le nombre de joueurs", 2),
+    ("Global", "The player count is your center's", 2),
+    ("SEO", "Combien de personnes trouvent", 1),
+    ("SEO", "How many people find", 1),
+]
+
+
+def connect():
+    e = _load_env()
+    return Metabase_API(domain=e["METABASE_DOMAIN"], email=e["METABASE_EMAIL"], password=e["METABASE_PASSWORD"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dashboard", type=int, required=True)
+    ap.add_argument("--yes", action="store_true")
+    args = ap.parse_args()
+    mb = connect()
+    d = mb.get(f"/api/dashboard/{args.dashboard}")
+    dcs = copy.deepcopy(d.get("dashcards") or [])
+    tabname = {t["id"]: t["name"] for t in (d.get("tabs") or [])}
+    orig_row = {dc["id"]: dc.get("row") for dc in dcs}
+
+    deltas = []
+    for dc in dcs:
+        vs = dc.get("visualization_settings") or {}
+        if (vs.get("virtual_card") or {}).get("display") != "text":
+            continue
+        txt = vs.get("text") or ""
+        tab = tabname.get(dc.get("dashboard_tab_id"))
+        for ttab, prefix, new_h in TARGETS:
+            if tab == ttab and txt.lstrip().startswith(prefix):
+                if MARK not in txt:
+                    print(f"[{tab}] row={dc['row']} pas de note, skip")
+                    break
+                cur = dc.get("size_y")
+                vs["text"] = txt.split(MARK)[0].rstrip()
+                if new_h != cur:
+                    deltas.append((dc["dashboard_tab_id"], dc["row"] + cur - 1, new_h - cur))
+                    dc["size_y"] = new_h
+                print(f"[{tab}] row={dc['row']} note retirée, h {cur}->{new_h}")
+                break
+
+    if not deltas:
+        print("Rien à faire."); return
+    for dc in dcs:
+        tab = dc.get("dashboard_tab_id")
+        shift = sum(delta for tb, b, delta in deltas if tb == tab and b < orig_row[dc["id"]])
+        dc["row"] += shift
+
+    if not args.yes:
+        print("\n(DRY-RUN.)"); return
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    MIG.mkdir(exist_ok=True)
+    (MIG / f"rmdisclaimer-snapshot-{args.dashboard}-{ts}.json").write_text(
+        json.dumps({"dashboard": args.dashboard, "dashcards": d.get("dashcards"), "tabs": d.get("tabs")}, ensure_ascii=False, indent=2))
+    payload = {"dashcards": dcs}
+    if d.get("tabs"):
+        payload["tabs"] = d["tabs"]
+    r = requests.put(mb.domain + f"/api/dashboard/{args.dashboard}", headers=mb.header, auth=mb.auth, json=payload, timeout=120)
+    print("PUT:", r.status_code); r.raise_for_status()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_conv_visibility.py
+++ b/tests/test_conv_visibility.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests de conv_visibility — script autonome. Usage : python3 tests/test_conv_visibility.py
+
+effective_column_status(display, card_vs, dashcard_vs, col) -> 'visible' | 'hidden' | 'ambiguous'
+
+Règle clé : la surcharge au niveau tuile (dashcard_vs) prime sur la carte (card_vs).
+On ne déclare 'hidden' que si c'est PROUVÉ masqué ; sinon 'ambiguous' (jamais deviné visible).
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import conv_visibility as cv
+
+
+def _tbl(cols):  # cols: list of (name, enabled)
+    return {"table.columns": [{"name": n, "enabled": e} for n, e in cols]}
+
+
+# --- table: explicit enabled / disabled ---
+def test_table_card_enabled_is_visible():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS_2", True)]), {}, "CONVERSIONS_2") == "visible"
+
+def test_table_card_disabled_is_hidden():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS_2", False)]), {}, "CONVERSIONS_2") == "hidden"
+
+# --- THE bug: dashcard override hides a card-enabled column ---
+def test_dashcard_override_hides_card_enabled():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS_2", True)]),
+                                      _tbl([("CONVERSIONS_2", False)]), "CONVERSIONS_2") == "hidden"
+
+# --- dashcard override can also REVEAL a card-disabled column ---
+def test_dashcard_override_reveals_card_disabled():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS_2", False)]),
+                                      _tbl([("CONVERSIONS_2", True)]), "CONVERSIONS_2") == "visible"
+
+# --- table with no explicit column list -> Metabase shows all query columns ---
+def test_table_no_column_list_is_visible():
+    assert cv.effective_column_status("table", {}, {}, "CONVERSIONS_2") == "visible"
+
+# --- table lists columns but not this one -> can't prove -> ambiguous ---
+def test_table_col_not_listed_is_ambiguous():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS", True)]), {}, "CONVERSIONS_2") == "ambiguous"
+
+# --- charts driven by graph.metrics ---
+def test_chart_metric_present_is_visible():
+    assert cv.effective_column_status("line", {"graph.metrics": ["CONVERSIONS_2"]}, {}, "CONVERSIONS_2") == "visible"
+
+def test_chart_metric_absent_is_hidden():
+    assert cv.effective_column_status("bar", {"graph.metrics": ["CONVERSIONS"]}, {}, "CONVERSIONS_2") == "hidden"
+
+def test_chart_no_metrics_is_ambiguous():
+    assert cv.effective_column_status("line", {}, {}, "CONVERSIONS_2") == "ambiguous"
+
+def test_chart_dashcard_metrics_override():
+    assert cv.effective_column_status("area", {"graph.metrics": ["CONVERSIONS_2"]},
+                                      {"graph.metrics": ["CONVERSIONS"]}, "CONVERSIONS_2") == "hidden"
+
+# --- scalar family ---
+def test_scalar_field_match_is_visible():
+    assert cv.effective_column_status("scalar", {"scalar.field": "CONVERSIONS_2"}, {}, "CONVERSIONS_2") == "visible"
+
+def test_scalar_field_other_is_hidden():
+    assert cv.effective_column_status("smartscalar", {"scalar.field": "CONVERSIONS"}, {}, "CONVERSIONS_2") == "hidden"
+
+def test_scalar_no_field_is_ambiguous():
+    assert cv.effective_column_status("scalar", {}, {}, "CONVERSIONS_2") == "ambiguous"
+
+# --- unknown display types can't be judged ---
+def test_unknown_display_is_ambiguous():
+    assert cv.effective_column_status("pie", {}, {}, "CONVERSIONS_2") == "ambiguous"
+
+# --- case-insensitivity ---
+def test_case_insensitive_match():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS_2", True)]), {}, "conversions_2") == "visible"
+
+# --- None dashcard settings handled ---
+def test_none_dashcard_settings():
+    assert cv.effective_column_status("table", _tbl([("CONVERSIONS_2", False)]), None, "CONVERSIONS_2") == "hidden"
+
+# --- defensive: stray None entries in metrics / column names must not crash ---
+def test_chart_metrics_with_none_entry():
+    assert cv.effective_column_status("line", {"graph.metrics": [None, "CONVERSIONS"]}, {}, "CONVERSIONS_2") == "hidden"
+    assert cv.effective_column_status("line", {"graph.metrics": [None, "CONVERSIONS_2"]}, {}, "CONVERSIONS_2") == "visible"
+
+def test_table_column_with_none_name():
+    cols = {"table.columns": [{"name": None, "enabled": True}, {"name": "CONVERSIONS_2", "enabled": True}]}
+    assert cv.effective_column_status("table", cols, {}, "CONVERSIONS_2") == "visible"
+
+
+# --- is_conversion_metric: recognise slot-tied conversion columns, reject unrelated ---
+def test_is_conversion_metric_true_cases():
+    for n in ["CONVERSIONS", "CONVERSION_VALUE", "CONVERSIONS_2", "CONVERSION_2_VALUE",
+              "CR_2", "CAC_2", "CURRENT_CONVERSIONS_5", "PREVIOUS_CR_3"]:
+        assert cv.is_conversion_metric(n), n
+
+def test_is_conversion_metric_false_cases():
+    for n in ["CLICKS", "IMPRESSIONS", "COST", "DATE", "TOP_10_PRODUCTS", "CPC"]:
+        assert not cv.is_conversion_metric(n), n
+
+# --- tile_slot_status: a slot is visible if ANY of its conversion columns (incl. derived) shows ---
+def test_tile_slot_visible_via_derived_column_when_base_hidden():
+    # conversions_2 hidden but cr_2 shown -> slot 2 is effectively visible
+    status = cv.tile_slot_status("table",
+        _tbl([("CONVERSIONS_2", False), ("CR_2", True), ("CAC_2", True)]), {},
+        ["CONVERSIONS_2", "CR_2", "CAC_2"], 2)
+    assert status == "visible", status
+
+def test_tile_slot_hidden_when_all_slot_columns_hidden():
+    status = cv.tile_slot_status("table",
+        _tbl([("CONVERSIONS_2", False), ("CR_2", False)]), {},
+        ["CONVERSIONS_2", "CR_2"], 2)
+    assert status == "hidden", status
+
+def test_tile_slot_ambiguous_when_not_listed():
+    status = cv.tile_slot_status("table",
+        _tbl([("CONVERSIONS", True)]), {},
+        ["CONVERSIONS_2"], 2)
+    assert status == "ambiguous", status
+
+def test_tile_slot_absent_when_no_slot_conversion_columns():
+    status = cv.tile_slot_status("table", _tbl([("CLICKS", True)]), {}, ["CLICKS", "COST"], 2)
+    assert status == "absent", status
+
+def test_tile_slot_dashcard_override_hides_slot():
+    # base card shows conversions_2, dashcard override hides every slot-2 column -> hidden
+    status = cv.tile_slot_status("table",
+        _tbl([("CONVERSIONS_2", True), ("CR_2", True)]),
+        _tbl([("CONVERSIONS_2", False), ("CR_2", False)]),
+        ["CONVERSIONS_2", "CR_2"], 2)
+    assert status == "hidden", status
+
+
+TESTS = [test_table_card_enabled_is_visible, test_table_card_disabled_is_hidden,
+         test_dashcard_override_hides_card_enabled, test_dashcard_override_reveals_card_disabled,
+         test_table_no_column_list_is_visible, test_table_col_not_listed_is_ambiguous,
+         test_chart_metric_present_is_visible, test_chart_metric_absent_is_hidden,
+         test_chart_no_metrics_is_ambiguous, test_chart_dashcard_metrics_override,
+         test_scalar_field_match_is_visible, test_scalar_field_other_is_hidden,
+         test_scalar_no_field_is_ambiguous, test_unknown_display_is_ambiguous,
+         test_case_insensitive_match, test_none_dashcard_settings,
+         test_chart_metrics_with_none_entry, test_table_column_with_none_name,
+         test_is_conversion_metric_true_cases, test_is_conversion_metric_false_cases,
+         test_tile_slot_visible_via_derived_column_when_base_hidden,
+         test_tile_slot_hidden_when_all_slot_columns_hidden,
+         test_tile_slot_ambiguous_when_not_listed, test_tile_slot_absent_when_no_slot_conversion_columns,
+         test_tile_slot_dashcard_override_hides_slot]
+
+def run():
+    failures = 0
+    for t in TESTS:
+        try:
+            t(); print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failures += 1; print(f"FAIL  {t.__name__}: {e!r}")
+    print(f"\n{len(TESTS) - failures}/{len(TESTS)} tests passés")
+    sys.exit(1 if failures else 0)
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Regroupe le travail non commité qui traînait dans le working tree, en 4 lots thématiques indépendants (aucun lien avec le fix regex #19) :

1. **conv-migration** — visibilité effective des slots conv + handoffs stricts (`conv_visibility` + test 25 cas, annotate/probe visibilité, regen strict, patch priorité, doc handoff Lucas)
2. **seo-corpus** — modèle + dashboard corpus SEO, lecture Excel, probes corpus/accents ; MAJ builders global/inverted
3. **quiz-room** — optimisation cartes joueurs + retrait disclaimer
4. **chatbot** — script `run_chatbot.sh`

Scripts d'outillage opérationnel. `tests/test_conv_visibility.py` : 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)